### PR TITLE
RWByteAddressBuffer and Interlocked functions available on all stages

### DIFF
--- a/desktop-src/direct3dhlsl/interlockedadd.md
+++ b/desktop-src/direct3dhlsl/interlockedadd.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      | x    | x      | x        | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedand.md
+++ b/desktop-src/direct3dhlsl/interlockedand.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedcompareexchange.md
+++ b/desktop-src/direct3dhlsl/interlockedcompareexchange.md
@@ -103,7 +103,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedcomparestore.md
+++ b/desktop-src/direct3dhlsl/interlockedcomparestore.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+|  x     | x    |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedexchange.md
+++ b/desktop-src/direct3dhlsl/interlockedexchange.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   | x      |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedmax.md
+++ b/desktop-src/direct3dhlsl/interlockedmax.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedmin.md
+++ b/desktop-src/direct3dhlsl/interlockedmin.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedor.md
+++ b/desktop-src/direct3dhlsl/interlockedor.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      |  x   |  x     |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/interlockedxor.md
+++ b/desktop-src/direct3dhlsl/interlockedxor.md
@@ -88,7 +88,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+|  x     |  x   | x      |  x       | x     | x       |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedadd.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedadd.md
@@ -75,7 +75,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   | x   | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedand.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedand.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   | x   |  x  | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedcompareexchange.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedcompareexchange.md
@@ -89,7 +89,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   | x   | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedcomparestore.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedcomparestore.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   | x   | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedexchange.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedexchange.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+|  x  |  x  |  x  |  x  | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedmax.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedmax.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   | x   | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedmin.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedmin.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   |  x  | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedor.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedor.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   |  x  | x   | x   | x   | x   |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedxor.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwbyteaddressbuffer-interlockedxor.md
@@ -74,7 +74,7 @@ This function is supported in the following types of shaders:
 
 | VS  | HS  | DS  | GS  | PS  | CS  |
 |-----|-----|-----|-----|-----|-----|
-|     |     |     |     | x   | x   |
+| x   |  x  | x   | x   | x   | x   |
 
 
 


### PR DESCRIPTION
A remnant of when D3D only allowed UAVs on PS and CS stages, that's no longer the case so these intrinsics work on all shader stages