### PR TITLE
Known DLL restriction is incorrect

### DIFF
--- a/desktop-src/Dlls/dynamic-link-library-redirection.md
+++ b/desktop-src/Dlls/dynamic-link-library-redirection.md
@@ -22,8 +22,6 @@ And, if both c:\\myapp\\myapp.exe.local and c:\\myapp\\mydll.dll exist, [**LoadL
 
 Alternatively, if a directory named c:\\myapp\\myapp.exe.local exists and contains mydll.dll, [**LoadLibrary**](https://msdn.microsoft.com/en-us/library/ms684175(v=VS.85).aspx) loads c:\\myapp\\myapp.exe.local\\mydll.dll.
 
-Known DLLs cannot be redirected. For a list of known DLLs, see the following registry key: **HKEY\_LOCAL\_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\KnownDLLs**. The system uses Windows File Protection to ensure that system DLLs such as these are not updated or deleted except by operating system updates such as service packs.
-
 If the application has a manifest, then any .local files are ignored.
 
 If you are using DLL redirection and the application does not have access to all drives and directories in the search order, [**LoadLibrary**](https://msdn.microsoft.com/en-us/library/ms684175(v=VS.85).aspx) stops searching as soon as access is denied. (If you are not using DLL redirection, **LoadLibrary** skips directories that it cannot access and then continues searching.)


### PR DESCRIPTION
The information on known dlls not being subject to dot-local redirection is not correct.  A test indicates that these too are dot-local redirected:

C:\Samples\dotlocal>dir /b
advapi32.dll
GdiPlus.dll
kernel32.dll
msvcrt.dll
oleaut32.dll
shell32.dll
ucrtbase.dll
user32.dll
write.exe
write.exe.local

C:\Samples\dotlocal>windbg.exe write.exe

...

00007ff9`b3730000 00007ff9`b3dfa000   SHELL32  C:\Samples\dotlocal\SHELL32.dll
00007ff9`ceb60000 00007ff9`cecf9000   USER32   C:\Samples\dotlocal\USER32.dll
00007ff9`d2bf0000 00007ff9`d2ced000   ucrtbase C:\Samples\dotlocal\ucrtbase.dll
00007ff9`d7790000 00007ff9`d7857000   OLEAUT32 C:\Samples\dotlocal\OLEAUT32.dll
00007ff9`ddaf0000 00007ff9`ddbab000   KERNEL32 C:\Samples\dotlocal\KERNEL32.DLL
00007ffa`010a0000 00007ffa`0114a000   advapi32 C:\Samples\dotlocal\advapi32.dll
00007ffa`07f90000 00007ffa`0802e000   msvcrt   C:\Samples\dotlocal\msvcrt.dll