### PR TITLE
Note performance counter permission distinction for interactive logon sessions

### DIFF
--- a/desktop-src/PerfCtrs/limited-user-access-support.md
+++ b/desktop-src/PerfCtrs/limited-user-access-support.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Limited User Access Support
 
-Only the administrator of the computer or users in the Performance Logs User Group can log and view counter data. Users in the Administrator group can log and view counter data only if the tool they use to log and view counter data is started from a Command Prompt window that is opened with **Run as administrator...**. Users in the Performance Monitoring Users group can view counter data.
+Only the administrator of the computer or users in the Performance Logs User Group can log counter data. Users in the Administrator group can log counter data only if the tool they use to log counter data is started from a Command Prompt window that is opened with **Run as administrator...**. Any users in interactive logon sessions can view counter data. However, users in non-interactive logon sessions must be in the Performance Monitoring Users group to view counter data.
 
 **Windows XP:** The Administrator or users in the Administrator group can log and view counter data without restriction.
 


### PR DESCRIPTION
I noticed that users in interactive sessions can always view counter data, and only non-interactive logon sessions need to be in the Performance Monitoring Users group in order to view counter data, but the documentation here made no mention of the interactive vs non-interactive distinction, so I have added that information.

I noticed that this exception for interactive sessions was introduced in Vista SP1. In Vista RTM, users in interactive sessions had to be in the Performance Monitoring Users group in order to view counter data. I believe that is why this documentation does not mention the interactive session exception, because this documentation was probably written when Vista RTM was released and not updated since.