### PR TITLE
Fix broken link to Control Spy 2.0

### DIFF
--- a/desktop-src/Controls/control-spy.md
+++ b/desktop-src/Controls/control-spy.md
@@ -55,7 +55,7 @@ The **Size/Color** tab can be used to change the size of the control as well as 
 
 ## Where to Get Control Spy
 
-You can download [Control Spy 2.0](https://go.microsoft.com/fwlink/p/?linkid=198349) from MSDN. Both versions are contained in the download.
+You can download [Control Spy 2.0](https://www.microsoft.com/en-us/download/details.aspx?id=4635) from MSDN. Both versions are contained in the download.
 
 ## Related topics
 


### PR DESCRIPTION
The original 'fwlink' points at https://www.microsoft.com/downloads/details.aspx?FamilyID=19d4294d-0531-4ec2-8b27-2e463b315f16 which is a dead link.