### PR TITLE
Update ldap-adspath.md

### DIFF
--- a/desktop-src/ADSI/ldap-adspath.md
+++ b/desktop-src/ADSI/ldap-adspath.md
@@ -56,7 +56,7 @@ For more information and examples of LDAP binding strings, as well as a descript
 
 ## LDAP Special Characters
 
-LDAP has several special characters which are reserved for use by the LDAP API. The list of special characters can be found in [Distinguished Names](https://docs.microsoft.com/previous-versions/windows/desktop/ldap/distinguished-names). To use one of these characters in an ADsPath without generating an error, the character must be preceded by a backslash (\) character. This is known as *escaping* the character. For example, if a user name is given in the form of "<last name>,<first name>", the comma in the name value must be escaped. The resulting string would look like this:
+LDAP has several special characters which are reserved for use by the LDAP API. The list of special characters can be found in [Distinguished Names](https://docs.microsoft.com/previous-versions/windows/desktop/ldap/distinguished-names). To use one of these characters in an ADsPath without generating an error, the character must be preceded by a backslash (\\) character. This is known as *escaping* the character. For example, if a user name is given in the form of "<last name>,<first name>", the comma in the name value must be escaped. The resulting string would look like this:
 
 
 ```C++


### PR DESCRIPTION
The docs only showed () and not (\\) because the backslash also needs to be escaped in markdown.