### PR TITLE
Update how-to-exclude-items-from-taskbar-pinning-and-recent-frequent-…

### DIFF
--- a/desktop-src/shell/how-to-exclude-items-from-taskbar-pinning-and-recent-frequent-lists.md
+++ b/desktop-src/shell/how-to-exclude-items-from-taskbar-pinning-and-recent-frequent-lists.md
@@ -56,7 +56,7 @@ Be aware that certain executable files, as well as shortcuts that contain certai
 
  
 
-If any of the following strings, regardless of case, are included in the shortcut name, the program is not pinnable and is not displayed in the most frequently used list:
+If any of the following strings, regardless of case, are included in the shortcut name, the program is not pinnable and is not displayed in the most frequently used list (not applicable to Windows 10):
 
 -   Documentation
 -   Help
@@ -111,7 +111,6 @@ HKEY_LOCAL_MACHINE
                Explorer
                   FileAssociation
                      AddRemoveApps
-                     AddRemoveNames
                      HostApps
 ```
 


### PR DESCRIPTION
…lists.md

Changed to reflect information on https://docs.microsoft.com/en-gb/windows/win32/shell/appids#exclusion_lists

So this part on the page needs to be marked not true for Win10:

If any of the following strings, regardless of case, are included in the shortcut name, the program is not pinnable and is not displayed in the most frequently used list:
•	Documentation
•	Help
•	Install
•	More Info
•	Read me
•	Read First
•	Readme
•	Remove
•	Setup
•	Support
•	What's New
This part needs a reg key removed as shown:

HKEY_LOCAL_MACHINE
Software
Microsoft
Windows
CurrentVersion
Explorer
FileAssociation
AddRemoveApps
AddRemoveNames – this no longer exists
HostApps