### PR TITLE
Update wmi-tasks--files-and-folders.md

### DIFF
--- a/desktop-src/WmiSdk/wmi-tasks--files-and-folders.md
+++ b/desktop-src/WmiSdk/wmi-tasks--files-and-folders.md
@@ -131,7 +131,7 @@ Next</code></pre></td>
 </thead>
 <tbody>
 <tr class="odd">
-<td><pre><code>Get-WmiObject -Class CIM_DataFile -namespace &quot;root\cimv2&quot; -Filter &quot;Extension = &quot;mp3&quot; | `
+<td><pre><code>Get-WmiObject -Class CIM_DataFile -namespace &quot;root\cimv2&quot; -Filter &quot;Extension = &#39;mp3&#39;&quot; | `
    format-list Name, Extension, Path</code></pre></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Adding single quotes around mp3 in the Powershell code for the "determine whether users have .MP3 files" example.