### PR TITLE
Update dx-graphics-hlsl-max.md

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-max.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-max.md
@@ -45,13 +45,20 @@ Selects the greater of x and y.
 
 The *x* or *y* parameter, whichever is the largest value.
 
+
 ## Remarks
 
-For values of -INF or INF, max will behave as expected. However for values of NaN, the results are undefined.
+Denormals are handled as follows:
+
+| src0 src1-> | -inf | F             | +inf | NAN  |
+|-------------|------|---------------|------|------|
+| -inf        | -inf | src1          | +inf | -inf |
+| F           | src0 | src0 or src1  | +inf | src0 |
+| +inf        | +inf | +inf          | +inf | +inf |
+| NaN         | -inf | src1          | +inf | NaN  |
+
 
 ## Type Description
-
-
 
 | Name | In/Out      | [**Template Type**](dx-graphics-hlsl-intrinsic-functions.md)                                                  | [**Component Type**](dx-graphics-hlsl-intrinsic-functions.md)                 | Size                         |
 |------|-------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|------------------------------|
@@ -85,11 +92,7 @@ This function is supported in the following shader models.
 [**Intrinsic Functions (DirectX HLSL)**](dx-graphics-hlsl-intrinsic-functions.md)
 </dt> </dl>
 
+[**DirectX Functional Specification**](https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#inst_MIN) 
+</dt> </dl>
  
-
  
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-max.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-max.md
@@ -57,6 +57,8 @@ Denormals are handled as follows:
 | +inf        | +inf | +inf          | +inf | +inf |
 | NaN         | -inf | src1          | +inf | NaN  |
 
+F means finite-real number.
+
 
 ## Type Description
 
@@ -92,7 +94,7 @@ This function is supported in the following shader models.
 [**Intrinsic Functions (DirectX HLSL)**](dx-graphics-hlsl-intrinsic-functions.md)
 </dt> </dl>
 
-[**DirectX Functional Specification**](https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#inst_MIN) 
+[**DirectX Functional Specification**](https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#inst_MAX) 
 </dt> </dl>
  
  


### PR DESCRIPTION
Fixes the incorrect statement that providing NaN to max is incorrect behaviour, and instead copies the table for handling denormals from the d3d functional spec.