### PR TITLE
Update signertimestampex3.md

### DIFF
--- a/desktop-src/SecCrypto/signertimestampex3.md
+++ b/desktop-src/SecCrypto/signertimestampex3.md
@@ -198,8 +198,8 @@ If the function fails, it returns an **HRESULT** value that indicates the error.
 
 |                                     |                                                                                         |
 |-------------------------------------|-----------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows 7 \[desktop apps only\]<br/>                                              |
-| Minimum supported server<br/> | Windows Server 2008 R2 \[desktop apps only\]<br/>                                 |
+| Minimum supported client<br/> | Windows 8 \[desktop apps only\]<br/>                                              |
+| Minimum supported server<br/> | Windows Server 2012 \[desktop apps only\]<br/>                                 |
 | DLL<br/>                      | <dl> <dt>Mssign32.dll</dt> </dl> |
 
 


### PR DESCRIPTION
The requirements information is incorrect
SignerTimestampEx3 only exists in Win8+