### PR TITLE
Update LVM_SETGROUPINFO docs

### DIFF
--- a/desktop-src/Controls/lvm-setgroupinfo.md
+++ b/desktop-src/Controls/lvm-setgroupinfo.md
@@ -18,17 +18,17 @@ ms.date: 05/31/2018
 
 # LVM\_SETGROUPINFO message
 
-Sets group information.
+Sets group information. Send this message explicitly or by using the [**ListView\_SetGroupInfo**](/windows/desktop/api/Commctrl/nf-commctrl-listview_setgroupinfo) macro.
 
 ## Parameters
 
 <dl> <dt>
 
-*wParam* 
+*wParam* \[in\]
 </dt> <dd>ID that specifies the group whose information is to be set.</dd> <dt>
 
-*lParam* 
-</dt> <dd>Pointer to an <a href="/windows/desktop/api/Commctrl/ns-commctrl-taglvgroup">**LVGROUP**</a> structure that contains the information to set.</dd> </dl>
+*lParam* \[in, out\]
+</dt> <dd>Pointer to a [**LVGROUP**](windows/win32/api/commctrl/ns-commctrl-lvgroup) structure that contains the information to set.</dd> </dl>
 
 ## Return value
 
@@ -36,10 +36,12 @@ Returns the ID of the group if successful, or -1 otherwise.
 
 ## Remarks
 
+To change a group ID of an existing group add <b>LVGF_GROUPID</b> to <b>LVGROUP.mask</b> and set <b>LVGROUP.iGroupId</b> to the new ID. The call will fail if <b>LVGROUP.iGroupId</b> contains ID of an existing group.
+
+To update other properties of an existing group (e.g. update an alignment of the header or footer text for the group, <b>uAlign</b>) <b>LVGROUP.mask</b> must not contain <b>LVGF_GROUPID</b>, else the update will fail.
+
 > [!Note]  
 > To use this message, you must provide a manifest specifying Comclt32.dll version 6.0. For more information on manifests, see [Enabling Visual Styles](cookbook-overview.md).
-
- 
 
 ## Requirements
 


### PR DESCRIPTION
See https://github.com/dotnet/winforms/issues/2554 and http://users.skynet.be/oleole/Listview_grouping_feature.htm

- Fix dead link
- Update documentation to indicate that `LVGF_GROUPID` should not be set in order to update `LVGROUPW` properties

/cc @weltkante