### PR TITLE
Incorrect Link

### DIFF
--- a/desktop-src/Services/protecting-anti-malware-services-.md
+++ b/desktop-src/Services/protecting-anti-malware-services-.md
@@ -31,7 +31,7 @@ This document describes how an anti-malware vendor with an Early Launch Anti-Mal
 
 Starting with Windows 8.1, a new security model has been put in place in the kernel to better defend against malicious attacks on system-critical components. This new security model extends the protected process infrastructure previous versions of Windows used for specific scenarios, such as playing DRM content, into a general-purpose model that can be used by 3rd party anti-malware vendors. The protected process infrastructure only allows trusted, signed code to load and has built-in defense against code injection attacks.
 
-See the [Protected Processes in Windows Vista](https://go.microsoft.com/fwlink/p/?LinkID=308979) whitepaper for more information on protected processes.
+See the [Protected Processes in Windows Vista](http://download.microsoft.com/download/a/f/7/af7777e5-7dcd-4800-8a0a-b18336565f5b/process_vista.doc) whitepaper for more information on protected processes.
 
 The new security model uses a slightly different variant of the protection process infrastructure called system protected process, which is more suitable for this feature as this keeps the DRM content separate. Each system protected process has an associated level or attribute, which indicates the signature policy of the signed code allowed to load within the process. After the anti-malware services have opted into the protected service mode, only Windows signed code or code signed with the anti-malware vendor’s certificates are allowed to load in that process. Similarly, other protected process levels have different code policies enforced by Windows.
 


### PR DESCRIPTION
The provided link to the "Protected Processes in Windows Vista" links to the Hardware Dev Center archive, and the paper of interest is not available anywhere on this page. The new link is the correct download link for the whitepaper.