### PR TITLE
Update dx-graphics-hlsl-min.md

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-min.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-min.md
@@ -45,13 +45,22 @@ Selects the lesser of x and y.
 
 The *x* or *y* parameter, whichever is the smallest value.
 
+
 ## Remarks
 
-For values of -INF or INF, min will behave as expected. However for values of NaN, the results are undefined.
+Denormals are handled as follows:
+
+| src0 src1-> | -inf | F             | +inf | NAN  |
+|-------------|------|---------------|------|------|
+| -inf        | -inf | -inf          | -inf | -inf |
+| F           | -inf | src0 or src1  | src0 | src0 |
+| +inf        | -inf | src1          | +inf | +inf |
+| NaN         | -inf | src1          | +inf | NaN  |
+
+F means finite-real number.
+
 
 ## Type Description
-
-
 
 | Name | In/Out      | [**Template Type**](dx-graphics-hlsl-intrinsic-functions.md)                                                  | [**Component Type**](dx-graphics-hlsl-intrinsic-functions.md)                 | Size                         |
 |------|-------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|------------------------------|
@@ -85,11 +94,5 @@ This function is supported in the following shader models.
 [**Intrinsic Functions (DirectX HLSL)**](dx-graphics-hlsl-intrinsic-functions.md)
 </dt> </dl>
 
- 
-
- 
-
-
-
-
+[**DirectX Functional Specification**](https://microsoft.github.io/DirectX-Specs/d3d/archive/D3D11_3_FunctionalSpec.htm#inst_MIN)  
 


### PR DESCRIPTION
Fixes the incorrect statement that providing NaN to min is incorrect behaviour, and instead copies the table for handling denormals from the d3d functional spec.