### PR TITLE
Slim Reader Writer locks are not reentrant

### DIFF
--- a/desktop-src/Sync/slim-reader-writer--srw--locks.md
+++ b/desktop-src/Sync/slim-reader-writer--srw--locks.md
@@ -15,7 +15,7 @@ Reader threads read data from a shared resource whereas writer threads write dat
 SRW locks provide two modes in which threads can access a shared resource:
 
 -   **Shared mode**, which grants shared read-only access to multiple reader threads, which enables them to read data from the shared resource concurrently. If read operations exceed write operations, this concurrency increases performance and throughput compared to critical sections.
--   **Exclusive mode**, which grants read/write access to one writer thread at a time. When the lock has been acquired in exclusive mode, no other thread can access the shared resource until the writer releases the lock.
+-   **Exclusive mode**, which grants read/write access to one writer thread at a time. When the lock has been acquired in exclusive mode, no other thread can access the shared resource until the writer releases the lock. (_Note: The same thread trying to acquire a lock it already holds will also fail (for `TryAcquireSRWLockExclusive`) or deadlock (for `AcquireSRWLockExclusive`). The lock is not rentrant._)
 
 A single SRW lock can be acquired in either mode; reader threads can acquire it in shared mode whereas writer threads can acquire it in exclusive mode. There is no guarantee about the order in which threads that request ownership will be granted ownership; SRW locks are neither fair nor FIFO.
 

--- a/desktop-src/Sync/slim-reader-writer--srw--locks.md
+++ b/desktop-src/Sync/slim-reader-writer--srw--locks.md
@@ -15,7 +15,9 @@ Reader threads read data from a shared resource whereas writer threads write dat
 SRW locks provide two modes in which threads can access a shared resource:
 
 -   **Shared mode**, which grants shared read-only access to multiple reader threads, which enables them to read data from the shared resource concurrently. If read operations exceed write operations, this concurrency increases performance and throughput compared to critical sections.
--   **Exclusive mode**, which grants read/write access to one writer thread at a time. When the lock has been acquired in exclusive mode, no other thread can access the shared resource until the writer releases the lock. (_Note: The same thread trying to acquire a lock it already holds will also fail (for `TryAcquireSRWLockExclusive`) or deadlock (for `AcquireSRWLockExclusive`). The lock is not rentrant._)
+-   **Exclusive mode**, which grants read/write access to one writer thread at a time. When the lock has been acquired in exclusive mode, no other thread can access the shared resource until the writer releases the lock.
+    > [!NOTE]
+    > Exclusive mode SRW locks are not re-entrant. If a thread tries to acquire a lock that it already holds, that attempt will fail (for [**TryAcquireSRWLockExclusive**](https://msdn.microsoft.com/library/Dd405523(v=VS.85).aspx)) or deadlock (for [**AcquireSRWLockExclusive**](https://msdn.microsoft.com/library/ms681930(v=VS.85).aspx))
 
 A single SRW lock can be acquired in either mode; reader threads can acquire it in shared mode whereas writer threads can acquire it in exclusive mode. There is no guarantee about the order in which threads that request ownership will be granted ownership; SRW locks are neither fair nor FIFO.
 


### PR DESCRIPTION
This should be clearer in the doc, as the talk about a "thread" owning and releasing a lock makes it sound like they are reentrant, when they are not.