### PR TITLE
errors in code

### DIFF
--- a/desktop-src/Debug/using-wct.md
+++ b/desktop-src/Debug/using-wct.md
@@ -238,11 +238,10 @@ Return Value:
 
             printf("\n----------------------------------\n");
 
-            // Get a snapshot of this process. This enables us to
-            // enumerate its threads.
-            snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD,
-                                                processes[i]);
-            if (snapshot)
+            // Get a snapshot of all threads and look for the ones
+            // from the relevant process
+            snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+            if (snapshot != INVALID_HANDLE_VALUE)
             {
                 THREADENTRY32 thread;
                 thread.dwSize = sizeof(thread);


### PR DESCRIPTION
CreateToolhelp32Snapshot returns INVALID_HANDLE_VALUE if it fails, not NULL
CreateToolhelp32Snapshot with TH32CS_SNAPTHREAD ignores the process ID argument. It always enumerates all threads in the system.