### PR TITLE
Remove incorrect link for GetRangePropertyValue 

### DIFF
--- a/desktop-src/tablet/hrecoalt-handle.md
+++ b/desktop-src/tablet/hrecoalt-handle.md
@@ -26,7 +26,7 @@ These functions are obsolete and need not be implemented by custom application r
 -   [**GetGuideIndex**](https://msdn.microsoft.com/library/ms701152(v=VS.85).aspx)
 -   [**GetMetrics**](https://msdn.microsoft.com/library/ms695560(v=VS.85).aspx)
 -   [**GetPropertyRanges**](https://msdn.microsoft.com/library/ms695602(v=VS.85).aspx)
--   [**GetRangePropertyValue**](https://msdn.microsoft.com/library/ms703427(v=VS.85).aspx)
+-   **GetRangePropertyValue**
 -   [**GetSegmentAlternateList**](https://msdn.microsoft.com/library/ms701702(v=VS.85).aspx)
 -   [**GetString**](https://msdn.microsoft.com/library/ms704890(v=VS.85).aspx)
 -   [**GetStrokeRanges**](https://msdn.microsoft.com/library/ms705304(v=VS.85).aspx)

--- a/desktop-src/tablet/hrecoalt-handle.md
+++ b/desktop-src/tablet/hrecoalt-handle.md
@@ -26,7 +26,6 @@ These functions are obsolete and need not be implemented by custom application r
 -   [**GetGuideIndex**](https://msdn.microsoft.com/library/ms701152(v=VS.85).aspx)
 -   [**GetMetrics**](https://msdn.microsoft.com/library/ms695560(v=VS.85).aspx)
 -   [**GetPropertyRanges**](https://msdn.microsoft.com/library/ms695602(v=VS.85).aspx)
--   **GetRangePropertyValue**
 -   [**GetSegmentAlternateList**](https://msdn.microsoft.com/library/ms701702(v=VS.85).aspx)
 -   [**GetString**](https://msdn.microsoft.com/library/ms704890(v=VS.85).aspx)
 -   [**GetStrokeRanges**](https://msdn.microsoft.com/library/ms705304(v=VS.85).aspx)

--- a/desktop-src/tablet/toc.yml
+++ b/desktop-src/tablet/toc.yml
@@ -2637,8 +2637,6 @@
           href: https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms695560(v=vs.85)
         - name: "GetPropertyRanges Function"
           href: https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms695602(v=vs.85)
-        - name: "GetRangePropertyValue Function"
-          href: https://docs.microsoft.com/windows/desktop/api/recapis/nf-recapis-destroyalternate
         - name: "GetSegmentAlternateList Function"
           href: https://docs.microsoft.com/previous-versions/windows/desktop/legacy/ms701702(v=vs.85)
         - name: "GetString Function"


### PR DESCRIPTION
I couldn't find any page for GetRangePropertyValue so this change removes the link completely.