### PR TITLE
Fix tag names as inline code in VML docs

### DIFF
--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----background--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----background--element.md
@@ -29,13 +29,13 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how you can customize the background of a Web page by using the <background> element provided in VML.
+In this topic, we will illustrate how you can customize the background of a Web page by using the `<background>` element provided in VML.
 
-As you've learned from the [Use <fill>](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md) topic, you can place the <fill> sub-element inside the <shape>, <shapetype>, or any predefined shape element to describe how to fill the shape.
+As you've learned from the [Use `<fill>`](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md) topic, you can place the `<fill>` sub-element inside the `<shape>`, `<shapetype>`, or any predefined shape element to describe how to fill the shape.
 
-Similarly, you can place the <fill> sub-element inside the <background> element to describe how to fill the background of a Web page. You can then use the property attributes of the <fill> sub-element to customize the fill effect, such as [gradient fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md), [pattern fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md), or [picture fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md).
+Similarly, you can place the `<fill>` sub-element inside the `<background>` element to describe how to fill the background of a Web page. You can then use the property attributes of the `<fill>` sub-element to customize the fill effect, such as [gradient fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md), [pattern fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md), or [picture fill](web-workshop---how-to-use-vml-on-web-pages-----fill--element.md).
 
-For example, to draw a gradient-filled background, you can type the following lines in the <BODY> region of your Web page:
+For example, to draw a gradient-filled background, you can type the following lines in the `<BODY>` region of your Web page:
 
 
 ```HTML

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----fill--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----fill--element.md
@@ -39,9 +39,9 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-As you've learned, you can use the **fillcolor** property attribute of a predefined shape element -- such as <oval> , <line>, <polyline>, <curve>, <rect>, <roundrect>, <arc> -- to specify the color that is used to fill the shape. In this topic, we will illustrate how to draw a shape that is filled with more advanced effects.
+As you've learned, you can use the **fillcolor** property attribute of a predefined shape element -- such as `<oval>` , `<line>`, `<polyline>`, `<curve>`, `<rect>`, `<roundrect>`, `<arc>` -- to specify the color that is used to fill the shape. In this topic, we will illustrate how to draw a shape that is filled with more advanced effects.
 
-You can place the <fill> sub-element inside the <shape>, or <shapetype>, or any predefined shape element to describe how to fill the shape. You can then use the property attributes of the <fill> sub-element to customize the fill effect, such as [gradient fill](#gradient-fill), [pattern fill](#pattern-fill), [picture fill](#picture-fill).
+You can place the `<fill>` sub-element inside the `<shape>`, or `<shapetype>`, or any predefined shape element to describe how to fill the shape. You can then use the property attributes of the `<fill>` sub-element to customize the fill effect, such as [gradient fill](#gradient-fill), [pattern fill](#pattern-fill), [picture fill](#picture-fill).
 
 In this topic:
 
@@ -51,7 +51,7 @@ In this topic:
 
 ## Gradient Fill
 
-To draw a gradient-filled shape, you can set the **type** property attribute of the <fill> sub-element to "gradient" or "gradientRadial", and then specify other property attributes of the <fill> sub-element, such as **method**, **color2**, **focus**, and **angle**.
+To draw a gradient-filled shape, you can set the **type** property attribute of the `<fill>` sub-element to "gradient" or "gradientRadial", and then specify other property attributes of the `<fill>` sub-element, such as **method**, **color2**, **focus**, and **angle**.
 
 **Examples:**
 
@@ -70,7 +70,7 @@ To create a shape that is gradient-filled horizontally, you can set the **type**
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/AdvancedFill/Gradient/Horizontal1.md)
 
-If you change the **fillcolor** property attribute of the shape, the shape is then gradient-filled with a different color. You can add a second color by specifying the **color2** property attribute of the <fill> sub-element. For example, to create a shape that is gradient-filled in two colors, you can add a second color by specifying the **color2** property attribute of the <fill> sub-element, as shown in the following VML representation:
+If you change the **fillcolor** property attribute of the shape, the shape is then gradient-filled with a different color. You can add a second color by specifying the **color2** property attribute of the `<fill>` sub-element. For example, to create a shape that is gradient-filled in two colors, you can add a second color by specifying the **color2** property attribute of the `<fill>` sub-element, as shown in the following VML representation:
 
 ![horizontal2.gif (3127 bytes)](images/horizontal2.gif)
 
@@ -160,7 +160,7 @@ type="gradientRadial" />
 
 ## Pattern Fill
 
-To draw a pattern-filled shape, you can set the **type** property attribute of the <fill> sub-element to "pattern", and then specify other property attributes of the <fill> sub-element, such as **src** and **color2**.
+To draw a pattern-filled shape, you can set the **type** property attribute of the `<fill>` sub-element to "pattern", and then specify other property attributes of the `<fill>` sub-element, such as **src** and **color2**.
 
 **Examples:**
 
@@ -199,7 +199,7 @@ color2="blue" />
 
 ## Picture Fill
 
-To draw a picture-filled shape, you can set the **type** property attribute of the <fill> sub-element to "frame", and then specify other property attributes of the <fill> sub-element, such as **src** and **color2**.
+To draw a picture-filled shape, you can set the **type** property attribute of the `<fill>` sub-element to "frame", and then specify other property attributes of the `<fill>` sub-element, such as **src** and **color2**.
 
 **Examples:**
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----formulas--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----formulas--element.md
@@ -29,13 +29,13 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how to use the <formulas> sub-element to define an adjustable path for a shape.
+In this topic, we will illustrate how to use the `<formulas>` sub-element to define an adjustable path for a shape.
 
-You can place the <formulas> sub-element inside <shape> or <shapetype> to define formulas that can vary the path of a shape. Inside the <formulas> sub-element, one **f** sub-element defines one formula so that one value is evaluated based upon that formula. For example, the formula, `<v:f eqn="prod 10 4 5"/>` defines a value that is equivalent to "10 x 4 / 5".
+You can place the <formulas> sub-element inside `<shape>` or `<shapetype>` to define formulas that can vary the path of a shape. Inside the `<formulas>` sub-element, one **f** sub-element defines one formula so that one value is evaluated based upon that formula. For example, the formula, `<v:f eqn="prod 10 4 5"/>` defines a value that is equivalent to "10 x 4 / 5".
 
-You can place many **f** sub-elements inside one <formulas> sub-element. Formulas can reference the values that are defined earlier in other formulas within the same <formulas> sub-element. The value that is defined in the first formula can be referred to as @0, the value that is defined in the second formula can be referred to as @1, and so on.
+You can place many **f** sub-elements inside one`<formulas>` sub-element. Formulas can reference the values that are defined earlier in other formulas within the same `<formulas>` sub-element. The value that is defined in the first formula can be referred to as @0, the value that is defined in the second formula can be referred to as @1, and so on.
 
-In addition, you can specify the **adj** property attribute of the <shape> element, such as adj="100, 200, 150". Inside the <formulas> element, you can then reference those values in the **adj** list. The first value (100) in the **adj** list can be referred to as \#0, the second value (200) can be referred to as \#1, and so on.
+In addition, you can specify the **adj** property attribute of the `<shape>` element, such as adj="100, 200, 150". Inside the `<formulas>` element, you can then reference those values in the **adj** list. The first value (100) in the **adj** list can be referred to as \#0, the second value (200) can be referred to as \#1, and so on.
 
 For example, to draw a smiling face, you can type the following VML representation:
 
@@ -67,7 +67,7 @@ m4960@0c8853@3,12747@3,16640@0nfe">
 -   The second formula, `<v:f eqn="prod #0 4 3"/>`, defines the value (= \#0 \* 4 / 3). This value can be referenced as @1.
 -   The third formula, `<v:f eqn="prod @0 1 3"/>`, defines the value (= @0 \* 1 / 3). This value can be referenced as @2.
 -   The fourth formula, `<v:f eqn="sum @1 0 @2"/>`, defines the value (=@1 + 0 -@2). This value can be referenced as @3.
--   Inside the <path> element, the values defined in the first (@0) and the fourth (@3) formulas are used to determine the outline of the shape.
+-   Inside the `<path>` element, the values defined in the first (@0) and the fourth (@3) formulas are used to determine the outline of the shape.
 
 If you change the **adj** list, such as `adj="20000"`, the values of the formulas that reference the **adj** list will be changed as well, affecting the smiling face as follows:
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----handles--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----handles--element.md
@@ -29,9 +29,9 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how to use the <handles> element to attach text to a shape.
+In this topic, we will illustrate how to use the `<handles>` element to attach text to a shape.
 
-You can place the <handles> sub-element inside <shape> or <shapetype> to define user interface elements that can vary the **adj** values on the shape.
+You can place the `<handles>` sub-element inside `<shape>` or `<shapetype>` to define user interface elements that can vary the **adj** values on the shape.
 
 For example, as shown the following VML representation, you can provide an adjust handle (yellow box) that users can simply drag to adjust the shape.
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----image--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----image--element.md
@@ -57,23 +57,23 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-Using <image>
+Using `<image>`
 
-In this topic, we will illustrate how to use the <image> element to display pictures with various special effects.
+In this topic, we will illustrate how to use the `<image>` element to display pictures with various special effects.
 
-If you wanted to display a picture that was loaded from an external source, you would usually use the <img> element provided in HTML, and then point the **src** property attribute to the location of the image file.
+If you wanted to display a picture that was loaded from an external source, you would usually use the `<img>` element provided in HTML, and then point the **src** property attribute to the location of the image file.
 
-Alternatively you can use the <image> element provided in VML. When you use the <image> element, you can create only one image file and then display the image differently by altering the property attributes of the <image> element. Also, the <image> element provides several special effects that you can't do by simply using the <img> element of HTML, such as [cropping](#crop), [contrast](#contrast), [brightness](#brightness), [gamma](#gamma), and [grayscale](#grayscale).
+Alternatively you can use the `<image>` element provided in VML. When you use the `<image>` element, you can create only one image file and then display the image differently by altering the property attributes of the `<image>` element. Also, the `<image>` element provides several special effects that you can't do by simply using the `<img>` element of HTML, such as [cropping](#crop), [contrast](#contrast), [brightness](#brightness), [gamma](#gamma), and [grayscale](#grayscale).
 
 [![back to top](images/top.gif) Back to top](#top)
 
 ## crop
 
-You can use the **cropbottom**, **croptop**, **cropleft**, and **cropright** property attributes of the <image> element to display different pictures that are cropped from the same image file.
+You can use the **cropbottom**, **croptop**, **cropleft**, and **cropright** property attributes of the `<image>` element to display different pictures that are cropped from the same image file.
 
 The value of these crop attributes represents the percentage cut from the edge of the picture. The value can be any number between 0 to 1. By default, the value is set to 0, indicating no crop from the edge. The value 0.1 indicates a cropping of 10 percent from the edge, The value 0.15 indicates a cropping of 15 percent from the edge, and so on.
 
-For example, to display five pictures that are all cropped from the same image file, you can use the <image> element and specify different crop values, as shown in the following VML representation:
+For example, to display five pictures that are all cropped from the same image file, you can use the `<image>` element and specify different crop values, as shown in the following VML representation:
 
 ![image1.jpg (5770 bytes)](images/image1.jpg)![image1\-2.jpg (1969 bytes)](images/image1-2.jpg)![image1\-3.jpg (1148 bytes)](images/image1-3.jpg)![image1\-4.jpg (1686 bytes)](images/image1-4.jpg)![image1\-5.jpg (1364 bytes)](images/image1-5.jpg)
 
@@ -104,11 +104,11 @@ Similarly the third, fourth, and fifth images have some crop values. The origina
 
 ## contrast
 
-You can use the **gain** property attribute of the <image> element to display various pictures that have different contrast settings.
+You can use the **gain** property attribute of the `<image>` element to display various pictures that have different contrast settings.
 
 The value of the **gain** property attribute can be any number. By default, the value is 1, indicating the use of the same contrast as the original image. The value 0 indicates no contrast. The larger the number, the higher the contrast.
 
-For example, to display five pictures that have different contrast settings, you can use the <image> element and set a different value for the **gain** property attribute, as shown in the following VML representation:
+For example, to display five pictures that have different contrast settings, you can use the `<image>` element and set a different value for the **gain** property attribute, as shown in the following VML representation:
 
 ![image1.jpg (5770 bytes)](images/image1.jpg)![image2\-2.jpg (270 bytes)](images/image2-2.jpg)![image2\-3.jpg (1919 bytes)](images/image2-3.jpg)![image2\-4.jpg (3143 bytes)](images/image2-4.jpg)![image2\-5.jpg (1724 bytes)](images/image2-5.jpg)
 
@@ -131,11 +131,11 @@ When the **gain** property attribute is set to 0, the entire image becomes gray 
 
 ## brightness
 
-You can use the **blacklevel** property attribute of the <image> element to display various pictures that have different brightness settings.
+You can use the **blacklevel** property attribute of the `<image>` element to display various pictures that have different brightness settings.
 
 The value of the **blacklevel** property attribute can be any value between 0 to 1. By default, the value is 0, indicating that the level of brightness in the original image is preserved. The value 1 indicates the highest level of brightness.
 
-For example, to display five pictures that have different brightness settings, you can use the <image> element and set a different value for the **blacklevel** property attribute, as shown in the following VML representation:
+For example, to display five pictures that have different brightness settings, you can use the `<image>` element and set a different value for the **blacklevel** property attribute, as shown in the following VML representation:
 
 ![image1.jpg (5770 bytes)](images/image1.jpg)![image3\-2.jpg (2579 bytes)](images/image3-2.jpg)![image3\-3.jpg (2330 bytes)](images/image3-3.jpg)![image3\-4.jpg (2727 bytes)](images/image3-4.jpg)![image3\-5.jpg (2435 bytes)](images/image3-5.jpg)
 
@@ -156,7 +156,7 @@ For example, to display five pictures that have different brightness settings, y
 
 ## grayscale
 
-You can use the **grayscale** property attribute of the <image> element to display pictures with or without grayscale.
+You can use the **grayscale** property attribute of the `<image>` element to display pictures with or without grayscale.
 
 The value of the **grayscale** property attribute can be either true or false. By default, the value is set to false so that the image will be displayed in color. If the value is set to true, the image will be displayed in grayscale.
 
@@ -181,11 +181,11 @@ grayscale=true />
 
 ## gamma
 
-You can use the **gamma** property attribute of the <image> element to display pictures that have different gamma settings.
+You can use the **gamma** property attribute of the `<image>` element to display pictures that have different gamma settings.
 
 The value of the gamma property attribute can be any value between 0 and 1. By default, the value is set to 1.
 
-For example, to display three pictures that have different gamma settings, you can use the <image> element and set a different value of the **gamma** property attribute, as shown in the following VML representation:
+For example, to display three pictures that have different gamma settings, you can use the `<image>` element and set a different value of the **gamma** property attribute, as shown in the following VML representation:
 
 ![image5\-1.jpg (2714 bytes)](images/image5-1.jpg)![image5\-2.jpg (2729 bytes)](images/image5-2.jpg)![image5\-3.jpg (2726 bytes)](images/image5-3.jpg)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----path--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----path--element.md
@@ -29,11 +29,11 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-You've learned that you can use the VML predefined shape elements -- such as <oval> , <line>, <polyline>, <curve>, <rect>, <roundrect>, and <arc> -- to draw a shape. In this topic, we will illustrate how to use the <path> sub-element to customize the outline of a shape.
+You've learned that you can use the VML predefined shape elements -- such as `<oval>` , `<line>`, `<polyline>`, `<curve>`, `<rect>`, `<roundrect>`, and `<arc>` -- to draw a shape. In this topic, we will illustrate how to use the `<path>` sub-element to customize the outline of a shape.
 
-You can place the <path> sub-element inside the <shape> or <shapetype> element. You can then use the property attributes of the <path> sub-element to customize the outline of the shape.
+You can place the `<path>` sub-element inside the `<shape>` or `<shapetype>` element. You can then use the property attributes of the `<path>` sub-element to customize the outline of the shape.
 
-For example, to draw the customized shape illustrated in the following picture, you can use the <path> sub-element to define the outline of the shape, as shown in the following VML representation:
+For example, to draw the customized shape illustrated in the following picture, you can use the `<path>` sub-element to define the outline of the shape, as shown in the following VML representation:
 
 ![shape1.gif (1301 bytes)](images/shape1p.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----shadow--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----shadow--element.md
@@ -29,11 +29,11 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how to use the <shadow> sub-element to draw a shape that has various shadow effects.
+In this topic, we will illustrate how to use the `<shadow>` sub-element to draw a shape that has various shadow effects.
 
-You can place the <shadow> sub-element inside the <shape>, <shapetype>, or any predefined shape element to draw a shape with a shadow. You can then use the property attributes of the <shadow> sub-element to customize the shadow.
+You can place the `<shadow>` sub-element inside the `<shape>`, `<shapetype>`, or any predefined shape element to draw a shape with a shadow. You can then use the property attributes of the `<shadow>` sub-element to customize the shadow.
 
-For example, to create a shape with a shadow, as shown in the following picture, you can type the following lines in the <BODY> region of your Web page:
+For example, to create a shape with a shadow, as shown in the following picture, you can type the following lines in the `<BODY>` region of your Web page:
 
 ![shape1.gif (887 bytes)](images/shape1.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----shapetype--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----shapetype--element.md
@@ -34,15 +34,15 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how to use the <shapetype> element to define your own frequently-used shapes and then instantiate, or create, shapes from the shapetype.
+In this topic, we will illustrate how to use the `<shapetype>` element to define your own frequently-used shapes and then instantiate, or create, shapes from the shapetype.
 
-If you wanted to draw many shapes that have the same or similar properties, it would be tedious if you had to repeatedly type the same property attributes for each shape. VML provides the <shapetype> element so that you can define a prototype of a shape. You can then use the <shape> element to instantiate many copies of shapes from the same shapetype.
+If you wanted to draw many shapes that have the same or similar properties, it would be tedious if you had to repeatedly type the same property attributes for each shape. VML provides the `<shapetype>` element so that you can define a prototype of a shape. You can then use the `<shape>` element to instantiate many copies of shapes from the same shapetype.
 
 You can follow the three steps to define a shapetype, and then instantiate a shape from the shapetype:
 
-1.  Type a <shapetype> element and give it a name by specifying the id attribute.
+1.  Type a `<shapetype>` element and give it a name by specifying the id attribute.
 2.  Describe the shapetype by using its property attributes or sub-elements.
-3.  Instantiate a shape by typing a <shape> element, and refer the type attribute of the shape to the id attribute of the shapetype.
+3.  Instantiate a shape by typing a `<shape>` element, and refer the type attribute of the shape to the id attribute of the shapetype.
 
 For example, you type the following lines to create a shapetype called "MyShape":
 
@@ -54,7 +54,7 @@ For example, you type the following lines to create a shapetype called "MyShape"
 
 
 
-Then, you alter the shapetype by setting some property attributes, such as `fillcolor="red" strokecolor="blue"`. Or, you can use sub-elements inside the shapetype, such as <path>, <fill>, <stroke> (we will talk about those sub-elements in later topics).
+Then, you alter the shapetype by setting some property attributes, such as `fillcolor="red" strokecolor="blue"`. Or, you can use sub-elements inside the shapetype, such as `<path>`, `<fill>`, `<stroke>` (we will talk about those sub-elements in later topics).
 
 
 ```HTML
@@ -106,9 +106,9 @@ path="m10860,2187c10451,1746,9529,1018,9015,730,7865,152,6685,,5415,,4175,
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/ShapeType/type1.md)
 
-As you've learned, when a shape is instantiated from a shapetype, it inherits all of the property attributes from the shapetype. You can overwrite some or all of the inherited attributes by redefining attributes inside the <shape> element. Be aware that the inheritance is only one level. This is because only a <shape> element can reference a <shapetype> element. A <shapetype> element cannot reference another <shapetype> element.
+As you've learned, when a shape is instantiated from a shapetype, it inherits all of the property attributes from the shapetype. You can overwrite some or all of the inherited attributes by redefining attributes inside the `<shape>` element. Be aware that the inheritance is only one level. This is because only a `<shape>` element can reference a `<shapetype>` element. A `<shapetype>` element cannot reference another `<shapetype>` element.
 
-Also, a shapetype doesn't belong to any group. Therefore, the <shapetype> element can appear by itself or inside a <group> element. You can have many shapes inside different groups that reference the same shapetype. If a shapetype appears inside a group, a shape living in another group can still reference this shapetype.
+Also, a shapetype doesn't belong to any group. Therefore, the `<shapetype>` element can appear by itself or inside a `<group>` element. You can have many shapes inside different groups that reference the same shapetype. If a shapetype appears inside a group, a shape living in another group can still reference this shapetype.
 
 For example, in the following VML representation, Rect1 and Rect2 are in GroupA, and Rect3 is in GroupB. All three rectangles are instantiated from MyShape shapetype.
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----stroke--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----stroke--element.md
@@ -44,21 +44,21 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-Using <stroke>
+Using `<stroke>`
 
-As you've learned, you can use the **strokecolor** and **strokeweight** property attributes of a predefined shape -- such as <oval> , <line>, <polyline>, <curve>, <rect>, <roundrect>, <arc> -- to specify the color and weight of a shape's outline. In this topic, we will illustrate how to draw a shape that has a more advanced outline.
+As you've learned, you can use the **strokecolor** and **strokeweight** property attributes of a predefined shape -- such as `<oval>` , `<line>`, `<polyline>`, `<curve>`, `<rect>`, `<roundrect>`, `<arc>` -- to specify the color and weight of a shape's outline. In this topic, we will illustrate how to draw a shape that has a more advanced outline.
 
-You can place the <stroke> sub-element inside the <shape>, or <shapetype>, or any predefined shape element to describe how to draw the outline of the shape. You can then use the property attributes -- for example, [dashstyle](#dashstyle), [opacity](#opacity), [linestyle](#linestyle), [joinstyle](#joinstyle), [filltype](#filltype) -- of the <stroke> sub-element to customize the outline.
+You can place the `<stroke>` sub-element inside the `<shape>`, or `<shapetype>`, or any predefined shape element to describe how to draw the outline of the shape. You can then use the property attributes -- for example, [dashstyle](#dashstyle), [opacity](#opacity), [linestyle](#linestyle), [joinstyle](#joinstyle), [filltype](#filltype) -- of the `<stroke>` sub-element to customize the outline.
 
 [![back to top](images/top.gif) Back to top](#top)
 
 ## dashstyle
 
-You can use the **dashstyle** property attribute of the <stroke> sub-element to draw an outline with various dash styles.
+You can use the **dashstyle** property attribute of the `<stroke>` sub-element to draw an outline with various dash styles.
 
 **Examples:**
 
-If you specify `<v:stroke dashstyle="solid" />` inside the <line> element, you can create a solid line, as shown in the following VML representation:
+If you specify `<v:stroke dashstyle="solid" />` inside the `<line>` element, you can create a solid line, as shown in the following VML representation:
 
 ![solid.gif (96 bytes)](images/solid.gif)
 
@@ -154,7 +154,7 @@ strokecolor="red" strokeweight="2pt">
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/AdvancedLine/DashStyle/longdashdot.md)
 
-If you place `<v:stroke dashstyle="dashdot" />` inside the <rect> element, you can create a rectangle that has a dashed and dotted outline, as shown in the following VML representation:
+If you place `<v:stroke dashstyle="dashdot" />` inside the `<rect>` element, you can create a rectangle that has a dashed and dotted outline, as shown in the following VML representation:
 
 ![rect.gif (615 bytes)](images/rect.gif)
 
@@ -173,7 +173,7 @@ If you place `<v:stroke dashstyle="dashdot" />` inside the <rect> element, you c
 
 ## opacity
 
-You can use the **opacity** property attribute of the <stroke> sub-element to draw an outline with various opacity styles. The value for the **opacity** property attribute can be any number between 0 to 1. By default, it is 1, indicating full opacity.
+You can use the **opacity** property attribute of the `<stroke>` sub-element to draw an outline with various opacity styles. The value for the **opacity** property attribute can be any number between 0 to 1. By default, it is 1, indicating full opacity.
 
 **Examples:**
 
@@ -192,7 +192,7 @@ strokeweight="2pt">
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/AdvancedLine/Opacity/Line1.md)
 
-If you add `<v:stroke opacity="0.5" />` inside the <line> element, you can create a line with 50% opacity, as shown in the following VML representation:
+If you add `<v:stroke opacity="0.5" />` inside the `<line>` element, you can create a line with 50% opacity, as shown in the following VML representation:
 
 ![line2.gif (108 bytes)](images/line2.gif)
 
@@ -212,11 +212,11 @@ strokeweight="2pt">
 
 ## linestyle
 
-You can use the **linestyle** property attribute of the <stroke> sub-element to draw an outline with various line styles.
+You can use the **linestyle** property attribute of the `<stroke>` sub-element to draw an outline with various line styles.
 
 **Examples:**
 
-If you specify `<v:stroke linestyle="single" />` inside the <rect> element, you can create a rectangle with a single outline, as shown in the following VML representation:
+If you specify `<v:stroke linestyle="single" />` inside the `<rect>` element, you can create a rectangle with a single outline, as shown in the following VML representation:
 
 ![single.gif (537 bytes)](images/single.gif)
 
@@ -299,9 +299,9 @@ strokeweight="10pt">
 
 ## joinstyle
 
-You can use the **joinstyle** attribute of the <stroke> sub-element to define how lines are joined together.
+You can use the **joinstyle** attribute of the `<stroke>` sub-element to define how lines are joined together.
 
-For example, to create a shape that has the round-join outline, as shown in the following illustration, you can specify `<v:stroke joinstyle="round" />` inside the <polyline> element, as shown in the following VML representation:
+For example, to create a shape that has the round-join outline, as shown in the following illustration, you can specify `<v:stroke joinstyle="round" />` inside the `<polyline>` element, as shown in the following VML representation:
 
 ![round.gif (660 bytes)](images/round.gif)
 
@@ -356,11 +356,11 @@ strokecolor="red" strokeweight="20pt">
 
 ## filltype
 
-You can use the **filltype** property attribute of the <stroke> sub-element to draw an outline with various fill effects.
+You can use the **filltype** property attribute of the `<stroke>` sub-element to draw an outline with various fill effects.
 
 **Examples:**
 
-If you specify `<v:stroke filltype="solid" />` inside the <roundrect> element, you can create a rounded rectangle with the solid-filled outline, as shown in the following VML representation:
+If you specify `<v:stroke filltype="solid" />` inside the `<roundrect>` element, you can create a rounded rectangle with the solid-filled outline, as shown in the following VML representation:
 
 ![solid.gif (701 bytes)](images/solidborder.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----textbox--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----textbox--element.md
@@ -31,7 +31,7 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
 ## Examples:
 
-To attach text to a rectangle, you can type the following lines in the <BODY> region of your Web page:
+To attach text to a rectangle, you can type the following lines in the `<BODY>` region of your Web page:
 
 
 ```HTML
@@ -48,7 +48,7 @@ I'm attaching some text to this shape!!!
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/AttachText/textbox1.md)
 
-To attach a hyperlink to a rounded rectangle that is gradient-filled, you can type the following lines in the <BODY> region of your Web page:
+To attach a hyperlink to a rounded rectangle that is gradient-filled, you can type the following lines in the `<BODY>` region of your Web page:
 
 ![textbox2.gif (1147 bytes)](images/textbox2.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----textpath--element.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages-----textpath--element.md
@@ -29,11 +29,11 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-In this topic, we will illustrate how to use the <textpath> element to draw text with various styles.
+In this topic, we will illustrate how to use the `<textpath>` element to draw text with various styles.
 
-You can place the <textpath> sub-element inside <shape> or <shapetype> to draw text. You can then use the property attributes of the <textpath> sub-element to customize the text. You can also use the <formulas> sub-element to define the outline of the text.
+You can place the `<textpath>` sub-element inside `<shape>` or `<shapetype>` to draw text. You can then use the property attributes of the `<textpath>` sub-element to customize the text. You can also use the `<formulas>` sub-element to define the outline of the text.
 
-For example, to create the text shown in the following picture, you can type the VML representation below. Notice that we use the <shapetype> element to define a prototype for the outline of the text. We then instantiate two shapes from the same shapetype. You can simply change the **string** property attribute to display different text.
+For example, to create the text shown in the following picture, you can type the VML representation below. Notice that we use the `<shapetype>` element to define a prototype for the outline of the text. We then instantiate two shapes from the same shapetype. You can simply change the **string** property attribute to display different text.
 
 ![shape1\-1.gif (4898 bytes)](images/shape1-1t.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----appendix.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----appendix.md
@@ -27,7 +27,7 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-To let the browsers know how to hand off data to a VML-specific processor, you need to type some information such as namespaces and behavior styles. You can then use VML to type graphics in the <BODY> region.
+To let the browsers know how to hand off data to a VML-specific processor, you need to type some information such as namespaces and behavior styles. You can then use VML to type graphics in the `<BODY>` region.
 
 In this topic:
 
@@ -40,7 +40,7 @@ An XML mechanism indicates the namespace that an element comes from. If you swit
 
 Ask the vender of your VML processor what information is required for the XML namespace.
 
-If you use Microsoft Internet Explorer to render VML, always type the following line in the <HTML> tag:
+If you use Microsoft Internet Explorer to render VML, always type the following line in the `<HTML>` tag:
 
 
 ```HTML
@@ -57,7 +57,7 @@ This information tells Internet Explorer to switch to namespace "urn:schemas-mic
 
 VML is defined in Microsoft Internet Explorer as a default behavior.
 
-To render VML, always type the following lines in the <HEAD> region:
+To render VML, always type the following lines in the `<HEAD>` region:
 
 
 ```HTML
@@ -68,7 +68,7 @@ v\:* { behavior: url(#default#VML); display:inline-block}
 
 
 
-VML is implemented in Internet Explorer through VGX.DLL. If your initial installation of the browser did not include VML behavior, you may need to add it as an option. You do not need to add an <object> tag.
+VML is implemented in Internet Explorer through VGX.DLL. If your initial installation of the browser did not include VML behavior, you may need to add it as an option. You do not need to add an `<object>` tag.
 
  
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----drawing-basic-shapes.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----drawing-basic-shapes.md
@@ -39,7 +39,7 @@ To create a red oval on a Web page, as shown in the following picture, you can d
 
 ![oval1.gif (627 bytes)](images/oval1.gif)
 
-Alternatively, you can use VML to draw graphics. In the preceding example, you can type the following lines in the <BODY> region of your Web page to draw the red oval:
+Alternatively, you can use VML to draw graphics. In the preceding example, you can type the following lines in the `<BODY>` region of your Web page to draw the red oval:
 
 
 ```HTML
@@ -69,9 +69,9 @@ Browsers that support VML can render and display the graphics represented in VML
 
 ## XML Structure
 
-VML is formatted according to the rules of Extensible Markup Language (XML). Any standard XML parser can parse VML and hand off the resulting data to a VML-specific processor. To let the browsers know how to hand off data to a VML-specific processor, you need to type some information such as [namespaces](web-workshop---how-to-use-vml-on-web-pages----appendix.md) and [embedded custom objects](web-workshop---how-to-use-vml-on-web-pages----appendix.md). You can then use VML to type graphics in the <BODY> region just as you did in the preceding example.
+VML is formatted according to the rules of Extensible Markup Language (XML). Any standard XML parser can parse VML and hand off the resulting data to a VML-specific processor. To let the browsers know how to hand off data to a VML-specific processor, you need to type some information such as [namespaces](web-workshop---how-to-use-vml-on-web-pages----appendix.md) and [embedded custom objects](web-workshop---how-to-use-vml-on-web-pages----appendix.md). You can then use VML to type graphics in the `<BODY>` region just as you did in the preceding example.
 
-The `"v:"` prefix on each XML tag identifies the tag as VML. The `"v:"` prefix in the <BODY> region should be consistent with `<html xmlns:v="...">`.
+The `"v:"` prefix on each XML tag identifies the tag as VML. The `"v:"` prefix in the `<BODY>` region should be consistent with `<html xmlns:v="...">`.
 
 [![back to top](images/top.gif) Back to top](#top)
 
@@ -83,9 +83,9 @@ VML uses [Cascading Style Sheets, Level 2 (CSS2)](https://www.w3.org/TR/PR-CSS2/
 
 ## VML Elements
 
-In the preceding example, we used a VML predefined **<oval>** element to draw an oval. We then used the **fillcolor** property attribute of the **<oval>** element to fill the oval with red.
+In the preceding example, we used a VML predefined `<oval>` element to draw an oval. We then used the **fillcolor** property attribute of the `<oval>` element to fill the oval with red.
 
-Based upon the [Start-Tags, End-Tags, and Empty-Element Tags](https://www.w3.org/TR/REC-xml#sec-starttags) section of [XML 1.0 specification](https://www.w3.org/TR/REC-xml), empty-element tags may be used for any element that has no content. For example, as shown in the following VML representation, there is no content (sub-element) within the **<oval>** element. (Note that the **style** and **fillcolor** are the attributes of the **<oval>** element; they are not sub-elements.)
+Based upon the [Start-Tags, End-Tags, and Empty-Element Tags](https://www.w3.org/TR/REC-xml#sec-starttags) section of [XML 1.0 specification](https://www.w3.org/TR/REC-xml), empty-element tags may be used for any element that has no content. For example, as shown in the following VML representation, there is no content (sub-element) within the `<oval>` element. (Note that the **style** and **fillcolor** are the attributes of the `<oval>` element; they are not sub-elements.)
 
 
 ```HTML

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----grouping-shapes.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----grouping-shapes.md
@@ -36,7 +36,7 @@ As you've learned, you can easily draw individual shapes by using VML. In this s
 
 If you had many shapes that needed to be scaled, moved, or rotated together, you would find it tedious to set the attributes individually for each shape. Plus you would raise your margin for errors. It would be better if you could group the shapes, and then set the attributes for the entire group.
 
-In VML, you can use the <group> element to group many shapes together so that they can be transformed as one unit. For example, as shown in the following VML representation, you can easily group two shapes together.
+In VML, you can use the `<group>` element to group many shapes together so that they can be transformed as one unit. For example, as shown in the following VML representation, you can easily group two shapes together.
 
 
 ```HTML
@@ -79,7 +79,7 @@ For more information about this element, see the [VML specification](https://www
 
 ## Summary
 
-You can use the <group> element to group many shapes together so that they can be transformed as one unit.
+You can use the `<group>` element to group many shapes together so that they can be transformed as one unit.
 
  
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----local-coordinate-space.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----local-coordinate-space.md
@@ -79,9 +79,9 @@ fillcolor="red" strokecolor="blue" strokeweight="2pt">
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/LocalCord/cord1.md)
 
 -   `coordsize="21600,21600"` defines the size of the Local Coordinate Space for the shape to be 21600 units by 21600 units. Therefore, one unit in the Local Coordinate Space is equivalent to 1/216 point.
--   `path="m10800,0l0,10800,10800,21600,21600,10800xe"` defines the outline of the shape as a diamond shape. As we've learned, all position-related information (such as width, height, left, top, path, etc.) is expressed in terms of the unit in Local Coordinate Space. Therefore, 10800 in the <path> means 10800 units, which is equivalent to 50 points.
+-   `path="m10800,0l0,10800,10800,21600,21600,10800xe"` defines the outline of the shape as a diamond shape. As we've learned, all position-related information (such as width, height, left, top, path, etc.) is expressed in terms of the unit in Local Coordinate Space. Therefore, 10800 in the `<path>` means 10800 units, which is equivalent to 50 points.
 
-When you want to resize this diamond shape, simply specify a different width or height -- that's it; you don't have to change any value in the <path>. For this complicated shape, if you didn't use the Local Coordinate Space feature, you would have to change every value in the <path> whenever you wanted to resize it.
+When you want to resize this diamond shape, simply specify a different width or height -- that's it; you don't have to change any value in the `<path>`. For this complicated shape, if you didn't use the Local Coordinate Space feature, you would have to change every value in the `<path>` whenever you wanted to resize it.
 
 For example, you can scale the diamond shape by simply specifying a different width or height, as shown in the following VML representation:
 
@@ -99,7 +99,7 @@ fillcolor="red" strokecolor="blue" strokeweight="2pt">
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/LocalCord/cord2.md)
 
-You can also use Local Coordinate Space in the <group> element so that the contents of all shapes within the group are scaled together according to the same coordinate. Then, whenever you want to scale or move a group of shapes, simply change the width and height, or **coordsize** and **coordorigin** settings, of the group.
+You can also use Local Coordinate Space in the `<group>` element so that the contents of all shapes within the group are scaled together according to the same coordinate. Then, whenever you want to scale or move a group of shapes, simply change the width and height, or **coordsize** and **coordorigin** settings, of the group.
 
 For example, in the following VML representation, `<v:group style='... width:200pt;height:200pt;'>` defines the size of the containing box for the group to be 200 points by 200 points.
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----positioning-shapes.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----positioning-shapes.md
@@ -116,7 +116,7 @@ End.
 
 Setting the position style attribute to "absolute" allows you to place the containing box an exact distance from the top left corner (the base point) of its parent element (the positioned element that contains the shape). Be aware that the containing box that is positioned as absolute doesn't take up space in the text flow.
 
-For example, in the following VML representation, the red oval is contained within the <body> element (the entire Web page); therefore, the base point is at the top left corner of the Web page. The containing box for the oval is positioned exactly 20 points from the left and 10 points from the top, relative to the top left corner of the Web page, as shown in the following picture:
+For example, in the following VML representation, the red oval is contained within the `<body>` element (the entire Web page); therefore, the base point is at the top left corner of the Web page. The containing box for the oval is positioned exactly 20 points from the left and 10 points from the top, relative to the top left corner of the Web page, as shown in the following picture:
 
 ![shape2.gif (2006 bytes)](images/shape2.gif)
 

--- a/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----using-predefined-shapes.md
+++ b/desktop-src/VML/web-workshop---how-to-use-vml-on-web-pages----using-predefined-shapes.md
@@ -53,7 +53,7 @@ This topic describes VML, a feature that is deprecated as of Windows Internet Ex
 
  
 
-As you've learned, you can use the <oval> element of VML to create a simple oval. VML provides several other predefined elements. In this topic, we will illustrate how to draw graphics by using these elements.
+As you've learned, you can use the `<oval>` element of VML to create a simple oval. VML provides several other predefined elements. In this topic, we will illustrate how to draw graphics by using these elements.
 
 In this topic:
 
@@ -67,7 +67,7 @@ In this topic:
 
 ## rect
 
-You can use the <rect> element to draw a rectangle. You can then customize the rectangle by specifying different property attributes.
+You can use the `<rect>` element to draw a rectangle. You can then customize the rectangle by specifying different property attributes.
 
 For example, you can draw a rectangle that is filled with blue by specifying **fillcolor**="blue", and give it a 3.5-point red outline by specifying **strokecolor**="red" **strokeweight**="3.5pt", as shown in the following VML representation:
 
@@ -83,13 +83,13 @@ strokecolor="red" strokeweight="3.5pt"/>
 
 [Show Me](https://samples.msdn.microsoft.com/workshop/samples/vml/examples/PredefinedShape/RECT1.md)
 
-For more information about this element, see the [VML specification](https://WWW.w3.org/TR/NOTE-VML#-toc416858405) . (Note: The VML specification doesn't have a bookmark for the <rect> element.)
+For more information about this element, see the [VML specification](https://WWW.w3.org/TR/NOTE-VML#-toc416858405) . (Note: The VML specification doesn't have a bookmark for the `<rect>` element.)
 
 [![back to top](images/top.gif) Back to top](#top)
 
 ## roundrect
 
-You can use the <roundrect> element to draw a rectangle with rounded corners. You can then customize the rounded rectangle by specifying different property attributes.
+You can use the `<roundrect>` element to draw a rectangle with rounded corners. You can then customize the rounded rectangle by specifying different property attributes.
 
 For example, you can draw a rectangle that has rounded corners 30% of half the smaller dimension of the rectangle by specifying **arcsize**="0.3", fill it with yellow by specifying **fillcolor**="yellow", and give it a 2-point red outline by specifying **strokecolor**="red" **strokeweight**="2pt", as shown in the following VML representation:
 
@@ -112,7 +112,7 @@ For more information about this element, see the [VML specification](https://WWW
 
 ## line
 
-You can use the <line> element to create a straight line. You can then customize the line by specifying different property attributes.
+You can use the `<line>` element to create a straight line. You can then customize the line by specifying different property attributes.
 
 For example, you can draw a horizontal line by specifying **from**="20pt,20pt" **to**="100pt,20pt", and make it 2-point and red by specifying **strokecolor**="red" **strokeweight**="2pt", as shown in the following VML representation:
 
@@ -148,7 +148,7 @@ For more information about this element, see the [VML specification](https://WWW
 
 ## polyline
 
-You can use the <polyline> element to define shapes that are created from connected line segments. You can then customize the shape by specifying different property attributes.
+You can use the `<polyline>` element to define shapes that are created from connected line segments. You can then customize the shape by specifying different property attributes.
 
 For example, to draw the shape shown in the following picture, you can type the following VML representation:
 
@@ -170,7 +170,7 @@ For more information about this element, see the [VML specification](https://WWW
 
 ## curve
 
-You can use the <curve> element to draw a cubic bézier curve. You can then customize the curve by specifying different property attributes.
+You can use the `<curve>` element to draw a cubic bézier curve. You can then customize the curve by specifying different property attributes.
 
 For example, to draw a curve as shown in the following picture, you can type the following VML representation:
 
@@ -193,7 +193,7 @@ For more information about this element, see the [VML specification](https://WWW
 
 ## arc
 
-You can use the <arc> element to draw an arc that is defined as a segment of an oval. The arc is defined by the intersection of the oval with the start and end radius vectors given by the angles. The angles are calculated by using the properties of a circle (width equal to height), then scaled anisotropically to the desired width and height.
+You can use the `<arc>` element to draw an arc that is defined as a segment of an oval. The arc is defined by the intersection of the oval with the start and end radius vectors given by the angles. The angles are calculated by using the properties of a circle (width equal to height), then scaled anisotropically to the desired width and height.
 
 For example, you can draw an arc that starts at 0 degrees and ends at 90 degrees by specifying **startangle**="0" **endangle**="90", as shown in the following VML representation:
 
@@ -244,7 +244,7 @@ For more information about this element, see the [VML specification](https://WWW
 
 ## Summary
 
-You can use VML predefined elements such as <oval>, <line>, <polyline>, <curve>, <rect>, <roundrect>, and <arc> to easily draw graphics on a Web page, and then customize those graphics by simply changing their property attributes.
+You can use VML predefined elements such as `<oval>`, `<line>`, `<polyline>`, `<curve>`, `<rect>`, `<roundrect>`, and `<arc>` to easily draw graphics on a Web page, and then customize those graphics by simply changing their property attributes.
 
  
 


### PR DESCRIPTION
Throughout all the "How to use VML on Web Pages" docs, VML and HTML tag names used as inline code are being rendered as HTML in a real browser. This PR should fix that by marking every tag name as an inline code.