### PR TITLE
Fixing broken link at the bottom of the article

### DIFF
--- a/desktop-src/Dlls/dllmain.md
+++ b/desktop-src/Dlls/dllmain.md
@@ -110,7 +110,7 @@ Calling functions that require DLLs other than Kernel32.dll may result in proble
 
 Because DLL notifications are serialized, entry-point functions should not attempt to communicate with other threads or processes. Deadlocks may occur as a result.
 
-For information on best practices when writing a DLL, see [https://www.microsoft.com/whdc/driver/kernel/DLL\_bestprac.mspx](https://go.microsoft.com/fwlink/p/?linkid=84138).
+For information on best practices when writing a DLL, see https://docs.microsoft.com/windows/win32/dlls/dynamic-link-library-best-practices.
 
 If your DLL is linked with the C run-time library (CRT), the entry point provided by the CRT calls the constructors and destructors for global and static C++ objects. Therefore, these restrictions for *DllMain* also apply to constructors and destructors and any code that is called from them.
 


### PR DESCRIPTION
Old content referred to best practices @ https://www.microsoft.com/whdc/driver/kernel/DLL_bestprac.mspx
Updated content to point to the real dllmain best practices @ https://docs.microsoft.com/windows/win32/dlls/dynamic-link-library-best-practices