### PR TITLE
Fix x64 crash due to pointer truncation

### DIFF
--- a/desktop-src/Direct2D/direct2d-quickstart.md
+++ b/desktop-src/Direct2D/direct2d-quickstart.md
@@ -442,7 +442,7 @@ In this part, you implement the windows procedure, the OnRender method that pain
             ::SetWindowLongPtrW(
                 hwnd,
                 GWLP_USERDATA,
-                PtrToUlong(pDemoApp)
+                reinterpret_cast<LONG_PTR>(pDemoApp)
                 );
 
             result = 1;


### PR DESCRIPTION
The code stores a pointer in the window that points to the DemoApp object instance (using SetWindowLongPtrW). The idea is to retrieve the object pointer later when it is needed for processing window message. Conversion to unsigned long is done by PtrToUlong and this unfortunately truncates the 64-bit pointer to a 32-bit unsigned long before SetWindowLongPtrW sees it. The corrupted pointer is then later used and at that point the program crashes on most but not all machines (ASLR?).