### PR TITLE
Update example code for multi-threaded pipe server

### DIFF
--- a/desktop-src/ipc/multithreaded-pipe-server.md
+++ b/desktop-src/ipc/multithreaded-pipe-server.md
@@ -31,7 +31,7 @@ int _tmain(VOID)
    BOOL   fConnected = FALSE; 
    DWORD  dwThreadId = 0; 
    HANDLE hPipe = INVALID_HANDLE_VALUE, hThread = NULL; 
-   LPTSTR lpszPipename = TEXT("\\\\.\\pipe\\mynamedpipe"); 
+   LPCTSTR lpszPipename = TEXT("\\\\.\\pipe\\mynamedpipe"); 
  
 // The main loop creates an instance of the named pipe and 
 // then waits for a client to connect to it. When the client 
@@ -164,7 +164,7 @@ DWORD WINAPI InstanceThread(LPVOID lpvParam)
       {   
           if (GetLastError() == ERROR_BROKEN_PIPE)
           {
-              _tprintf(TEXT("InstanceThread: client disconnected.\n"), GetLastError()); 
+              _tprintf(TEXT("InstanceThread: client disconnected.\n")); 
           }
           else
           {

--- a/desktop-src/ipc/multithreaded-pipe-server.md
+++ b/desktop-src/ipc/multithreaded-pipe-server.md
@@ -202,7 +202,7 @@ DWORD WINAPI InstanceThread(LPVOID lpvParam)
    HeapFree(hHeap, 0, pchRequest);
    HeapFree(hHeap, 0, pchReply);
 
-   printf("InstanceThread exitting.\n");
+   printf("InstanceThread exiting.\n");
    return 1;
 }
 


### PR DESCRIPTION
- Change LPTSTR to LPCTSTR to properly initialize from string literal (const char[N])
- Remove GetLastError() parameter passed to _tprintf() not used in the format string