### PR TITLE
Replaced reserved symbol '<' with HTML entities.

### DIFF
--- a/desktop-src/search/-search-3x-advancedquerysyntax.md
+++ b/desktop-src/search/-search-3x-advancedquerysyntax.md
@@ -264,8 +264,8 @@ The syntax listed in the following table consists of an operator, operator symbo
 </tr>
 <tr class="odd">
 <td>COP_VALUE_STARTSWITH</td>
-<td>~<<br/></td>
-<td>System.FileName:~<&quot;C++ Primer&quot;<br/></td>
+<td>~&lt;<br/></td>
+<td>System.FileName:~&lt;&quot;C++ Primer&quot;<br/></td>
 <td>Finds items where the file name begins with the characters &quot;<em>C++ Primer</em>&quot;.<br/></td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
The document currently renders as:

    COP_VALUE_STARTSWITH | ~ | System.FileName:~<"c++> | Finds items where the file name begins with the characters "C++ Primer".

This fix changes the output to this:

    COP_VALUE_STARTSWITH | ~< | System.FileName:~<"C++ Primer" | Finds items where the file name begins with the characters "C++ Primer".