### PR TITLE
Define WMI acronym on first [stand-alone] use

### DIFF
--- a/desktop-src/WmiSdk/wmic.md
+++ b/desktop-src/WmiSdk/wmic.md
@@ -9,7 +9,7 @@ ms.date: 05/31/2018
 
 # wmic
 
-The WMI command-line (WMIC) utility provides a command-line interface for WMI (Windows Management Instrumentation). WMIC is compatible with existing shells and utility commands. The following is a general reference topic for wmic. For more information and guidelines on how to use mic, including additional information on aliases, verbs, switches, and commands, see [Using Windows Management Instrumentation Command-line](https://TechNet.Microsoft.Com/library/cc779482.aspx) and [WMIC - Take Command-line Control over WMI](https://TechNet.Microsoft.Com/library/bb742610.aspx).
+The WMI command-line (WMIC) utility provides a command-line interface for Windows Management Instrumentation (WMI). WMIC is compatible with existing shells and utility commands. The following is a general reference topic for WMIC. For more information and guidelines on how to use WMIC, including additional information on aliases, verbs, switches, and commands, see [Using Windows Management Instrumentation Command-line](https://TechNet.Microsoft.Com/library/cc779482.aspx) and [WMIC - Take Command-line Control over WMI](https://TechNet.Microsoft.Com/library/bb742610.aspx).
 
 ## Alias
 

--- a/desktop-src/WmiSdk/wmic.md
+++ b/desktop-src/WmiSdk/wmic.md
@@ -9,7 +9,7 @@ ms.date: 05/31/2018
 
 # wmic
 
-The WMI command-line (WMIC) utility provides a command-line interface for WMI. WMIC is compatible with existing shells and utility commands. The following is a general reference topic for wmic. For more information and guidelines on how to use mic, including additional information on aliases, verbs, switches, and commands, see [Using Windows Management Instrumentation Command-line](https://TechNet.Microsoft.Com/library/cc779482.aspx) and [WMIC - Take Command-line Control over WMI](https://TechNet.Microsoft.Com/library/bb742610.aspx).
+The WMI command-line (WMIC) utility provides a command-line interface for WMI (Windows Management Instrumentation). WMIC is compatible with existing shells and utility commands. The following is a general reference topic for wmic. For more information and guidelines on how to use mic, including additional information on aliases, verbs, switches, and commands, see [Using Windows Management Instrumentation Command-line](https://TechNet.Microsoft.Com/library/cc779482.aspx) and [WMIC - Take Command-line Control over WMI](https://TechNet.Microsoft.Com/library/bb742610.aspx).
 
 ## Alias
 


### PR DESCRIPTION
While trying to diagnose an issue coming from a `wmic` command, search results brought me to this page. The page defines the tool name with another acronym, which isn't defined on this page except indirectly in a link to another docs page. Hopefully, expanding it toward the first usage will help someone else coming here.