### PR TITLE
Added 'runas' verb to the options

### DIFF
--- a/desktop-src/shell/launch.md
+++ b/desktop-src/shell/launch.md
@@ -47,8 +47,9 @@ Commonly available verbs include:
 | open       | Launches an application. If this file is not an executable file, its associated application is launched. |
 | print      | Prints the document file.                                                                                |
 | properties | Displays the object's properties.                                                                        |
-
-
+| runas      | Launches an application as Administrator. User Account Control (UAC) will prompt the user for consent to |
+|            | run the application elevated or enter the credentials of an administrator account used to run the        |
+|            | application.                                                                                             |
 
  
 


### PR DESCRIPTION
While reviewing KBs for archival, we came across - https://support.microsoft.com/en-us/help/981778/how-to-self-elevate-an-application-to-a-high-privilege-level-under-uac - this in turn refers to https://code.msdn.microsoft.com/windowsapps/CppUACSelfElevation-981c0160#content which is also being retired. I am submitting this change based on my discussion with Dave Anderson (Sr.EE in Windows Dev Support)