### PR TITLE
Migration of Legacy VeriSign Time Stamping Services

### DIFF
--- a/desktop-src/SbsCs/assembly-signing-example.md
+++ b/desktop-src/SbsCs/assembly-signing-example.md
@@ -59,7 +59,7 @@ The next step is to run Makecat.exe over this .cdf to create the security catalo
 
 The final step is to run SignTool.exe to sign the catalog file with the certificate. This should be the same certificate that was used in the preceding to generate the public key token. For more information about SignTool.exe see the [**SignTool**](https://docs.microsoft.com/windows/desktop/SecCrypto/signtool) topic. The call to **SignTool** for the example would appear as follows:
 
-**c:\\MySampleAssembly>signtool sign /f** *<fullpath>***mycompany.pfx /du https://www.mycompany.com/MySampleAssembly /t https://timestamp.verisign.com/scripts/timstamp.dll MySampleAssembly.cat**
+**c:\\MySampleAssembly>signtool sign /f** *<fullpath>***mycompany.pfx /du https://www.mycompany.com/MySampleAssembly /t http://timestamp.digicert.com MySampleAssembly.cat**
 
 If you have an authenticated digital certificate, and your certification authority uses the PVK file format to store the private key, you can use the PVK Digital Certificate Files Importer (pvkimprt.exe) to import the key into your cryptographic service provider (CSP). This utility enables you to export to the industry standard format of PFX/P12. For more information about the PVK Digital Certificate Files Importer, see the Deployment Resources section of the MSDN library or contact your certification authority. You may be able to obtain pvkimprt.exe from https://office.microsoft.com/downloads/2000/pvkimprt.aspx.
 


### PR DESCRIPTION
See - https://knowledge.digicert.com/alerts/migration-of-legacy-verisign-and-symantec-time-stamping-services.html
As part of our rebranding initiative from the acquisition of Symantec in 2017, DigiCert has stopped future timestamp signatures from legacy Verisign timestamp services and facilitate all future timestamps via our consolidated DigiCert timestamping service.