### PR TITLE
Fix value of _WIN32_WINNT_WINBLUE

### DIFF
--- a/desktop-src/WinProg/using-the-windows-headers.md
+++ b/desktop-src/WinProg/using-the-windows-headers.md
@@ -65,7 +65,7 @@ The following tables describe other macros used in the Windows header files.
 
 | Minimum system required                           | Minimum value for \_WIN32\_WINNT and WINVER |
 |---------------------------------------------------|---------------------------------------------|
-| Windows 8.1                                       | **\_WIN32\_WINNT\_WINBLUE** (0x0602)        |
+| Windows 8.1                                       | **\_WIN32\_WINNT\_WINBLUE** (0x0603)        |
 | Windows 8                                         | **\_WIN32\_WINNT\_WIN8** (0x0602)           |
 | Windows 7                                         | **\_WIN32\_WINNT\_WIN7** (0x0601)           |
 | Windows Server 2008                               | **\_WIN32\_WINNT\_WS08** (0x0600)           |


### PR DESCRIPTION
Fix value of _WIN32_WINNT_WINBLUE (0x0603). This can be verified by opening the sdkddkver.h header in the official Windows SDK. This matters, see https://docs.microsoft.com/en-us/windows/win32/api/winuser/ne-winuser-pointer_device_type. POINTER_DEVICE_TYPE_TOUCH_PAD is defined for 8.1, but not for 8.