### PR TITLE
Add "streamid" field

### DIFF
--- a/desktop-src/Http/error-logging-in-windows-server-2003-sp1.md
+++ b/desktop-src/Http/error-logging-in-windows-server-2003-sp1.md
@@ -81,6 +81,7 @@ The error logging fields are listed in the following table:
 | SiteId               | Yes               | 0x01000000 |
 | Reason Phrase        | Yes               | 0x02000000 |
 | Queue Name           | No                | 0x04000000 |
+| Stream Id            | No                | 0x???????? |
 
 
 


### PR DESCRIPTION
The "streamid" field is present in Windows Server 29016, but documented ANYWHERE. This should change, as a lot of developers require this information.