### PR TITLE
Fix typo.

### DIFF
--- a/desktop-src/direct3dhlsl/quadswapx.md
+++ b/desktop-src/direct3dhlsl/quadswapx.md
@@ -1,13 +1,13 @@
 ---
-title: QuadReadAccrossX function
+title: QuadReadAcrossX function
 description: Returns the specified local value read from the other lane in this quad in the X direction.
 ms.assetid: 7A7E0623-30EC-4167-90A5-D79E10A394CC
 keywords:
-- QuadReadAccrossX function HLSL
+- QuadReadAcrossX function HLSL
 topic_type:
 - apiref
 api_name:
-- QuadReadAccrossX
+- QuadReadAcrossX
 api_type:
 - NA
 ms.topic: reference
@@ -15,14 +15,14 @@ ms.date: 05/31/2018
 api_location: 
 ---
 
-# QuadReadAccrossX function
+# QuadReadAcrossX function
 
 Returns the specified local value read from the other lane in this quad in the X direction.
 
 ## Syntax
 
 ``` syntax
-<type> QuadReadAccrossX(
+<type> QuadReadAcrossX(
    <type> localValue
 );
 ```


### PR DESCRIPTION
Across only has one ;c'