### PR TITLE
Update vrs.md

### DIFF
--- a/desktop-src/direct3d12/vrs.md
+++ b/desktop-src/direct3d12/vrs.md
@@ -500,7 +500,7 @@ return
         D3D12_FEATURE_D3D12_OPTIONS6, 
         &options, 
         sizeof(options))) && 
-    options.ShadingRateTier == D3D12_SHADING_RATE_TIER_1;
+    options.ShadingRateTier == D3D12_VARIABLE_SHADING_RATE_TIER_1;
 ```
 
 ### Shading rates


### PR DESCRIPTION
Hi I found that in this file, in section "Calling the VRS APIs"->Capability querying, when you gave example code, the last line reads  options.ShadingRateTier == D3D12_SHADING_RATE_TIER_1;
When I implement it I found that there's no D3D12_SHADING_RATE_TIER_1, also the type of options.ShadingRateTier is D3D12_VARIABLE_SHADING_RATE_TIER. So I believe it should be:
options.ShadingRateTier == D3D12_VARIABLE_SHADING_RATE_TIER_1;//there's a "VARIABLE" missing

I believe it was a typo?