### PR TITLE
Fix softlock in example for creating-a-child-process-with-redirected-input-and-output

### DIFF
--- a/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
+++ b/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
@@ -157,6 +157,13 @@ void CreateChildProcess()
 
       CloseHandle(piProcInfo.hProcess);
       CloseHandle(piProcInfo.hThread);
+      
+      // We've given the child process the writable end of stdout pipe so we don't need it anymore
+      // We've given the child process the readable end of stdin pipe so we don't need it anymore
+      // Without these, the pipes will not close and we will not know that the child process has ended
+      
+      CloseHandle(g_hChildStd_OUT_Wr);
+      CloseHandle(g_hChildStd_IN_Rd);
    }
 }
  

--- a/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
+++ b/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
@@ -158,9 +158,8 @@ void CreateChildProcess()
       CloseHandle(piProcInfo.hProcess);
       CloseHandle(piProcInfo.hThread);
       
-      // We've given the child process the writable end of stdout pipe so we don't need it anymore
-      // We've given the child process the readable end of stdin pipe so we don't need it anymore
-      // Without these, the pipes will not close and we will not know that the child process has ended
+      // Close handles to the stdin and stdout pipes no longer needed by the child process.
+      // If they are not explicitly closed, there is no way to recognize that the child process has ended.
       
       CloseHandle(g_hChildStd_OUT_Wr);
       CloseHandle(g_hChildStd_IN_Rd);


### PR DESCRIPTION
After spending a good hour trying to figure out if softlocking was caused by other code in my project (attempting to pause was pointing at unrelated code inside a WaitForObject call elsewhere), it came to my attention that there is [a stackoverflow question](https://stackoverflow.com/q/35969730/5578773) where someone else was mislead by this exact example - as it stands, the sample program softlocks due to unclosed pipes.