### PR TITLE
Update sacl-access-right.md

### DIFF
--- a/desktop-src/SecAuthZ/sacl-access-right.md
+++ b/desktop-src/SecAuthZ/sacl-access-right.md
@@ -1,5 +1,5 @@
 ---
-Description: The ACCESS\_SYSTEM\_SECURITY access right controls the ability to get or set the SACL in an objects security descriptor. The system grants this access right only if the SE\_SECURITY\_NAME privilege is enabled in the access token of the requesting thread.
+Description: The ACCESS\_SYSTEM\_SECURITY access right controls the ability to get or set the SACL in an objects security descriptor. The system grants this access right if the SE\_SECURITY\_NAME privilege is enabled in the access token of the requesting thread.
 ms.assetid: 88198243-dae5-49ac-9d54-bfae7a3a0b1a
 title: SACL Access Right
 ms.topic: article


### PR DESCRIPTION
I removed the *only* since is not true.  You can have ACCESS_SYSTEM_SECURITY if it is a file or directory and you have specified FILE_FLAG_BACKUP_SEMANTICS and you possess and have enabled either the SE_BACKUP_NAME or SE_RESTORE_NAME privileges.