### PR TITLE
Fixed the formulas.

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-lit.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-lit.md
@@ -30,9 +30,9 @@ Returns a lighting coefficient vector.
 
 This function returns a lighting coefficient vector (ambient, diffuse, specular, 1) where:
 
--   ambient = 1.
--   diffuse = ((n   l) < 0) ? 0 : n   l.
--   specular = ((n   l) < 0) \|\| ((n   h) < 0) ? 0 : ((n   h) \* m).
+-   ambient = 1
+-   diffuse = n · l < 0 ? 0 : n · l
+-   specular = n · l < 0 \|\| n · h < 0 ? 0 : (n · h) ^ m
 
 Where the vector n is the normal vector, l is the direction to light and h is the half vector.
 


### PR DESCRIPTION
I added the dot product operator for n·l and n·h, and removed the unnecessary parentheses. The specular component contained multiplication (*) with the specular exponent, so I replaced that with exponentiation (^). Source: https://en.wikipedia.org/wiki/Blinn%E2%80%93Phong_reflection_model