### PR TITLE
Specify the language type in the example code in WMP

### DIFF
--- a/desktop-src/WMP/creating-the-windows-media-player-control-programmatically.md
+++ b/desktop-src/WMP/creating-the-windows-media-player-control-programmatically.md
@@ -31,8 +31,7 @@ To create the Windows Media Player control programmatically, you must first add 
 The following example code, part of a Form1 class, shows how to create a **Player** object and play a file. When playback ends, or if the file cannot be played, the form is closed.
 
 
-```C++
-' [ Visual Basic ]
+```VB
 Dim WithEvents Player As WMPLib.WindowsMediaPlayer
 
 Private Sub PlayFile(ByVal url As String)
@@ -65,8 +64,7 @@ End Sub
 
 
 
-```C++
-// [ C# ]
+```CSharp
 WMPLib.WindowsMediaPlayer Player;
 
 private void PlayFile(String url)

--- a/desktop-src/WMP/embedding-the-player-control-in-a-web-page-displayed-by-firefox.md
+++ b/desktop-src/WMP/embedding-the-player-control-in-a-web-page-displayed-by-firefox.md
@@ -47,7 +47,7 @@ The preferred mime type is application/x-ms-wmp.
 The following examples show how to embed the Player control using an OBJECT element or an EMBED element.
 
 
-```C++
+```HTML
 <OBJECT id="Player"
   type="application/x-ms-wmp" 
   width="320" height="320">
@@ -68,7 +68,7 @@ The preceeding examples work in Firefox but not in Internet Explorer. To embed t
 The following example shows how to embed the Windows Media Player control in a webpage that can be displayed correctly by both Internet Explorer and Firefox. Script on the page detects the browser type and generates the appropriate OBJECT tag.
 
 
-```C++
+```HTML
 <HTML>
   <BODY>
     <SCRIPT type="text/javascript">

--- a/desktop-src/WMP/embedding-the-windows-media-player-control-in-a-c--solution.md
+++ b/desktop-src/WMP/embedding-the-windows-media-player-control-in-a-c--solution.md
@@ -44,7 +44,7 @@ Now, add two buttons to the form. Select the first button and change the **Text*
 Double-click the **Play** button to reveal the Code window. In C#, the following code will be displayed:
 
 
-```C++
+```CSharp
 private void button1_Click(object sender, System.EventArgs e)
 {
 
@@ -57,7 +57,7 @@ private void button1_Click(object sender, System.EventArgs e)
 Add this line between the two curly braces:
 
 
-```C++
+```CSharp
 axWindowsMediaPlayer1.URL = @"c:\mediafile.wmv";
 
 ```
@@ -69,7 +69,7 @@ In the preceding code example, "axWindowsMediaPlayer1" is the default name of th
 If you have added the digital media content from the Windows Media Player SDK to the library in Windows Media Player, you can use this code instead:
 
 
-```C++
+```CSharp
 axWindowsMediaPlayer1.currentPlaylist = axWindowsMediaPlayer1.mediaCollection.getByName("mediafile");
 
 ```
@@ -83,7 +83,7 @@ Because the **autoStart** property is true by default, Windows Media Player will
 Double-click the **Stop** button to reveal the Code window. In C#, the following code will be displayed:
 
 
-```C++
+```CSharp
 private void button2_Click(object sender, System.EventArgs e)
 {
 
@@ -96,7 +96,7 @@ private void button2_Click(object sender, System.EventArgs e)
 Add this line between the two curly braces:
 
 
-```C++
+```CSharp
 axWindowsMediaPlayer1.Ctlcontrols.stop();
 
 ```
@@ -115,7 +115,7 @@ The Windows Media Player control does not raise an exception when it encounters 
 To create an event handler, first open the Properties window for the Windows Media Player control. In the list of events, double-click **MediaError**. The following code is displayed:
 
 
-```C++
+```CSharp
 private void Player_MediaError(object sender, _WMPOCXEvents_MediaErrorEvent e)
 {
 }
@@ -127,7 +127,7 @@ private void Player_MediaError(object sender, _WMPOCXEvents_MediaErrorEvent e)
 The following code could be inserted in the method to provide minimal error-handling capability. Note that information about the error can be retrieved from the **\_WMPOCXEvents\_MediaErrorEvent** argument.
 
 
-```C++
+```CSharp
 try
 // If the Player encounters a corrupt or missing file, 
 // show the hexadecimal error code and URL.

--- a/desktop-src/WMP/embedding-the-windows-media-player-control-in-a-visual-basic--net-solution.md
+++ b/desktop-src/WMP/embedding-the-windows-media-player-control-in-a-visual-basic--net-solution.md
@@ -44,7 +44,7 @@ Now add two buttons to the form. Select the first button and change the **Text**
 Double-click the **Play** button to reveal the Code window. The following code is displayed:
 
 
-```C++
+```VB
 Private Sub Button1_Click(ByVal sender As System.Object, _
         ByVal e As System.EventArgs) Handles Button1.Click
 
@@ -56,7 +56,7 @@ End Sub
 Add this line to the subroutine:
 
 
-```C++
+```VB
 AxWindowsMediaPlayer1.URL = "c:\mediafile.wmv"
 ```
 
@@ -67,7 +67,7 @@ In the preceding code example, "axWindowsMediaPlayer1" is the default name of th
 If you have added the digital media content from the Windows Media Player SDK to the library in Windows Media Player, you can use this code instead:
 
 
-```C++
+```VB
 axWindowsMediaPlayer1.currentPlaylist = _
     axWindowsMediaPlayer1.mediaCollection.getByName("mediafile")
 
@@ -82,7 +82,7 @@ Because the **autoStart** property is true by default, Windows Media Player will
 Double-click the **Stop** button to reveal the Code window. The following code is displayed:
 
 
-```C++
+```VB
 Private Sub Button2_Click(ByVal sender As System.Object, _
         ByVal e As System.EventArgs) Handles Button1.Click
 
@@ -95,7 +95,7 @@ End Sub
 Add this line to the subroutine:
 
 
-```C++
+```VB
 AxWindowsMediaPlayer1.Ctlcontrols.stop()
 
 ```
@@ -114,7 +114,7 @@ The Windows Media Player control does not raise an exception when it encounters 
 To create an event handler, open the code window for your form class. From the drop-down list at the top of the window, select the Windows Media Player control. A list of events appears in the drop-down list to the right. From that list, select [**MediaError**](axwmplib-axwindowsmediaplayer-mediaerror.md). The following code is displayed:
 
 
-```C++
+```VB
 Private Sub AxWindowsMediaPlayer1_MediaError(ByVal sender As Object, _
     ByVal e As _WMPOCXEvents_MediaErrorEvent) Handles AxWindowsMediaPlayer1.MediaError
 
@@ -127,7 +127,7 @@ End Sub
 The following code could be inserted in the subroutine to provide minimal error-handling capability. Note that information about the error can be retrieved from the **\_WMPOCXEvents\_MediaErrorEvent** argument.
 
 
-```C++
+```VB
 Try
     ' If the file is corrupt or missing, show the 
     ' hexadecimal error code and URL.

--- a/desktop-src/WMP/handling-events-in-a-web-page-displayed-by-firefox.md
+++ b/desktop-src/WMP/handling-events-in-a-web-page-displayed-by-firefox.md
@@ -39,7 +39,7 @@ When you embed the Windows Media Player control in a webpage, you can write scri
 If the mime type associated with an embedded Player control is application/x-ms-wmp, you can write event handlers that have the following format:
 
 
-```C++
+```HTML
 <SCRIPT for="Player" language="jscript" event="EventName(Params)">
   ...
 </SCRIPT>
@@ -50,7 +50,7 @@ If the mime type associated with an embedded Player control is application/x-ms-
 where *EventName* is the name of a Windows Media Player event, and *Params* is a list of the event's parameters. For example, the following code has a handler for the [PlayStateChange](player-player-playstatechange.md) event.
 
 
-```C++
+```HTML
 <OBJECT id="Player" type="application/x-ms-wmp" width="300" height="200">
   <PARAM name="URL" value="c:\MediaFiles\Seattle.wmv"/>
 </OBJECT>
@@ -69,7 +69,7 @@ If you have several instances of the Player control on a webpage and if you use 
 If the mime type associated with an embedded Player control is not application/x-ms-wmp, you can write event handlers that have the following format:
 
 
-```C++
+```HTML
 <SCRIPT language="jscript">
   function OnDSEventNameEvt(Params)
   {...}
@@ -81,7 +81,7 @@ If the mime type associated with an embedded Player control is not application/x
 where *EventName* is the name of a Windows Media Player event, and *Params* is a list of the event's parameters. For example, the following code has a handler for the **PlayStateChange** event.
 
 
-```C++
+```HTML
 <OBJECT id="Player" type="application/asx" width="300" height="200">
   <PARAM name="URL" value="c:\MediaFiles\Test.asx"/>
 </OBJECT>

--- a/desktop-src/WMP/param-elements-in-an-object-element.md
+++ b/desktop-src/WMP/param-elements-in-an-object-element.md
@@ -24,7 +24,7 @@ Windows Media Player uses the PARAM element to define specific startup condition
 For example, if you want to define whether the **autoStart** property is True, you would embed the PARAM element inside the OBJECT element.
 
 
-```C++
+```HTML
 <OBJECT ID="Player"
   CLASSID="CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6">
     <PARAM name="autoStart" value="True">

--- a/desktop-src/WMP/simple-example-of-scripting-in-a-web-page.md
+++ b/desktop-src/WMP/simple-example-of-scripting-in-a-web-page.md
@@ -39,7 +39,7 @@ You can embed the Windows Media Player ActiveX control in a webpage using the fo
 The first step is to create a valid HTML webpage. The following code is the minimum needed to create a blank but valid HTML page:
 
 
-```C++
+```HTML
 <HTML>
     <HEAD>
     </HEAD>
@@ -56,7 +56,7 @@ The first step is to create a valid HTML webpage. The following code is the mini
 Once you have created a webpage, you need to add an OBJECT tag. This identifies the ActiveX control to the browser and sets up any initial definitions. You must place the OBJECT tag in the BODY of the code. If you place it in the BODY, the default user interface of Windows Media Player will be visible. If you want to create your own user interface, set the height and width attributes to 0 (zero). You can also set the *Player*.**uiMode** property to "invisible" when you want to hide the control, but still reserve space for it on the page. The following code is recommended when you provide a custom user interface:
 
 
-```C++
+```HTML
 <OBJECT ID="Player" height="0" width="0"
   CLASSID="CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6">
 </OBJECT>
@@ -80,7 +80,7 @@ A very large hexadecimal number that is unique to the control. Only one control 
 HTML allows a vast wealth of user interface elements, allowing the user to interact with your webpage by clicking, pressing keys, and other user actions. Adding a few INPUT buttons is the easiest way to provide a quick user interface. The following code creates two buttons that can respond to the user. Clicking one button starts the media stream playing and the other button stops it:
 
 
-```C++
+```HTML
 <INPUT TYPE="BUTTON" NAME="BtnPlay" VALUE="Play" OnClick="StartMeUp()">
 <INPUT TYPE="BUTTON" NAME="BtnStop" VALUE="Stop" OnClick="ShutMeDown()">
 
@@ -99,7 +99,7 @@ It is good authoring practice to enclose your script in HTML comment tags so bro
 The following Microsoft JScript code example calls the Windows Media Player control and performs an appropriate action in response to the corresponding button click.
 
 
-```C++
+```HTML
 <SCRIPT>
 <!--
 
@@ -129,7 +129,7 @@ The ShutMeDown code calls the **stop** method of the **Controls** object. Note t
 The following code shows a complete example.
 
 
-```C++
+```HTML
 <HTML>
 <HEAD>
 </HEAD>

--- a/desktop-src/WMP/url-flipping.md
+++ b/desktop-src/WMP/url-flipping.md
@@ -33,7 +33,7 @@ You are free to handle the URL script commands in your JScript code just as you 
 The following example illustrates a typical frameset for URL flipping. First, create a page that describes the frameset:
 
 
-```C++
+```HTML
 <HTML>
 <FRAMESET cols="300,*">
   <FRAME name="player" src="player.html">
@@ -48,7 +48,7 @@ The following example illustrates a typical frameset for URL flipping. First, cr
 Next, create the player.html file referenced in the frameset by using the following code (the video.wmv file is assumed to exist in the same directory as the HTML files):
 
 
-```C++
+```HTML
 <HTML>
 <BODY>
 <OBJECT ID="Player" CLASSID="CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6">

--- a/desktop-src/WMP/using-param-elements-in-a-web-page-displayed-by-firefox.md
+++ b/desktop-src/WMP/using-param-elements-in-a-web-page-displayed-by-firefox.md
@@ -31,7 +31,7 @@ ms.date: 05/31/2018
 You can use PARAM elements inside an OBJECT element to set the initial state of the Player control. For example, the PARAM elements in the following example specify that the control should play seattle.wmv automatically.
 
 
-```C++
+```HTML
 <OBJECT id="Player" type="application/x-ms-wmp" width="300" height="200">
   <PARAM name="url" value="c:\MediaFiles\seattle.wmv" />
   <PARAM name="autostart" value="true" />

--- a/desktop-src/WMP/using-script-in-a-web-page-displayed-by-firefox.md
+++ b/desktop-src/WMP/using-script-in-a-web-page-displayed-by-firefox.md
@@ -37,7 +37,7 @@ ms.date: 05/31/2018
 Script on a webpage can use the Player object model to control the Player as the user interacts with the page. For example, the following INPUT element has script that sets the Player volume.
 
 
-```C++
+```HTML
 <INPUT type="button" value="Vol" OnClick="ChangeVolume()"/>
  
 <SCRIPT>

--- a/desktop-src/WMP/using-script-to-control-url-flipping.md
+++ b/desktop-src/WMP/using-script-to-control-url-flipping.md
@@ -48,7 +48,7 @@ You can avoid displaying a blank or incomplete webpage by invoking the URL using
 First, you must create a frameset webpage to contain the frame with the embedded Player and the frame that displays the streaming HTML. Each of these two frames will display a separate webpage initially, so you will create a total of three webpages. The following example code demonstrates the frameset webpage:
 
 
-```C++
+```HTML
 <HTML>
 <HEAD>
 </HEAD>
@@ -75,7 +75,7 @@ First, you must create a frameset webpage to contain the frame with the embedded
 The preceding webpage example incorporates two frames. The first frame displays in the left half of the browser window and displays the webpage named embed\_player.htm. The following example code creates this webpage:
 
 
-```C++
+```HTML
 <HTML>
 <HEAD>
 </HEAD>
@@ -119,7 +119,7 @@ The preceding webpage example incorporates two frames. The first frame displays 
 The second frame in the frameset displays in the right half of the browser window and displays a webpage named "blank.htm". The following example code creates this webpage:
 
 
-```C++
+```HTML
 <HTML>
 <HEAD>
 </HEAD>

--- a/desktop-src/WMP/using-the-invokeurls-property-in-a-web-page-displayed-by-firefox.md
+++ b/desktop-src/WMP/using-the-invokeurls-property-in-a-web-page-displayed-by-firefox.md
@@ -41,7 +41,7 @@ The Firefox plug-in does not support setting the **invokeURLs** property in a PA
 You can work around this limitation by setting the **invokeURLs** property in script. The following code shows how to set the **invokeURLs** property to false in a webpage that can be displayed by both Internet Explorer and Firefox.
 
 
-```C++
+```HTML
 <HTML>
   <BODY OnLoad="Initialize()">
 
@@ -85,7 +85,7 @@ You can work around this limitation by setting the **invokeURLs** property in sc
 A media file can contain URLs that display webpages in a browser window or frame as the media file is played. In Internet Explorer, you can use the [Settings.defaultFrame](settings-defaultframe.md) property to specify the frame in which those pages are displayed. If you do not set the **defaultFrame** property, URLs are displayed in a separate window of the default browser. However, the Firefox plug-in does not support the **Settings.defaultFrame** property. To work around this limitation, set the **Settings.invokeURLs** property to false and write a [ScriptCommand](player-player-scriptcommand.md) event handler that sets the location of the target frame. The following example, which works in Internet Explorer and Firefox, illustrates this technique. Assume that the webpage shown in the example is in frames\[0\] and you want the URL's page to be displayed in frames\[1\].
 
 
-```C++
+```HTML
 <HTML>
   <BODY OnLoad="Initialize()">
 

--- a/desktop-src/WMP/using-the-windows-media-player-control-with-microsoft-visual-studio.md
+++ b/desktop-src/WMP/using-the-windows-media-player-control-with-microsoft-visual-studio.md
@@ -57,16 +57,14 @@ Adding the Windows Media Player control from the Toolbox also adds references to
 To make using the objects in the Player namespace easier, you should include the namespace in the using or imports directives of your files, as follows:
 
 
-```C++
-// [C#]
+```Csharp
 using WMPLib;
 ```
 
 
 
 
-```C++
-' [Visual Basic]
+```VB
 imports WMPLib
 
 ```


### PR DESCRIPTION
The language of the example code is marked C++ as markdown.
It can be tolerate to read on raw file but confused to read at Microsoft web site

[Example : 'Creating the Windows Media Player Control Programmatically' docs](https://docs.microsoft.com/en-us/windows/win32/wmp/creating-the-windows-media-player-control-programmatically)