### PR TITLE
Remove internal-only references in Windows version compatibility discussions; otherwise improve same

### DIFF
--- a/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
+++ b/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
@@ -8,10 +8,10 @@ ms.date: 05/31/2018
 
 # Targeting your application for Windows
 
-In Windows 8.1 and Windows 10, the [**GetVersion**](https://msdn.microsoft.com/en-us/library/ms724439(v=VS.85).aspx) and [**GetVersionEx**](https://msdn.microsoft.com/en-us/library/ms724451(v=VS.85).aspx) functions have been deprecated. In Windows 10, the [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function has also been deprecated. While you can still call the deprecated functions, if your application does not specifically target Windows 8.1 or Windows 10, the functions will return the Windows 8 version (6.2).
+In Windows 8.1 and Windows 10, the [**GetVersion**](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversion) and [**GetVersionEx**](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa) functions have been deprecated. In Windows 10, the [**VerifyVersionInfo**](/windows/win32/api/winbase/nf-winbase-verifyversioninfoa) function has also been deprecated. While you can still call the deprecated functions, if your application does not specifically target Windows 8.1 or Windows 10, the functions will return the Windows 8 version (6.2).
 
 > [!Note]  
-> [**GetVersion**](https://msdn.microsoft.com/en-us/library/ms724439(v=VS.85).aspx), [**GetVersionEx**](https://msdn.microsoft.com/en-us/library/ms724451(v=VS.85).aspx), [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa), and the [Version Helper functions](version-helper-apis.md) are for desktop apps only. Universal Windows apps can use the [**AnalyticsInfo.VersionInfo**](https://docs.microsoft.com/uwp/api/windows.system.profile.analyticsinfo.versioninfo) property for telemetry and diagnostic logs.
+> [**GetVersion**](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversion), [**GetVersionEx**](/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa), [**VerifyVersionInfo**](/windows/win32/api/winbase/nf-winbase-verifyversioninfoa), and the [Version Helper functions](version-helper-apis.md) are for desktop apps only. Universal Windows apps can use the [**AnalyticsInfo.VersionInfo**](https://docs.microsoft.com/uwp/api/windows.system.profile.analyticsinfo.versioninfo) property for telemetry and diagnostic logs.
 
 In order for your app to target Windows 8.1 or Windows 10, you'll need to include an [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Then, in the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
 
@@ -21,16 +21,16 @@ The following example shows an app manifest file for an app that supports all ve
 <!-- example.exe.manifest -->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity 
-        type="win32" 
+    <assemblyIdentity
+        type="win32"
         name="Contoso.ExampleApplication.ExampleBinary"
         version="1.2.3.4"
         processorArchitecture="x86"
     />
     <description>Contoso Example Application</description>
-    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
-        <application> 
-            <!-- Windows 10 --> 
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
@@ -40,7 +40,7 @@ The following example shows an app manifest file for an app that supports all ve
             <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
             <!-- Windows Vista -->
             <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
-        </application> 
+        </application>
     </compatibility>
 </assembly>
 ```

--- a/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
+++ b/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
@@ -8,70 +8,44 @@ ms.date: 05/31/2018
 
 # Targeting your application for Windows
 
-In Windows 8.1 and Windows 10, the [**GetVersion**](https://msdn.microsoft.com/en-us/library/ms724439(v=VS.85).aspx) and [**GetVersionEx**](https://msdn.microsoft.com/en-us/library/ms724451(v=VS.85).aspx) functions have been deprecated. In Windows 10, the [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function has also been deprecated. While you can still call the deprecated functions, if your application does not specifically target Windows 8.1 or Windows 10, you will get Windows 8 version (6.2.0.0).
+In Windows 8.1 and Windows 10, the [**GetVersion**](https://msdn.microsoft.com/en-us/library/ms724439(v=VS.85).aspx) and [**GetVersionEx**](https://msdn.microsoft.com/en-us/library/ms724451(v=VS.85).aspx) functions have been deprecated. In Windows 10, the [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function has also been deprecated. While you can still call the deprecated functions, if your application does not specifically target Windows 8.1 or Windows 10, the functions will return the Windows 8 version (6.2).
 
 > [!Note]  
 > [**GetVersion**](https://msdn.microsoft.com/en-us/library/ms724439(v=VS.85).aspx), [**GetVersionEx**](https://msdn.microsoft.com/en-us/library/ms724451(v=VS.85).aspx), [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa), and the [Version Helper functions](version-helper-apis.md) are for desktop apps only. Universal Windows apps can use the [**AnalyticsInfo.VersionInfo**](https://docs.microsoft.com/uwp/api/windows.system.profile.analyticsinfo.versioninfo) property for telemetry and diagnostic logs.
 
- 
+In order for your app to target Windows 8.1 or Windows 10, you'll need to include an [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Then, in the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
 
-In order to target Windows 8.1 or Windows 10, you need to include the app manifest in the source file. The following example shows an app manifest file.
-
+The following example shows an app manifest file for an app that supports all versions of Windows from Windows Vista to Windows 10:
 
 ```XML
-<exe>.manifest
+<!-- example.exe.manifest -->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
     <assemblyIdentity 
         type="win32" 
-        name=SXS_ASSEMBLY_NAME
-        version=SXS_ASSEMBLY_VERSION
-        processorArchitecture=SXS_PROCESSOR_ARCHITECTURE
+        name="Contoso.ExampleApplication.ExampleBinary"
+        version="1.2.3.4"
+        processorArchitecture="x86"
     />
-    <description> my exe </description>
-    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-        <security>
-            <requestedPrivileges>
-                <requestedExecutionLevel
-                    level="asInvoker"
-                    uiAccess="false"
-                />   
-            </requestedPrivileges>
-        </security>
-    </trustInfo>
+    <description>Contoso Example Application</description>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
         <application> 
             <!-- Windows 10 --> 
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-            <!-- Windows Vista -->
-            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
-            <!-- Windows 7 -->
-            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
             <!-- Windows 8 -->
             <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
         </application> 
     </compatibility>
 </assembly>
 ```
 
-
-
-Next, add the following to your sources:
-
-``` syntax
-SXS_MANIFEST_RESOURCE_ID=1
-SXS_MANIFEST=foo.manifest
-SXS_ASSEMBLY_NAME=Microsoft.Windows.Foo
-SXS_ASSEMBLY_VERSION=1.0    
-SXS_ASSEMBLY_LANGUAGE_INDEPENDENT=1
-SXS_MANIFEST_IN_RESOURCES=1
-```
-
-Manifesting the **.exe** for Windows 8.1 or Windows 10 will not have any impact when run on previous operating systems. You can also add this to your **.rc** file if you already have it defined.
-
-Adding the **trustInfo** isn’t essential, but it is highly recommended. This will allow your **.exe** to always get the correct version, whether the operating system is Windows 10, Windows 8.1, or Windows 8.
+Declaring support for Windows 8.1 or Windows 10 in your app manifest will not have any effect when running your app on previous operating systems.
 
 ## Related topics
 

--- a/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
+++ b/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
@@ -42,10 +42,28 @@ The following example shows an app manifest file for an app that supports all ve
             <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
         </application>
     </compatibility>
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <!--
+                  UAC settings:
+                  - app should run at same integrity level as calling process
+                  - app does not need to manipulate windows belonging to
+                    higher-integrity-level processes
+                  -->
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />   
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
 </assembly>
 ```
 
 Declaring support for Windows 8.1 or Windows 10 in your app manifest will not have any effect when running your app on previous operating systems.
+
+The above app manifest also includes a [**&lt;trustInfo&gt;** section](/previous-versions/bb756929(v=msdn.10)), which specifies how the system should treat it with respect to [User Account Control (UAC)](/windows/security/identity-protection/user-account-control/how-user-account-control-works). Adding **trustInfo** isn't essential, but it is highly recommended, even when your app doesn't need any particular UAC-related behavior. In particular, if you don't add **trustInfo** at all, then 32-bit x86 versions of your app will be subject to [UAC file virtualization](/windows/security/identity-protection/user-account-control/how-user-account-control-works#virtualization), which allows writes to administrator-privileged folders like the Windows system folders to succeed when they would otherwise fail, but redirects them to a user-specific "VirtualStore" folder.
 
 ## Related topics
 

--- a/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
+++ b/desktop-src/SysInfo/targeting-your-application-at-windows-8-1.md
@@ -62,10 +62,3 @@ Declaring support for Windows 8.1 or Windows 10 in your app manifest will not 
 
 [OSVERSIONINFOEX](/windows/desktop/api/winnt/ns-winnt-osversioninfoexa)
 </dt> </dl>
-
- 
-
- 
-
-
-

--- a/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
+++ b/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
@@ -14,6 +14,7 @@ ms.assetid: 3040262A-85EB-4F26-BE34-D2BBD5886E9E
 ## Platforms
 
 **Clients -** Windows 8.1
+
 **Servers -** Windows Server 2012 R2
 
 ## Description
@@ -22,96 +23,84 @@ We have made some significant changes in how the GetVersion(Ex) APIs work in Win
 
 In previous versions of Windows, calling the GetVersion(Ex) APIs would return the actual version of the operating system (OS), unless the process had been mitigated by an app compat shim to give it a different version. This was done on a provisional basis and was relatively incomplete in terms of the number of processes that Microsoft could reasonably shim in a release. Many applications fell through the cracks because they didn’t get shimmed due to poorly designed version checks.
 
-The number one reason to do a version check is to show some message of OS supportability for the application. However due to the poor checks, the message would often show that the app needed to be run on XP or later, which of course the newest OS is. More often than not, the newest OS would run the application without any issues if not for these checks.
+The number one reason to do a version check is to warn the user that the application needs to run on a newer version of the OS. However due to poor checks, apps would often incorrectly warn that they needed to be run on Windows XP or later, which of course the newest OS is. More often than not, the newest OS would run the application without any issues if not for these checks.
 
 ## Manifestation
 
-In Windows 8.1, the GetVersion(Ex) APIs have been deprecated. That means that while you can still call the APIs, if your app does not specifically target Windows 8.1, you will get Windows 8 versioning (6.2.0.0).
+In Windows 8.1, the GetVersion(Ex) APIs have been deprecated. That means that while you can still call these API functions, if your app does not specifically target Windows 8.1, the functions will return the Windows 8 version (6.2).
 
 ## Solution
 
-In order to target Windows 8.1, you need to either include the app manifest or include \_NT\_TARGET\_VERSION=$ (\_NT\_TARGET\_VERSION\_LATEST) in the source file.
+### Adding an app manifest
 
-This is what the app manifest would look like:
+In order for your app to target Windows 8.1, you'll need to include an [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Then, in the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
+
+The following example shows an app manifest file for an app that supports all versions of Windows from Windows Vista to Windows 8.1:
 
 ```XML
-<exe>.manifest
+<!-- example.exe.manifest -->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity 
-        type="win32" 
-        name=SXS_ASSEMBLY_NAME
-        version=SXS_ASSEMBLY_VERSION
-        processorArchitecture=SXS_PROCESSOR_ARCHITECTURE
+    <assemblyIdentity
+        type="win32"
+        name="Contoso.ExampleApplication.ExampleBinary"
+        version="1.2.3.4"
+        processorArchitecture="x86"
     />
-    <description> my app exe </description>
-    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-        <security>
-            <requestedPrivileges>
-                <requestedExecutionLevel
-                    level="asInvoker"
-                    uiAccess="false"
-                />   
-            </requestedPrivileges>
-        </security>
-    </trustInfo>
-    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
-        <application> 
-         *  <!-- Windows 8.1 -->
-         *  <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-            <!-- Windows Vista -->
-            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
-            <!-- Windows 7 -->
-            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    <description>Contoso Example Application</description>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/> <!-- * ADD THIS LINE * -->
             <!-- Windows 8 -->
             <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-        </application> 
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+        </application>
     </compatibility>
 </assembly>
 ```
 
-And then add this to your sources:
+The line above marked `* ADD THIS LINE *` shows how to accurately target your application for Windows 8.1.
 
-SXS\_MANIFEST\_RESOURCE\_ID=1
-SXS\_MANIFEST=foo.manifest
-SXS\_ASSEMBLY\_NAME=Microsoft.Windows.Foo
-SXS\_ASSEMBLY\_VERSION=1.0
-SXS\_ASSEMBLY\_LANGUAGE\_INDEPENDENT=1
-SXS\_MANIFEST\_IN\_RESOURCES=1
-For Windows 8.1, the two lines above marked with an asterisk (\*) show how to accurately target your application for the Windows 8.1 version of the operating system. Manifesting the .exe for Windows 8.1 will not have any impact when run on previous operating systems. You can also add this to your .rc file if you already have it defined.
+Declaring support for Windows 8.1 in your app manifest will not have any effect when running your app on previous operating systems.
 
-Adding the trustInfo isn’t essential, but it is highly recommended. This will allow your .exe to always get the correct version, no matter whether the operating system is Windows 8.1 or Windows 8.
+### Using VersionHelpers instead of GetVersion(Ex)
 
-The replacement APIs are known as VersionHelpers. They are extremely easy to use; all you have to do is \#include &lt;VersionHelpers.h&gt;.
+Windows 8.1 introduces new replacement API functions for GetVersion(Ex), known as VersionHelpers. They are extremely easy to use; all you have to do is `#include <VersionHelpers.h>`. The inline functions available in the VersionHelpers.h header file allow your code to ask whether the operating system is a given version of Windows or later.
 
 **Example**
-
-The inline functions available in the VersionHelpers.h header file enable you to verify the version of the operating system by returning a Boolean value when testing for the version of Windows. For example, if your application requires Windows 8 or later, use the following test:
+For example, if your application requires Windows 8 or later, use the following test:
 
 ```cpp
 #include <VersionHelpers.h>
-…
+// ...
     if (!IsWindows8OrGreater())
     {
        MessageBox(NULL, "You need at least Windows 8", "Version Not Supported", MB_OK);
     }
 ```
 
-The available APIs are:
+The available VersionHelper API functions are:
 
-\#define VERSIONHELPERAPI FORCEINLINE BOOL
-VERSIONHELPERAPI IsWindowsXPOrGreater()
-VERSIONHELPERAPI IsWindowsXPSP1OrGreater()
-VERSIONHELPERAPI IsWindowsXPSP2OrGreater()
-VERSIONHELPERAPI IsWindowsXPSP3OrGreater()
-VERSIONHELPERAPI IsWindowsVistaOrGreater()
-VERSIONHELPERAPI IsWindowsVistaSP1OrGreater()
-VERSIONHELPERAPI IsWindowsVistaSP2OrGreater()
-VERSIONHELPERAPI IsWindows7OrGreater()
-VERSIONHELPERAPI IsWindows7SP1OrGreater()
-VERSIONHELPERAPI IsWindows8OrGreater()
-VERSIONHELPERAPI IsWindows8\_1OrGreater()
-VERSIONHELPERAPI IsWindowsServer()
+```c
+#define VERSIONHELPERAPI FORCEINLINE BOOL
+VERSIONHELPERAPI IsWindowsXPOrGreater();
+VERSIONHELPERAPI IsWindowsXPSP1OrGreater();
+VERSIONHELPERAPI IsWindowsXPSP2OrGreater();
+VERSIONHELPERAPI IsWindowsXPSP3OrGreater();
+VERSIONHELPERAPI IsWindowsVistaOrGreater();
+VERSIONHELPERAPI IsWindowsVistaSP1OrGreater();
+VERSIONHELPERAPI IsWindowsVistaSP2OrGreater();
+VERSIONHELPERAPI IsWindows7OrGreater();
+VERSIONHELPERAPI IsWindows7SP1OrGreater();
+VERSIONHELPERAPI IsWindows8OrGreater();
+VERSIONHELPERAPI IsWindows8Point1OrGreater();
+VERSIONHELPERAPI IsWindowsServer();
+```
+
 They will return TRUE or FALSE depending on the question you are asking, and you only need to define the minimum level operating system that you support.
 
 ## Resources

--- a/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
+++ b/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
@@ -2,6 +2,7 @@
 title: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
 description: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
 ms.assetid: 3040262A-85EB-4F26-BE34-D2BBD5886E9E
+ms.topic: article
 ms.date: 05/31/2018
 ---
 

--- a/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
+++ b/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
@@ -1,12 +1,8 @@
 ---
-title: Operating system version changes - Compatibility Cookbook
-description: GetVersion APIs have been changed significantly in Windows 8 and Windows Server 2012 R2
-keywords: compatibility, windows 8.1, version, GetVersion
-author: QuinnRadich
-ms.author: quradic
-ms.date: 07/11/2018
-ms.topic: article
+title: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
+description: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
 ms.assetid: 3040262A-85EB-4F26-BE34-D2BBD5886E9E
+ms.date: 05/31/2018
 ---
 
 # Operating system version changes in Windows 8.1 and Windows Server 2012 R2

--- a/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
+++ b/desktop-src/w8cookbook/operating-system-version-changes-in-windows-8-1.md
@@ -1,18 +1,20 @@
 ---
-title: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
-description: Operating system version changes in Windows 8.1 and Windows Server 2012 R2
-ms.assetid: 3040262A-85EB-4F26-BE34-D2BBD5886E9E
+title: Operating system version changes - Compatibility Cookbook
+description: GetVersion APIs have been changed significantly in Windows 8 and Windows Server 2012 R2
+keywords: compatibility, windows 8.1, version, GetVersion
+author: QuinnRadich
+ms.author: quradic
+ms.date: 07/11/2018
 ms.topic: article
-ms.date: 05/31/2018
+ms.assetid: 3040262A-85EB-4F26-BE34-D2BBD5886E9E
 ---
 
 # Operating system version changes in Windows 8.1 and Windows Server 2012 R2
 
 ## Platforms
 
-<dl> **Clients -** Windows 8.1  
-**Servers -** Windows Server 2012 R2  
-</dl>
+**Clients -** Windows 8.1
+**Servers -** Windows Server 2012 R2
 
 ## Description
 
@@ -31,7 +33,6 @@ In Windows 8.1, the GetVersion(Ex) APIs have been deprecated. That means that w
 In order to target Windows 8.1, you need to either include the app manifest or include \_NT\_TARGET\_VERSION=$ (\_NT\_TARGET\_VERSION\_LATEST) in the source file.
 
 This is what the app manifest would look like:
-
 
 ```XML
 <exe>.manifest
@@ -69,31 +70,25 @@ This is what the app manifest would look like:
 </assembly>
 ```
 
-
-
 And then add this to your sources:
 
-<dl> SXS\_MANIFEST\_RESOURCE\_ID=1  
-SXS\_MANIFEST=foo.manifest  
-SXS\_ASSEMBLY\_NAME=Microsoft.Windows.Foo  
-SXS\_ASSEMBLY\_VERSION=1.0  
-SXS\_ASSEMBLY\_LANGUAGE\_INDEPENDENT=1  
-SXS\_MANIFEST\_IN\_RESOURCES=1  
-</dl>
-
+SXS\_MANIFEST\_RESOURCE\_ID=1
+SXS\_MANIFEST=foo.manifest
+SXS\_ASSEMBLY\_NAME=Microsoft.Windows.Foo
+SXS\_ASSEMBLY\_VERSION=1.0
+SXS\_ASSEMBLY\_LANGUAGE\_INDEPENDENT=1
+SXS\_MANIFEST\_IN\_RESOURCES=1
 For Windows 8.1, the two lines above marked with an asterisk (\*) show how to accurately target your application for the Windows 8.1 version of the operating system. Manifesting the .exe for Windows 8.1 will not have any impact when run on previous operating systems. You can also add this to your .rc file if you already have it defined.
 
 Adding the trustInfo isn’t essential, but it is highly recommended. This will allow your .exe to always get the correct version, no matter whether the operating system is Windows 8.1 or Windows 8.
 
-The replacement APIs are known as VersionHelpers. They are extremely easy to use; all you have to do is \#include <VersionHelpers.h>.
+The replacement APIs are known as VersionHelpers. They are extremely easy to use; all you have to do is \#include &lt;VersionHelpers.h&gt;.
 
 **Example**
 
 The inline functions available in the VersionHelpers.h header file enable you to verify the version of the operating system by returning a Boolean value when testing for the version of Windows. For example, if your application requires Windows 8 or later, use the following test:
 
-
-```
-C++
+```cpp
 #include <VersionHelpers.h>
 …
     if (!IsWindows8OrGreater())
@@ -102,25 +97,21 @@ C++
     }
 ```
 
-
-
 The available APIs are:
 
-<dl> \#define VERSIONHELPERAPI FORCEINLINE BOOL  
-VERSIONHELPERAPI IsWindowsXPOrGreater()  
-VERSIONHELPERAPI IsWindowsXPSP1OrGreater()  
-VERSIONHELPERAPI IsWindowsXPSP2OrGreater()  
-VERSIONHELPERAPI IsWindowsXPSP3OrGreater()  
-VERSIONHELPERAPI IsWindowsVistaOrGreater()  
-VERSIONHELPERAPI IsWindowsVistaSP1OrGreater()  
-VERSIONHELPERAPI IsWindowsVistaSP2OrGreater()  
-VERSIONHELPERAPI IsWindows7OrGreater()  
-VERSIONHELPERAPI IsWindows7SP1OrGreater()  
-VERSIONHELPERAPI IsWindows8OrGreater()  
-VERSIONHELPERAPI IsWindows8\_1OrGreater()  
-VERSIONHELPERAPI IsWindowsServer()  
-</dl>
-
+\#define VERSIONHELPERAPI FORCEINLINE BOOL
+VERSIONHELPERAPI IsWindowsXPOrGreater()
+VERSIONHELPERAPI IsWindowsXPSP1OrGreater()
+VERSIONHELPERAPI IsWindowsXPSP2OrGreater()
+VERSIONHELPERAPI IsWindowsXPSP3OrGreater()
+VERSIONHELPERAPI IsWindowsVistaOrGreater()
+VERSIONHELPERAPI IsWindowsVistaSP1OrGreater()
+VERSIONHELPERAPI IsWindowsVistaSP2OrGreater()
+VERSIONHELPERAPI IsWindows7OrGreater()
+VERSIONHELPERAPI IsWindows7SP1OrGreater()
+VERSIONHELPERAPI IsWindows8OrGreater()
+VERSIONHELPERAPI IsWindows8\_1OrGreater()
+VERSIONHELPERAPI IsWindowsServer()
 They will return TRUE or FALSE depending on the question you are asking, and you only need to define the minimum level operating system that you support.
 
 ## Resources
@@ -128,11 +119,3 @@ They will return TRUE or FALSE depending on the question you are asking, and you
 -   [Application Compatibility Toolkit Download](https://go.microsoft.com/fwlink/p/?LinkID=205020)
 -   [Known Compatibility Fixes, Compatibility Modes, and AppHelp Messages](https://go.microsoft.com/fwlink/p/?LinkID=205039)
 -   [VersionHelpers APIs](https://go.microsoft.com/fwlink/p/?LinkId=325426)
-
- 
-
- 
-
-
-
-

--- a/desktop-src/w8cookbook/windows-version-check.md
+++ b/desktop-src/w8cookbook/windows-version-check.md
@@ -23,12 +23,12 @@ Some apps perform a version check and simply pass a warning to users. However, t
 -   If the app is dependent on specific API functionality, ensure you target the correct API version.
 -   NTDDI (NT device driver interface) version number will increment only if target functionality in the API changes. Ensure you detect the change via APISet or other exposed API as created by the feature team, and do not use the version as a proxy for some feature or fix. If there are breaking changes and a proper check is not exposed, then that is a bug.
 -   Ensure the app does NOT check for version in odd ways, such as via the registry, file versions, offsets, kernel mode, drivers or other means. If the app absolutely needs to check the version, use the GetVersion APIs, which should return the major, minor and build number.
--   If you are using the GetVersion API or other Version Helper functions such as [VerifyVersionInfo](https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-verifyversioninfoa), remember that the behavior of this API has changed since Windows 8.1. Please refer to [the API documentation](https://docs.microsoft.com/windows/desktop/SysInfo/version-helper-apis) for more details.
+-   If you are using the GetVersion API or other Version Helper functions such as [VerifyVersionInfo](https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-verifyversioninfoa), remember that the behavior of this API has changed since Windows 8.1. Please refer to [the API documentation](../SysInfo/version-helper-apis.md) for more details.
 -   If you own apps such as antimalware or firewall, you should work through your usual feedback channels and via the Windows Insider program.
 
 ## Declaring Windows 10 Compatibility With An App Manifest
 
-In order for your app to target Windows 10, you'll need to include an [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Then, in the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
+If your app is compatible with Windows 10, it can declare this fact in the [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Specifically, within the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
 
 The following example shows an app manifest file for an app that supports all versions of Windows from Windows Vista to Windows 10:
 

--- a/desktop-src/w8cookbook/windows-version-check.md
+++ b/desktop-src/w8cookbook/windows-version-check.md
@@ -26,72 +26,46 @@ Some apps perform a version check and simply pass a warning to users. However, t
 -   If you are using the GetVersion API or other Version Helper functions such as [VerifyVersionInfo](https://docs.microsoft.com/windows/desktop/api/winbase/nf-winbase-verifyversioninfoa), remember that the behavior of this API has changed since Windows 8.1. Please refer to [the API documentation](https://docs.microsoft.com/windows/desktop/SysInfo/version-helper-apis) for more details.
 -   If you own apps such as antimalware or firewall, you should work through your usual feedback channels and via the Windows Insider program.
 
-## App Manifest
+## Declaring Windows 10 Compatibility With An App Manifest
 
-Below is an example app manifest:
+In order for your app to target Windows 10, you'll need to include an [app (executable) manifest](/windows/compatibility/application-executable-manifest) for the app's executable. Then, in the [**&lt;compatibility&gt;** section](../SbsCs/application-manifests.md#compatibility) of the manifest, you'll need to add a **&lt;supportedOS&gt;** element for each Windows version you want to declare that your app supports.
 
+The following example shows an app manifest file for an app that supports all versions of Windows from Windows Vista to Windows 10:
 
-```
-<exe>.manifest
+```XML
+<!-- example.exe.manifest -->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity 
-        type="win32" 
-        name=SXS_ASSEMBLY_NAME
-        version=SXS_ASSEMBLY_VERSION
-        processorArchitecture=SXS_PROCESSOR_ARCHITECTURE
+    <assemblyIdentity
+        type="win32"
+        name="Contoso.ExampleApplication.ExampleBinary"
+        version="1.2.3.4"
+        processorArchitecture="x86"
     />
-    <description> my app exe </description>
-    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-        <security>
-            <requestedPrivileges>
-                <requestedExecutionLevel
-                    level="asInvoker"
-                    uiAccess="false"
-                />   
-            </requestedPrivileges>
-        </security>
-    </trustInfo>
-    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
-        <application> 
-
-      * <!-- Windows 10 --> 
-      * <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    <description>Contoso Example Application</description>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/> <!-- * ADD THIS LINE * -->
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
-            <!-- Windows Vista -->
-            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
-            <!-- Windows 7 -->
-            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
             <!-- Windows 8 -->
             <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-        </application> 
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+        </application>
     </compatibility>
 </assembly>
 ```
 
+The line above marked `* ADD THIS LINE *` shows how to accurately target your application for Windows 10.
 
-
-Add these variables to your sources:<dl> SXS\_MANIFEST\_RESOURCE\_ID=1  
-SXS\_MANIFEST=foo.manifest  
-SXS\_ASSEMBLY\_NAME=Microsoft.Windows.Foo  
-SXS\_ASSEMBLY\_VERSION=1.0  
-SXS\_ASSEMBLY\_LANGUAGE\_INDEPENDENT=1  
-SXS\_MANIFEST\_IN\_RESOURCES=1  
-</dl>For Windows 10, the two lines above marked with an asterisk (\*) show how to accurately target your application for the Windows 10 version of the OS. Manifesting the .exe for Windows 10 will not have any impact when run on previous versions of the Windows OS. You can also add this to your .rc file if you already have it defined.
-
-Adding the trustInfo isn’t essential, but it is highly recommended. This will allow your .exe to always get the correct version, no matter whether the OS is Windows 10 or Windows 8.1.
+Declaring support for Windows 10 in your app manifest will not have any effect when running your app on previous operating systems.
 
 ## Resources
 
 -   [Application Compatibility Toolkit Download: Download the Windows ADK for Windows 10](https://go.microsoft.com/fwlink/p/?LinkId=526740)
 -   [Known Compatibility Fixes, Compatibility Modes, and AppHelp Messages](https://go.microsoft.com/fwlink/?LinkID=205039)
 -   [Version Helpers API](https://go.microsoft.com/fwlink/p/?LinkId=325426)
-
- 
-
- 
-
-
-
-


### PR DESCRIPTION
These documentation pages discuss how to mark your app as compatible with Windows 8.1 and Windows 10, as well as the "version lie by default" compatibility change in Windows 8.1 which requires many apps to explicitly mark themselves as compatible with newer versions of Windows if they don't want to be told that they are running on Windows 8.

The previous style and content of these pages was a little out of step with the rest of Windows docs, as they were originally based on an internal document that wasn't meant for customer-ready documentation. In particular, they make references to `sources` files and C preprocessor macros which only exist in Windows' internal build system ("Razzle").

The updates I've made are as follows:
- Delete all Razzle-ish references and usages or replace them with constructs everyone can use.
- Delete the `<trustInfo>` section from all but one of the example app manifests. Clarified why `<trustInfo>` is "recommended" - the previous text implied that it is important to OS versioning, but in fact it is useful to bypass a _different_ compatibility behavior (UAC file system virtualization).
- Fixed some formatting and updated some links which still work but redirect.