### PR TITLE
Update code samples in "Using Mailslots"

### DIFF
--- a/desktop-src/ipc/creating-a-mailslot.md
+++ b/desktop-src/ipc/creating-a-mailslot.md
@@ -18,9 +18,9 @@ The following code sample uses the [**CreateMailslot**](/windows/desktop/api/Win
 #include <stdio.h>
 
 HANDLE hSlot;
-LPTSTR Slot = TEXT("\\\\.\\mailslot\\sample_mailslot");
+LPCTSTR SlotName = TEXT("\\\\.\\mailslot\\sample_mailslot");
 
-BOOL WINAPI MakeSlot(LPTSTR lpszSlotName) 
+BOOL WINAPI MakeSlot(LPCTSTR lpszSlotName) 
 { 
     hSlot = CreateMailslot(lpszSlotName, 
         0,                             // no maximum message size 
@@ -38,7 +38,7 @@ BOOL WINAPI MakeSlot(LPTSTR lpszSlotName)
 
 void main()
 { 
-   MakeSlot(Slot);
+   MakeSlot(SlotName);
 }
 ```
 

--- a/desktop-src/ipc/reading-from-a-mailslot.md
+++ b/desktop-src/ipc/reading-from-a-mailslot.md
@@ -20,7 +20,7 @@ A mailslot exists until the [**CloseHandle**](https://docs.microsoft.com/windows
 #include <strsafe.h>
 
 HANDLE hSlot;
-LPTSTR SlotName = TEXT("\\\\.\\mailslot\\sample_mailslot");
+LPCTSTR SlotName = TEXT("\\\\.\\mailslot\\sample_mailslot");
 
 BOOL ReadSlot() 
 { 
@@ -120,7 +120,7 @@ BOOL ReadSlot()
     return TRUE; 
 }
 
-BOOL WINAPI MakeSlot(LPTSTR lpszSlotName) 
+BOOL WINAPI MakeSlot(LPCTSTR lpszSlotName) 
 { 
     hSlot = CreateMailslot(lpszSlotName, 
         0,                             // no maximum message size 

--- a/desktop-src/ipc/writing-to-a-mailslot.md
+++ b/desktop-src/ipc/writing-to-a-mailslot.md
@@ -15,9 +15,9 @@ Writing to a mailslot is similar to writing to a standard disk file. The followi
 #include <windows.h>
 #include <stdio.h>
 
-LPTSTR SlotName = TEXT("\\\\.\\mailslot\\sample_mailslot");
+LPCTSTR SlotName = TEXT("\\\\.\\mailslot\\sample_mailslot");
 
-BOOL WriteSlot(HANDLE hSlot, LPTSTR lpszMessage)
+BOOL WriteSlot(HANDLE hSlot, LPCTSTR lpszMessage)
 {
    BOOL fResult; 
    DWORD cbWritten; 


### PR DESCRIPTION
_Creating a Mailslot_:
- Rename "Slot" to "SlotName" to be more descriptive as well as to maintain consistency with the extension of the example in "Reading from a Mailslot" section
- Add constant qualifier to SlotName to properly initialize

_Writing to a Mailslot_:
- Add constant qualifier to SlotName to properly initialize
- Change parameter type of `WriteSlot` to accept non-modifiable string 

_Reading from a Mailslot_:
- Add constant qualifier to SlotName to properly initialize
- Change parameter type of `MakeSlot` to accept non-modifiable string