### PR TITLE
Fix unescaped anchor tag running loose

### DIFF
--- a/desktop-src/Controls/syslink-overview.md
+++ b/desktop-src/Controls/syslink-overview.md
@@ -21,7 +21,7 @@ This article contains the following sections.
 
 ## SysLink Markup
 
-The SysLink control supports the anchor tag(<a>) along with the attributes **HREF** and **ID**. An **HREF** can be any protocol, such as http, ftp, and mailto. An **ID** is an optional name, unique within a SysLink control, and it is associated with an individual link. Links are also assigned a zero-based index according to their position within the string. This index is used to access a link.
+The SysLink control supports the anchor tag(&lt;a&gt;) along with the attributes **HREF** and **ID**. An **HREF** can be any protocol, such as http, ftp, and mailto. An **ID** is an optional name, unique within a SysLink control, and it is associated with an individual link. Links are also assigned a zero-based index according to their position within the string. This index is used to access a link.
 
 ## Link Attributes
 


### PR DESCRIPTION
Replace literal angled brackets of the **unescaped** anchor tag with appropiate character entities as else this mess happens on the MSFT Docs page
![image](https://user-images.githubusercontent.com/6952402/72214776-1914e900-3509-11ea-8fb7-bc8f7f7432d1.png)
