### PR TITLE
Fix Typo

### DIFF
--- a/desktop-src/ProcThread/getprocessdefaultcpusets.md
+++ b/desktop-src/ProcThread/getprocessdefaultcpusets.md
@@ -79,7 +79,7 @@ This API returns TRUE on success. If the buffer is not large enough the API retu
 |-------------------------------------|-----------------------------------------------------------------------------------------------|
 | Minimum supported client<br/> | Windows 10 \[desktop apps \| UWP apps\]<br/>                                            |
 | Minimum supported server<br/> | Windows Server 2016 \[desktop apps \| UWP apps\]<br/>                                   |
-| Header<br/>                   | <dl> <dt>Processthreadapi.h</dt> </dl> |
+| Header<br/>                   | <dl> <dt>Processthreadsapi.h</dt> </dl> |
 | Library<br/>                  | <dl> <dt>Windows.h</dt> </dl>          |
 | DLL<br/>                      | <dl> <dt>Kernel32.dll</dt> </dl>       |
 


### PR DESCRIPTION
Typo: Processthreadapi.h was wrong. Correct file name is Processthreadsapi.h.