### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/desktop-src/SecCrypto/adding-time-stamps-to-previously-signed-files.md
+++ b/desktop-src/SecCrypto/adding-time-stamps-to-previously-signed-files.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Time stamps are normally included when a file is signed using SignTool with the **-t** option. In addition, time stamps can be added to files that were signed without a time stamp. The following command adds a time stamp to a previously signed file:
 
-**signtool timestamp -t https://timestamp.verisign.com/scripts/timstamp.dll** *MyControl.exe*
+**signtool timestamp -t http://timestamp.digicert.com** *MyControl.exe*
 
 > [!Note]  
 > The file to be time stamped must have previously been signed.


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.