### PR TITLE
Fixed typo in GetLaunchSecurityDescriptor ref.

### DIFF
--- a/desktop-src/CIMWin32Prov/win32-dcomapplicationsetting-methods.md
+++ b/desktop-src/CIMWin32Prov/win32-dcomapplicationsetting-methods.md
@@ -17,7 +17,7 @@ The [**Win32\_DCOMApplicationSetting**](win32-dcomapplicationsetting.md) class e
 -   [**SetAccessSecurityDescriptor method**](setaccesssecuritydescriptor-method-in-class-win32-dcomapplicationsetting.md)
 -   [**GetConfigurationSecurityDescriptor method**](getconfigurationsecuritydescriptor-method-in-class-win32-dcomapplicationsetting.md)
 -   [**SetConfigurationSecurityDescriptor method**](setconfigurationsecuritydescriptor-method-in-class-win32-dcomapplicationsetting.md)
--   [**SetLaunchSecurityDescriptor method**](getlaunchsecuritydescriptor-in-class-win32-dcomapplicationsetting.md)
+-   [**GetLaunchSecurityDescriptor method**](getlaunchsecuritydescriptor-in-class-win32-dcomapplicationsetting.md)
 -   [**SetLaunchSecurityDescriptor method**](setlaunchsecuritydescriptor-method-in-class-win32-dcomapplicationsetting.md)
 
  


### PR DESCRIPTION
Fixed typo in GetLaunchSecurityDescriptor reference (from "SetLaunchSecurityDescriptor" to "GetLaunchSecurityDescriptor" in the text of the link to the GetLaunchSecurityDescriptor description, the link itself points to the correct location)