### PR TITLE
Need confirmation on below points

### DIFF
--- a/desktop-src/WmiSdk/example--getting-wmi-data-from-the-local-computer.md
+++ b/desktop-src/WmiSdk/example--getting-wmi-data-from-the-local-computer.md
@@ -248,7 +248,9 @@ int main(int argc, char **argv)
 }
 ```
 
-
+Note: Below points are not permitted to connecting WMI to local computer or executing query on local computer.
+1. We can't provide user credentials to "ConnectServer" API.
+2. We can't provide user credentials or authentication information (domain, username, password) on WMI query/proxy. Something like using "CoSetProxyBlanket" API or "CoInitializeSecurity" API.
 
  
 


### PR DESCRIPTION
Please correct my understanding regarding execute WMI query on local computer. Understanding based on below documents. And please make changes in documents if those are correct.

https://docs.microsoft.com/en-us/windows/win32/wmisdk/connecting-to-wmi-on-a-remote-computer
https://docs.microsoft.com/en-us/windows/win32/wmisdk/setting-the-security-on-iwbemservices-and-other-proxies

Below points are not permitted to connecting WMI to local computer or executing query on local computer.
1. We can't provide user credentials to "ConnectServer" API.
2. We can't provide user credentials or authentication information (domain, username, password) on WMI query/proxy. Something like using "CoSetProxyBlanket" API or "CoInitializeSecurity" API.

Summary: Is there any way to provide user credentials to execute WMI query?