### PR TITLE
Fix and update documentation for HDM_GET*RECT messages

### DIFF
--- a/desktop-src/Controls/hdm-getitemdropdownrect.md
+++ b/desktop-src/Controls/hdm-getitemdropdownrect.md
@@ -20,8 +20,6 @@ ms.date: 05/31/2018
 
 Gets the bounding rectangle of the split button for a header item with style **HDF\_SPLITBUTTON**. Send this message explicitly or by using the [**Header\_GetItemDropDownRect**](/windows/desktop/api/Commctrl/nf-commctrl-header_getitemdropdownrect) macro.
 
-A window receives this message through its [**WindowProc**](https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
-
 ## Parameters
 
 <dl> <dt>
@@ -36,7 +34,7 @@ The zero-based index of the header control item for which to retrieve the boundi
 *lParam* \[in, out\]
 </dt> <dd>
 
-A pointer to a [**RECT**](https://docs.microsoft.com/previous-versions//dd162897(v=vs.85)) structure to receive the bounding rectangle information. The message sender is responsible for allocating this structure. The coordinates returned in the **RECT** structure are expressed as screen coordinates.
+A pointer to a [**RECT**](/windows/win32/api/windef/ns-windef-rect) structure that receives the bounding rectangle information. The message sender is responsible for allocating this structure. The coordinates returned in the RECT structure are expressed relative to the header control parent.
 
 </dd> </dl>
 

--- a/desktop-src/Controls/hdm-getitemrect.md
+++ b/desktop-src/Controls/hdm-getitemrect.md
@@ -24,17 +24,17 @@ Gets the bounding rectangle for a given item in a header control. You can send t
 
 <dl> <dt>
 
-*wParam* 
+*wParam* \[in\]
 </dt> <dd>
 
 The zero-based index of the header control item for which to retrieve the bounding rectangle.
 
 </dd> <dt>
 
-*lParam* 
+*lParam* \[in, out\]
 </dt> <dd>
 
-A pointer to a [**RECT**](https://docs.microsoft.com/previous-versions//dd162897(v=vs.85)) structure that receives the bounding rectangle information.
+A pointer to a [**RECT**](/windows/win32/api/windef/ns-windef-rect) structure that receives the bounding rectangle information. The message sender is responsible for allocating this structure. The coordinates returned in the RECT structure are expressed relative to the header control parent.
 
 </dd> </dl>
 


### PR DESCRIPTION
## Proposed Changes
- `HDM_GETITEMDROPDOWNRECT` returns coordinates relative to the parent, not to the screen

E.g. in the following code that handles `LVN_COLUMNDROPDOWN` we get:
```cs
NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
IntPtr header = User32.SendMessageW(Handle, (User32.WindowMessage)LVM.GETHEADER, IntPtr.Zero, IntPtr.Zero);

RECT r1 = default;
IntPtr result1 = User32.SendMessageW(header, (User32.WindowMessage)HDM.GETITEMDROPDOWNRECT, (IntPtr)nmlv->iSubItem, ref r1);

RECT r2 = default;
IntPtr result2 = User32.SendMessageW(header, (User32.WindowMessage)HDM.GETITEMRECT, (IntPtr)nmlv->iSubItem, ref r2);

Point p1 = PointToScreen(new Point(r1.left, r1.bottom));
Point p2 = PointToScreen(new Point(r2.right - SystemInformation.MenuButtonSize.Width, r2.bottom));
```

We get
```
r1
{Interop.RECT}
    Size: {Width = 15 Height = 24}
    bottom: 24
    left: 293
    right: 308
    top: 0
p1
{X = 498 Y = 252}
    IsEmpty: false
    X: 498
    Y: 252
```
and

```
r2
{Interop.RECT}
    Size: {Width = 250 Height = 24}
    bottom: 24
    left: 60
    right: 310
    top: 0
p2
{X = 496 Y = 252}
    IsEmpty: false
    X: 496
    Y: 252
```

/cref https://github.com/dotnet/winforms/issues/2627

/cc @weltkante @RussKie