### PR TITLE
fix MD parser miss-interpretation of nested *

### DIFF
--- a/desktop-src/SecCrypto/using-signtool-to-sign-a-file.md
+++ b/desktop-src/SecCrypto/using-signtool-to-sign-a-file.md
@@ -10,11 +10,11 @@ ms.date: 05/31/2018
 
 The following command signs the file named MyControl.exe using a [*certificate*](https://msdn.microsoft.com/en-us/library/ms721572(v=VS.85).aspx) stored in a Personal Information Exchange (PFX) file:
 
-**SignTool sign /f***MyCert***.pfx MyControl.exe**
+_SignTool sign /f***MyCert***.pfx MyControl.exe_
 
 The following command signs the file using a certificate stored in a password-protected PFX file:
 
-**SignTool sign /f***MyCert***.pfx /p***MyPassword* **MyControl.exe**
+_SignTool sign /f***MyCert***.pfx /p***MyPassword* **MyControl.exe_
 
 > [!Note]  
 > Ensure that you properly protect the password.
@@ -23,7 +23,7 @@ The following command signs the file using a certificate stored in a password-pr
 
 The following command signs and time stamps the file:
 
-**SignTool sign /f***MyCert***.pfx /t http://timestamp.digicert.com MyControl.exe**
+_SignTool sign /f***MyCert***.pfx /t http://timestamp.digicert.com MyControl.exe_
 
 > [!Note]  
 > For information about time stamping a file after it has already been signed, see [Adding Time Stamps to Previously Signed Files](adding-time-stamps-to-previously-signed-files.md).
@@ -32,23 +32,23 @@ The following command signs and time stamps the file:
 
 The following command signs the file using a certificate located in the My store with a subject name of My Company Publisher:
 
-**SignTool sign /n "My Company Publisher" MyControl.exe**
+_SignTool sign /n "My Company Publisher" MyControl.exe_
 
 The following command signs an ActiveX control and provides information that is displayed by Internet Explorer when the user is prompted to install the control:
 
-**SignTool sign /f MyCert.pfx /d "***My Product Name***" /du "https://www.***example***.com/***my\_product***/info.html" MyControl.exe**
+_SignTool sign /f MyCert.pfx /d "***My Product Name***" /du "https://www.***example***.com/***my\_product***/info.html" MyControl.exe_
 
 The following command signs the file using a certificate whose [*private key*](https://msdn.microsoft.com/en-us/library/ms721603(v=VS.85).aspx) information is protected by a hardware cryptography module. For example purposes, assume that the certificate called "My High-Value Certificate," has a private key installed in a hardware cryptography module, and the certificate is properly installed.
 
-**SignTool sign /n "My High-Value Certificate" MyControl.exe**
+_SignTool sign /n "My High-Value Certificate" MyControl.exe_
 
 The following command signs the file using a certificate whose [*private key*](https://msdn.microsoft.com/en-us/library/ms721603(v=VS.85).aspx) information is protected by a hardware cryptography module. A computer store is specified for the [*certification authority*](https://msdn.microsoft.com/en-us/library/ms721572(v=VS.85).aspx) (CA) store.
 
-**SignTool sign /n "***My High Value Certificate***" /sm /s CA MyControl.exe**
+_SignTool sign /n "***My High Value Certificate***" /sm /s CA MyControl.exe_
 
 The following command signs the file using a certificate stored in a file. The private key information is protected by a hardware cryptography module, and the [*cryptographic service provider*](https://msdn.microsoft.com/en-us/library/ms721572(v=VS.85).aspx) (CSP)and [*key container*](https://msdn.microsoft.com/en-us/library/ms721590(v=VS.85).aspx) are specified by name. This command is useful if the certificate is not properly installed.
 
-**SignTool sign /f***HighValue***.cer /csp "***Hardware Cryptography Module***" /k***HighValueContainer***MyControl.exe**
+_SignTool sign /f***HighValue***.cer /csp "***Hardware Cryptography Module***" /k***HighValueContainer***MyControl.exe_
 
 [SignTool](signtool.md) returns command line text that states the result of the signing operation. Additionally, SignTool returns an exit code of zero for successful execution, one for failed execution, and two for execution that completed with warnings.
 


### PR DESCRIPTION
Nested asterisks (*) do not usually work well with the MD interpreter