### PR TITLE
Fix incorrect information regarding NonUniformResourceIndex

### DIFF
--- a/desktop-src/direct3d12/resource-binding-in-hlsl.md
+++ b/desktop-src/direct3d12/resource-binding-in-hlsl.md
@@ -83,7 +83,7 @@ sampler samp[7] : register(s0);
 tex1[myMaterialID].Sample(samp[samplerID], texCoords);
 ```
 
-There is an important default restriction on the use of the indices (`myMaterialID` and `samplerID` in the code above) in that they are not allowed to vary within a wave (aka 'wavefront' or 'warp'). Even changing the index based on instancing counts as varying.
+There's an important default restriction on the use of the indices (`myMaterialID` and `samplerID` in the code above) in that they're not allowed to vary within a [wave](/windows/win32/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12#terminology). Even changing the index based on instancing counts as varying.
 
 If varying the index is required then specify the `NonUniformResourceIndex` qualifier on the index, for example:
 

--- a/desktop-src/direct3d12/resource-binding-in-hlsl.md
+++ b/desktop-src/direct3d12/resource-binding-in-hlsl.md
@@ -83,7 +83,7 @@ sampler samp[7] : register(s0);
 tex1[myMaterialID].Sample(samp[samplerID], texCoords);
 ```
 
-There is an important default restriction on the use of the indices (`myMaterialID` and `samplerID` in the code above) in that they are not allowed to vary in a draw/dispatch call. Even changing the index based on instancing counts as varying.
+There is an important default restriction on the use of the indices (`myMaterialID` and `samplerID` in the code above) in that they are not allowed to vary within a wave (aka 'wavefront' or 'warp'). Even changing the index based on instancing counts as varying.
 
 If varying the index is required then specify the `NonUniformResourceIndex` qualifier on the index, for example:
 


### PR DESCRIPTION
This information was incorrect. It is only within a wave that the index is not allowed to vary, not within a draw/dispatch.