### PR TITLE
Minor edit(s) to resolve C++ compile time error

### DIFF
--- a/desktop-src/WinSock/complete-client-code.md
+++ b/desktop-src/WinSock/complete-client-code.md
@@ -39,7 +39,7 @@ int __cdecl main(int argc, char **argv)
     struct addrinfo *result = NULL,
                     *ptr = NULL,
                     hints;
-    char *sendbuf = "this is a test";
+    const char *sendbuf = "this is a test";
     char recvbuf[DEFAULT_BUFLEN];
     int iResult;
     int recvbuflen = DEFAULT_BUFLEN;

--- a/desktop-src/WinSock/sending-and-receiving-data-on-the-client.md
+++ b/desktop-src/WinSock/sending-and-receiving-data-on-the-client.md
@@ -18,7 +18,7 @@ The following code demonstrates the [**send**](/windows/desktop/api/Winsock2/nf-
 
 int recvbuflen = DEFAULT_BUFLEN;
 
-char *sendbuf = "this is a test";
+const char *sendbuf = "this is a test";
 char recvbuf[DEFAULT_BUFLEN];
 
 int iResult;


### PR DESCRIPTION
Fix for: error C2440: 'initializing': cannot convert from 'const char [15]' to 'char *'
