### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/desktop-src/SecCrypto/using-signtool-to-sign-a-file.md
+++ b/desktop-src/SecCrypto/using-signtool-to-sign-a-file.md
@@ -23,7 +23,7 @@ The following command signs the file using a certificate stored in a password-pr
 
 The following command signs and time stamps the file:
 
-**SignTool sign /f***MyCert***.pfx /t https://timestamp.verisign.com/scripts/timstamp.dll MyControl.exe**
+**SignTool sign /f***MyCert***.pfx /t http://timestamp.digicert.com MyControl.exe**
 
 > [!Note]  
 > For information about time stamping a file after it has already been signed, see [Adding Time Stamps to Previously Signed Files](adding-time-stamps-to-previously-signed-files.md).


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.