### PR TITLE
Fix broken list due to mismatching dl tags, update MSDN links

### DIFF
--- a/desktop-src/CIMWin32Prov/win32-processor.md
+++ b/desktop-src/CIMWin32Prov/win32-processor.md
@@ -75,9 +75,9 @@ api_location:
 - CIMWin32.dll
 ---
 
-# Win32\_Processor class
+# Win32_Processor class
 
-The **Win32\_Processor** [WMI class](https://msdn.microsoft.com/library/Aa393244(v=VS.85).aspx) represents a device that can interpret a sequence of instructions on a computer running on a Windows operating system.
+The **Win32_Processor** [WMI class][0] represents a device that can interpret a sequence of instructions on a computer running on a Windows operating system.
 
 The following syntax is simplified from Managed Object Format (MOF) code and includes all of the inherited properties. Properties are listed in alphabetic order, not MOF order.
 
@@ -149,3448 +149,996 @@ class Win32_Processor : CIM_Processor
 
 ## Members
 
-The **Win32\_Processor** class has these types of members:
+The **Win32_Processor** class has these types of members:
 
 -   [Methods](#methods)
 -   [Properties](#properties)
 
 ### Methods
 
-The **Win32\_Processor** class has these methods.
+The **Win32_Processor** class has these methods.
 
+| Method            | Description                                                                                                                                                                                             |
+|:------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Reset**         | Not implemented. For more information about how to implement this method, see the [**Reset**](reset-method-in-class-cim-controller.md) method in [**CIM_Processor**](cim-processor.md).                 |
+| **SetPowerState** | Not implemented. For more information about how to implement this method, see the [**SetPowerState**](setpowerstate-method-in-class-cim-controller.md) method in [**CIM_Processor**](cim-processor.md). |
 
-
-| Method            | Description                                                                                                                                                                                                           |
-|:------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Reset**         | Not implemented. For more information about how to implement this method, see the [**Reset**](reset-method-in-class-cim-controller.md) method in [**CIM\_Processor**](cim-processor.md).<br/>                 |
-| **SetPowerState** | Not implemented. For more information about how to implement this method, see the [**SetPowerState**](setpowerstate-method-in-class-cim-controller.md) method in [**CIM\_Processor**](cim-processor.md).<br/> |
-
-
-
- 
 
 ### Properties
 
-The **Win32\_Processor** class has these properties.
-
-<dl> <dt>
-
-**AddressWidth**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("bits")
-</dt> </dl>
-
+The <b>Win32_Processor</b> class has these properties.
+<dl>
+  <dt><b>AddressWidth</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Units</b>][1] ("bits")</dt>
+    </dl>
 On a 32-bit operating system, the value is 32 and on a 64-bit operating system it is 64.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**Architecture**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-Processor architecture used by the platform.
-
-<dt>
-
-<span id="x86"></span><span id="X86"></span>
-
-<span id="x86"></span><span id="X86"></span>**x86** (0)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS"></span><span id="mips"></span>
-
-<span id="MIPS"></span><span id="mips"></span>**MIPS** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha"></span><span id="alpha"></span><span id="ALPHA"></span>
-
-<span id="Alpha"></span><span id="alpha"></span><span id="ALPHA"></span>**Alpha** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PowerPC"></span><span id="powerpc"></span><span id="POWERPC"></span>
-
-<span id="PowerPC"></span><span id="powerpc"></span><span id="POWERPC"></span>**PowerPC** (3)
-
-
-</dt> <dd></dd> <dt>
-
-5
-</dt> <dd>
-
-ARM
-
-</dd> <dt>
-
-<span id="ia64"></span><span id="IA64"></span>
-
-<span id="ia64"></span><span id="IA64"></span>**ia64** (6)
-
-
-</dt> <dd>
-
-Itanium-based systems
-
-</dd> <dt>
-
-<span id="x64"></span><span id="X64"></span>
-
-<span id="x64"></span><span id="X64"></span>**x64** (9)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**AssetTag**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Asset Tag")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).
+  </dd>
+  <dt><b>Architecture</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+    <dl>Processor architecture used by the platform.
+      <dt><b>x86</b> (0)</dt>
+      <dt><b>MIPS</b> (1)</dt>
+      <dt><b>Alpha</b> (2)</dt>
+      <dt><b>PowerPC</b> (3)</dt>
+      <dt><b>ARM</b> (5)</dt>
+      <dt><b>ia64</b> (6)</dt>
+      <dd>Itanium-based systems</dd>
+      <dt><b>x64</b> (9)</dt>
+    </dl>
+  </dd>
+  <dt><b>AssetTag</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Asset Tag")</dt>
+    </dl>
 Represents the asset tag of this processor.
 
-This value comes from the **Asset Tag** member of the **Processor Information** structure in the SMBIOS information.
-
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**Availability**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Operational State\|003.5", "MIB.IETF\|HOST-RESOURCES-MIB.hrDeviceStatus")
-</dt> </dl>
-
-Availability and status of the device.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-<dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>**Other** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>**Unknown** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Running_Full_Power"></span><span id="running_full_power"></span><span id="RUNNING_FULL_POWER"></span>
-
-<span id="Running_Full_Power"></span><span id="running_full_power"></span><span id="RUNNING_FULL_POWER"></span>**Running/Full Power** (3)
-
-
-</dt> <dd>
-
-Running or Full Power
-
-</dd> <dt>
-
-<span id="Warning"></span><span id="warning"></span><span id="WARNING"></span>
-
-<span id="Warning"></span><span id="warning"></span><span id="WARNING"></span>**Warning** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="In_Test"></span><span id="in_test"></span><span id="IN_TEST"></span>
-
-<span id="In_Test"></span><span id="in_test"></span><span id="IN_TEST"></span>**In Test** (5)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Not_Applicable"></span><span id="not_applicable"></span><span id="NOT_APPLICABLE"></span>
-
-<span id="Not_Applicable"></span><span id="not_applicable"></span><span id="NOT_APPLICABLE"></span>**Not Applicable** (6)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_Off"></span><span id="power_off"></span><span id="POWER_OFF"></span>
-
-<span id="Power_Off"></span><span id="power_off"></span><span id="POWER_OFF"></span>**Power Off** (7)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Off_Line"></span><span id="off_line"></span><span id="OFF_LINE"></span>
-
-<span id="Off_Line"></span><span id="off_line"></span><span id="OFF_LINE"></span>**Off Line** (8)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Off_Duty"></span><span id="off_duty"></span><span id="OFF_DUTY"></span>
-
-<span id="Off_Duty"></span><span id="off_duty"></span><span id="OFF_DUTY"></span>**Off Duty** (9)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Degraded"></span><span id="degraded"></span><span id="DEGRADED"></span>
-
-<span id="Degraded"></span><span id="degraded"></span><span id="DEGRADED"></span>**Degraded** (10)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Not_Installed"></span><span id="not_installed"></span><span id="NOT_INSTALLED"></span>
-
-<span id="Not_Installed"></span><span id="not_installed"></span><span id="NOT_INSTALLED"></span>**Not Installed** (11)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Install_Error"></span><span id="install_error"></span><span id="INSTALL_ERROR"></span>
-
-<span id="Install_Error"></span><span id="install_error"></span><span id="INSTALL_ERROR"></span>**Install Error** (12)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_Save_-_Unknown"></span><span id="power_save_-_unknown"></span><span id="POWER_SAVE_-_UNKNOWN"></span>
-
-<span id="Power_Save_-_Unknown"></span><span id="power_save_-_unknown"></span><span id="POWER_SAVE_-_UNKNOWN"></span>**Power Save - Unknown** (13)
-
-
-</dt> <dd>
-
-The device is known to be in a power save state, but its exact status is unknown.
-
-</dd> <dt>
-
-<span id="Power_Save_-_Low_Power_Mode"></span><span id="power_save_-_low_power_mode"></span><span id="POWER_SAVE_-_LOW_POWER_MODE"></span>
-
-<span id="Power_Save_-_Low_Power_Mode"></span><span id="power_save_-_low_power_mode"></span><span id="POWER_SAVE_-_LOW_POWER_MODE"></span>**Power Save - Low Power Mode** (14)
-
-
-</dt> <dd>
-
-The device is in a power save state, but is still functioning, and may exhibit decreased performance.
-
-</dd> <dt>
-
-<span id="Power_Save_-_Standby"></span><span id="power_save_-_standby"></span><span id="POWER_SAVE_-_STANDBY"></span>
-
-<span id="Power_Save_-_Standby"></span><span id="power_save_-_standby"></span><span id="POWER_SAVE_-_STANDBY"></span>**Power Save - Standby** (15)
-
-
-</dt> <dd>
-
-The device is not functioning, but can be brought to full power quickly.
-
-</dd> <dt>
-
-<span id="Power_Cycle"></span><span id="power_cycle"></span><span id="POWER_CYCLE"></span>
-
-<span id="Power_Cycle"></span><span id="power_cycle"></span><span id="POWER_CYCLE"></span>**Power Cycle** (16)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_Save_-_Warning"></span><span id="power_save_-_warning"></span><span id="POWER_SAVE_-_WARNING"></span>
-
-<span id="Power_Save_-_Warning"></span><span id="power_save_-_warning"></span><span id="POWER_SAVE_-_WARNING"></span>**Power Save - Warning** (17)
-
-
-</dt> <dd>
-
-The device is in a warning state, though also in a power save state.
-
-</dd> <dt>
-
-<span id="Paused"></span><span id="paused"></span><span id="PAUSED"></span>
-
-<span id="Paused"></span><span id="paused"></span><span id="PAUSED"></span>**Paused** (18)
-
-
-</dt> <dd>
-
-The device is paused.
-
-</dd> <dt>
-
-<span id="Not_Ready"></span><span id="not_ready"></span><span id="NOT_READY"></span>
-
-<span id="Not_Ready"></span><span id="not_ready"></span><span id="NOT_READY"></span>**Not Ready** (19)
-
-
-</dt> <dd>
-
-The device is not ready.
-
-</dd> <dt>
-
-<span id="Not_Configured"></span><span id="not_configured"></span><span id="NOT_CONFIGURED"></span>
-
-<span id="Not_Configured"></span><span id="not_configured"></span><span id="NOT_CONFIGURED"></span>**Not Configured** (20)
-
-
-</dt> <dd>
-
-The device is not configured.
-
-</dd> <dt>
-
-<span id="Quiesced"></span><span id="quiesced"></span><span id="QUIESCED"></span>
-
-<span id="Quiesced"></span><span id="quiesced"></span><span id="QUIESCED"></span>**Quiesced** (21)
-
-
-</dt> <dd>
-
-The device is quiet.
-
-</dd> </dl>
-
-</dd> <dt>
-
-**Caption**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MaxLen**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) (64), [**DisplayName**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Caption")
-</dt> </dl>
-
+This value comes from the <b>Asset Tag</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+
+<b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.
+  </dd>
+  <dt><b>Availability</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Operational State\|003.5", "MIB.IETF\|HOST-RESOURCES-MIB.hrDeviceStatus")</dt>
+    </dl>
+    <dl>Availability and status of the device.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).
+      <dt><b>Other</b> (1)</dt>
+      <dt><b>Unknown</b> (2)</dt>
+      <dt><b>Running/Full Power</b> (3)</dt>
+      <dd>Running or Full Power</dd>
+      <dt><b>Warning</b> (4)</dt>
+      <dt><b>In Test</b> (5)</dt>
+      <dt><b>Not Applicable</b> (6)</dt>
+      <dt><b>Power Off</b> (7)</dt>
+      <dt><b>Off Line</b> (8)</dt>
+      <dt><b>Off Duty</b> (9)</dt>
+      <dt><b>Degraded</b> (10)</dt>
+      <dt><b>Not Installed</b> (11)</dt>
+      <dt><b>Install Error</b> (12)</dt>
+      <dt><b>Power Save - Unknown</b> (13)</dt>
+      <dd>The device is known to be in a power save state, but its exact status is unknown.</dd>
+      <dt><b>Power Save - Low Power Mode</b> (14)</dt>
+      <dd>The device is in a power save state, but is still functioning, and may exhibit decreased performance.</dd>
+      <dt><b>Power Save - Standby</b> (15)</dt>
+      <dd>The device is not functioning, but can be brought to full power quickly.</dd>
+      <dt><b>Power Cycle</b> (16)</dt>
+      <dt><b>Power Save - Warning</b> (17)</dt>
+      <dd>The device is in a warning state, though also in a power save state.</dd>
+      <dt><b>Paused</b> (18)</dt>
+      <dd>The device is paused.</dd>
+      <dt><b>Not Ready</b> (19)</dt>
+      <dd>The device is not ready.</dd>
+      <dt><b>Not Configured</b> (20)</dt>
+      <dd>The device is not configured.</dd>
+      <dt><b>Quiesced</b> (21)</dt>
+      <dd>The device is quiet.</dd>
+    </dl>
+  </dd>
+  <dt><b>Caption</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MaxLen</b>][1] (64), [<b>DisplayName</b>][1] ("Caption")</dt>
+    </dl>
 Short description of an object (a one-line string).
 
-This property is inherited from [**CIM\_ManagedSystemElement**](cim-managedsystemelement.md).
-
-</dd> <dt>
-
-**Characteristics**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Characteristics")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_ManagedSystemElement</b>](cim-managedsystemelement.md).
+  </dd>
+  <dt><b>Characteristics</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Characteristics")</dt>
+    </dl>
 Defines which functions the processor supports.
 
-This value comes from the **Processor Characteristics** member of the **Processor Information** structure in the SMBIOS information.
-
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**ConfigManagerErrorCode**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Schema**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Win32")
-</dt> </dl>
-
-Windows API Configuration Manager error code.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-<dt>
-
-<span id="This_device_is_working_properly."></span><span id="this_device_is_working_properly."></span><span id="THIS_DEVICE_IS_WORKING_PROPERLY."></span>
-
-<span id="this_device_is_working_properly."></span><span id="THIS_DEVICE_IS_WORKING_PROPERLY."></span>**This device is working properly.** (0)
-
-
-</dt> <dd>
-
-Device is working properly.
-
-</dd> <dt>
-
-<span id="This_device_is_not_configured_correctly."></span><span id="this_device_is_not_configured_correctly."></span><span id="THIS_DEVICE_IS_NOT_CONFIGURED_CORRECTLY."></span>
-
-<span id="this_device_is_not_configured_correctly."></span><span id="THIS_DEVICE_IS_NOT_CONFIGURED_CORRECTLY."></span>**This device is not configured correctly.** (1)
-
-
-</dt> <dd>
-
-Device is not configured correctly.
-
-</dd> <dt>
-
-<span id="Windows_cannot_load_the_driver_for_this_device."></span><span id="windows_cannot_load_the_driver_for_this_device."></span><span id="WINDOWS_CANNOT_LOAD_THE_DRIVER_FOR_THIS_DEVICE."></span>
-
-<span id="windows_cannot_load_the_driver_for_this_device."></span><span id="WINDOWS_CANNOT_LOAD_THE_DRIVER_FOR_THIS_DEVICE."></span>**Windows cannot load the driver for this device.** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="The_driver_for_this_device_might_be_corrupted__or_your_system_may_be_running_low_on_memory_or_other_resources."></span><span id="the_driver_for_this_device_might_be_corrupted__or_your_system_may_be_running_low_on_memory_or_other_resources."></span><span id="THE_DRIVER_FOR_THIS_DEVICE_MIGHT_BE_CORRUPTED__OR_YOUR_SYSTEM_MAY_BE_RUNNING_LOW_ON_MEMORY_OR_OTHER_RESOURCES."></span>
-
-<span id="the_driver_for_this_device_might_be_corrupted__or_your_system_may_be_running_low_on_memory_or_other_resources."></span><span id="THE_DRIVER_FOR_THIS_DEVICE_MIGHT_BE_CORRUPTED__OR_YOUR_SYSTEM_MAY_BE_RUNNING_LOW_ON_MEMORY_OR_OTHER_RESOURCES."></span>**The driver for this device might be corrupted, or your system may be running low on memory or other resources.** (3)
-
-
-</dt> <dd>
-
-Driver for this device might be corrupted or the system may be low on memory or other resources.
-
-</dd> <dt>
-
-<span id="This_device_is_not_working_properly._One_of_its_drivers_or_your_registry_might_be_corrupted."></span><span id="this_device_is_not_working_properly._one_of_its_drivers_or_your_registry_might_be_corrupted."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY._ONE_OF_ITS_DRIVERS_OR_YOUR_REGISTRY_MIGHT_BE_CORRUPTED."></span>
-
-<span id="This_device_is_not_working_properly._One_of_its_drivers_or_your_registry_might_be_corrupted."></span><span id="this_device_is_not_working_properly._one_of_its_drivers_or_your_registry_might_be_corrupted."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY._ONE_OF_ITS_DRIVERS_OR_YOUR_REGISTRY_MIGHT_BE_CORRUPTED."></span>**This device is not working properly. One of its drivers or your registry might be corrupted.** (4)
-
-
-</dt> <dd>
-
-Device is not working properly. One of its drivers or the registry might be corrupted.
-
-</dd> <dt>
-
-<span id="The_driver_for_this_device_needs_a_resource_that_Windows_cannot_manage."></span><span id="the_driver_for_this_device_needs_a_resource_that_windows_cannot_manage."></span><span id="THE_DRIVER_FOR_THIS_DEVICE_NEEDS_A_RESOURCE_THAT_WINDOWS_CANNOT_MANAGE."></span>
-
-<span id="the_driver_for_this_device_needs_a_resource_that_windows_cannot_manage."></span><span id="THE_DRIVER_FOR_THIS_DEVICE_NEEDS_A_RESOURCE_THAT_WINDOWS_CANNOT_MANAGE."></span>**The driver for this device needs a resource that Windows cannot manage.** (5)
-
-
-</dt> <dd>
-
-Driver for the device requires a resource that Windows cannot manage.
-
-</dd> <dt>
-
-<span id="The_boot_configuration_for_this_device_conflicts_with_other_devices."></span><span id="the_boot_configuration_for_this_device_conflicts_with_other_devices."></span><span id="THE_BOOT_CONFIGURATION_FOR_THIS_DEVICE_CONFLICTS_WITH_OTHER_DEVICES."></span>
-
-<span id="the_boot_configuration_for_this_device_conflicts_with_other_devices."></span><span id="THE_BOOT_CONFIGURATION_FOR_THIS_DEVICE_CONFLICTS_WITH_OTHER_DEVICES."></span>**The boot configuration for this device conflicts with other devices.** (6)
-
-
-</dt> <dd>
-
-Boot configuration for the device conflicts with other devices.
-
-</dd> <dt>
-
-<span id="Cannot_filter."></span><span id="cannot_filter."></span><span id="CANNOT_FILTER."></span>
-
-<span id="cannot_filter."></span><span id="CANNOT_FILTER."></span>**Cannot filter.** (7)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="The_driver_loader_for_the_device_is_missing."></span><span id="the_driver_loader_for_the_device_is_missing."></span><span id="THE_DRIVER_LOADER_FOR_THE_DEVICE_IS_MISSING."></span>
-
-<span id="the_driver_loader_for_the_device_is_missing."></span><span id="THE_DRIVER_LOADER_FOR_THE_DEVICE_IS_MISSING."></span>**The driver loader for the device is missing.** (8)
-
-
-</dt> <dd>
-
-Driver loader for the device is missing.
-
-</dd> <dt>
-
-<span id="This_device_is_not_working_properly_because_the_controlling_firmware_is_reporting_the_resources_for_the_device_incorrectly."></span><span id="this_device_is_not_working_properly_because_the_controlling_firmware_is_reporting_the_resources_for_the_device_incorrectly."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_THE_CONTROLLING_FIRMWARE_IS_REPORTING_THE_RESOURCES_FOR_THE_DEVICE_INCORRECTLY."></span>
-
-<span id="this_device_is_not_working_properly_because_the_controlling_firmware_is_reporting_the_resources_for_the_device_incorrectly."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_THE_CONTROLLING_FIRMWARE_IS_REPORTING_THE_RESOURCES_FOR_THE_DEVICE_INCORRECTLY."></span>**This device is not working properly because the controlling firmware is reporting the resources for the device incorrectly.** (9)
-
-
-</dt> <dd>
-
-Device is not working properly. The controlling firmware is incorrectly reporting the resources for the device.
-
-</dd> <dt>
-
-<span id="This_device_cannot_start."></span><span id="this_device_cannot_start."></span><span id="THIS_DEVICE_CANNOT_START."></span>
-
-<span id="this_device_cannot_start."></span><span id="THIS_DEVICE_CANNOT_START."></span>**This device cannot start.** (10)
-
-
-</dt> <dd>
-
-Device cannot start.
-
-</dd> <dt>
-
-<span id="This_device_failed."></span><span id="this_device_failed."></span><span id="THIS_DEVICE_FAILED."></span>
-
-<span id="this_device_failed."></span><span id="THIS_DEVICE_FAILED."></span>**This device failed.** (11)
-
-
-</dt> <dd>
-
-Device failed.
-
-</dd> <dt>
-
-<span id="This_device_cannot_find_enough_free_resources_that_it_can_use."></span><span id="this_device_cannot_find_enough_free_resources_that_it_can_use."></span><span id="THIS_DEVICE_CANNOT_FIND_ENOUGH_FREE_RESOURCES_THAT_IT_CAN_USE."></span>
-
-<span id="this_device_cannot_find_enough_free_resources_that_it_can_use."></span><span id="THIS_DEVICE_CANNOT_FIND_ENOUGH_FREE_RESOURCES_THAT_IT_CAN_USE."></span>**This device cannot find enough free resources that it can use.** (12)
-
-
-</dt> <dd>
-
-Device cannot find enough free resources to use.
-
-</dd> <dt>
-
-<span id="Windows_cannot_verify_this_device_s_resources."></span><span id="windows_cannot_verify_this_device_s_resources."></span><span id="WINDOWS_CANNOT_VERIFY_THIS_DEVICE_S_RESOURCES."></span>
-
-<span id="windows_cannot_verify_this_device_s_resources."></span><span id="WINDOWS_CANNOT_VERIFY_THIS_DEVICE_S_RESOURCES."></span>**Windows cannot verify this device's resources.** (13)
-
-
-</dt> <dd>
-
-Windows cannot verify the device's resources.
-
-</dd> <dt>
-
-<span id="This_device_cannot_work_properly_until_you_restart_your_computer."></span><span id="this_device_cannot_work_properly_until_you_restart_your_computer."></span><span id="THIS_DEVICE_CANNOT_WORK_PROPERLY_UNTIL_YOU_RESTART_YOUR_COMPUTER."></span>
-
-<span id="this_device_cannot_work_properly_until_you_restart_your_computer."></span><span id="THIS_DEVICE_CANNOT_WORK_PROPERLY_UNTIL_YOU_RESTART_YOUR_COMPUTER."></span>**This device cannot work properly until you restart your computer.** (14)
-
-
-</dt> <dd>
-
-Device cannot work properly until the computer is restarted.
-
-</dd> <dt>
-
-<span id="This_device_is_not_working_properly_because_there_is_probably_a_re-enumeration_problem."></span><span id="this_device_is_not_working_properly_because_there_is_probably_a_re-enumeration_problem."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_THERE_IS_PROBABLY_A_RE-ENUMERATION_PROBLEM."></span>
-
-<span id="This_device_is_not_working_properly_because_there_is_probably_a_re-enumeration_problem."></span><span id="this_device_is_not_working_properly_because_there_is_probably_a_re-enumeration_problem."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_THERE_IS_PROBABLY_A_RE-ENUMERATION_PROBLEM."></span>**This device is not working properly because there is probably a re-enumeration problem.** (15)
-
-
-</dt> <dd>
-
-Device is not working properly due to a possible re-enumeration problem.
-
-</dd> <dt>
-
-<span id="Windows_cannot_identify_all_the_resources_this_device_uses."></span><span id="windows_cannot_identify_all_the_resources_this_device_uses."></span><span id="WINDOWS_CANNOT_IDENTIFY_ALL_THE_RESOURCES_THIS_DEVICE_USES."></span>
-
-<span id="windows_cannot_identify_all_the_resources_this_device_uses."></span><span id="WINDOWS_CANNOT_IDENTIFY_ALL_THE_RESOURCES_THIS_DEVICE_USES."></span>**Windows cannot identify all the resources this device uses.** (16)
-
-
-</dt> <dd>
-
-Windows cannot identify all of the resources that the device uses.
-
-</dd> <dt>
-
-<span id="This_device_is_asking_for_an_unknown_resource_type."></span><span id="this_device_is_asking_for_an_unknown_resource_type."></span><span id="THIS_DEVICE_IS_ASKING_FOR_AN_UNKNOWN_RESOURCE_TYPE."></span>
-
-<span id="this_device_is_asking_for_an_unknown_resource_type."></span><span id="THIS_DEVICE_IS_ASKING_FOR_AN_UNKNOWN_RESOURCE_TYPE."></span>**This device is asking for an unknown resource type.** (17)
-
-
-</dt> <dd>
-
-Device is requesting an unknown resource type.
-
-</dd> <dt>
-
-<span id="Reinstall_the_drivers_for_this_device."></span><span id="reinstall_the_drivers_for_this_device."></span><span id="REINSTALL_THE_DRIVERS_FOR_THIS_DEVICE."></span>
-
-<span id="reinstall_the_drivers_for_this_device."></span><span id="REINSTALL_THE_DRIVERS_FOR_THIS_DEVICE."></span>**Reinstall the drivers for this device.** (18)
-
-
-</dt> <dd>
-
-Device drivers must be reinstalled.
-
-</dd> <dt>
-
-<span id="Failure_using_the_VxD_loader."></span><span id="failure_using_the_vxd_loader."></span><span id="FAILURE_USING_THE_VXD_LOADER."></span>
-
-<span id="failure_using_the_vxd_loader."></span><span id="FAILURE_USING_THE_VXD_LOADER."></span>**Failure using the VxD loader.** (19)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Your_registry_might_be_corrupted."></span><span id="your_registry_might_be_corrupted."></span><span id="YOUR_REGISTRY_MIGHT_BE_CORRUPTED."></span>
-
-<span id="your_registry_might_be_corrupted."></span><span id="YOUR_REGISTRY_MIGHT_BE_CORRUPTED."></span>**Your registry might be corrupted.** (20)
-
-
-</dt> <dd>
-
-Registry might be corrupted.
-
-</dd> <dt>
-
-<span id="System_failure__Try_changing_the_driver_for_this_device._If_that_does_not_work__see_your_hardware_documentation._Windows_is_removing_this_device."></span><span id="system_failure__try_changing_the_driver_for_this_device._if_that_does_not_work__see_your_hardware_documentation._windows_is_removing_this_device."></span><span id="SYSTEM_FAILURE__TRY_CHANGING_THE_DRIVER_FOR_THIS_DEVICE._IF_THAT_DOES_NOT_WORK__SEE_YOUR_HARDWARE_DOCUMENTATION._WINDOWS_IS_REMOVING_THIS_DEVICE."></span>
-
-<span id="System_failure__Try_changing_the_driver_for_this_device._If_that_does_not_work__see_your_hardware_documentation._Windows_is_removing_this_device."></span><span id="system_failure__try_changing_the_driver_for_this_device._if_that_does_not_work__see_your_hardware_documentation._windows_is_removing_this_device."></span><span id="SYSTEM_FAILURE__TRY_CHANGING_THE_DRIVER_FOR_THIS_DEVICE._IF_THAT_DOES_NOT_WORK__SEE_YOUR_HARDWARE_DOCUMENTATION._WINDOWS_IS_REMOVING_THIS_DEVICE."></span>**System failure: Try changing the driver for this device. If that does not work, see your hardware documentation. Windows is removing this device.** (21)
-
-
-</dt> <dd>
-
-System failure. If changing the device driver is ineffective, see the hardware documentation. Windows is removing the device.
-
-</dd> <dt>
-
-<span id="This_device_is_disabled."></span><span id="this_device_is_disabled."></span><span id="THIS_DEVICE_IS_DISABLED."></span>
-
-<span id="this_device_is_disabled."></span><span id="THIS_DEVICE_IS_DISABLED."></span>**This device is disabled.** (22)
-
-
-</dt> <dd>
-
-Device is disabled.
-
-</dd> <dt>
-
-<span id="System_failure__Try_changing_the_driver_for_this_device._If_that_doesn_t_work__see_your_hardware_documentation."></span><span id="system_failure__try_changing_the_driver_for_this_device._if_that_doesn_t_work__see_your_hardware_documentation."></span><span id="SYSTEM_FAILURE__TRY_CHANGING_THE_DRIVER_FOR_THIS_DEVICE._IF_THAT_DOESN_T_WORK__SEE_YOUR_HARDWARE_DOCUMENTATION."></span>
-
-<span id="System_failure__Try_changing_the_driver_for_this_device._If_that_doesn_t_work__see_your_hardware_documentation."></span><span id="system_failure__try_changing_the_driver_for_this_device._if_that_doesn_t_work__see_your_hardware_documentation."></span><span id="SYSTEM_FAILURE__TRY_CHANGING_THE_DRIVER_FOR_THIS_DEVICE._IF_THAT_DOESN_T_WORK__SEE_YOUR_HARDWARE_DOCUMENTATION."></span>**System failure: Try changing the driver for this device. If that doesn't work, see your hardware documentation.** (23)
-
-
-</dt> <dd>
-
-System failure. If changing the device driver is ineffective, see the hardware documentation.
-
-</dd> <dt>
-
-<span id="This_device_is_not_present__is_not_working_properly__or_does_not_have_all_its_drivers_installed."></span><span id="this_device_is_not_present__is_not_working_properly__or_does_not_have_all_its_drivers_installed."></span><span id="THIS_DEVICE_IS_NOT_PRESENT__IS_NOT_WORKING_PROPERLY__OR_DOES_NOT_HAVE_ALL_ITS_DRIVERS_INSTALLED."></span>
-
-<span id="this_device_is_not_present__is_not_working_properly__or_does_not_have_all_its_drivers_installed."></span><span id="THIS_DEVICE_IS_NOT_PRESENT__IS_NOT_WORKING_PROPERLY__OR_DOES_NOT_HAVE_ALL_ITS_DRIVERS_INSTALLED."></span>**This device is not present, is not working properly, or does not have all its drivers installed.** (24)
-
-
-</dt> <dd>
-
-Device is not present, not working properly, or does not have all of its drivers installed.
-
-</dd> <dt>
-
-<span id="Windows_is_still_setting_up_this_device."></span><span id="windows_is_still_setting_up_this_device."></span><span id="WINDOWS_IS_STILL_SETTING_UP_THIS_DEVICE."></span>
-
-<span id="windows_is_still_setting_up_this_device."></span><span id="WINDOWS_IS_STILL_SETTING_UP_THIS_DEVICE."></span>**Windows is still setting up this device.** (25)
-
-
-</dt> <dd>
-
-Windows is still setting up the device.
-
-</dd> <dt>
-
-<span id="Windows_is_still_setting_up_this_device."></span><span id="windows_is_still_setting_up_this_device."></span><span id="WINDOWS_IS_STILL_SETTING_UP_THIS_DEVICE."></span>
-
-<span id="windows_is_still_setting_up_this_device."></span><span id="WINDOWS_IS_STILL_SETTING_UP_THIS_DEVICE."></span>**Windows is still setting up this device.** (26)
-
-
-</dt> <dd>
-
-Windows is still setting up the device.
-
-</dd> <dt>
-
-<span id="This_device_does_not_have_valid_log_configuration."></span><span id="this_device_does_not_have_valid_log_configuration."></span><span id="THIS_DEVICE_DOES_NOT_HAVE_VALID_LOG_CONFIGURATION."></span>
-
-<span id="this_device_does_not_have_valid_log_configuration."></span><span id="THIS_DEVICE_DOES_NOT_HAVE_VALID_LOG_CONFIGURATION."></span>**This device does not have valid log configuration.** (27)
-
-
-</dt> <dd>
-
-Device does not have valid log configuration.
-
-</dd> <dt>
-
-<span id="The_drivers_for_this_device_are_not_installed."></span><span id="the_drivers_for_this_device_are_not_installed."></span><span id="THE_DRIVERS_FOR_THIS_DEVICE_ARE_NOT_INSTALLED."></span>
-
-<span id="the_drivers_for_this_device_are_not_installed."></span><span id="THE_DRIVERS_FOR_THIS_DEVICE_ARE_NOT_INSTALLED."></span>**The drivers for this device are not installed.** (28)
-
-
-</dt> <dd>
-
-Device drivers are not installed.
-
-</dd> <dt>
-
-<span id="This_device_is_disabled_because_the_firmware_of_the_device_did_not_give_it_the_required_resources."></span><span id="this_device_is_disabled_because_the_firmware_of_the_device_did_not_give_it_the_required_resources."></span><span id="THIS_DEVICE_IS_DISABLED_BECAUSE_THE_FIRMWARE_OF_THE_DEVICE_DID_NOT_GIVE_IT_THE_REQUIRED_RESOURCES."></span>
-
-<span id="this_device_is_disabled_because_the_firmware_of_the_device_did_not_give_it_the_required_resources."></span><span id="THIS_DEVICE_IS_DISABLED_BECAUSE_THE_FIRMWARE_OF_THE_DEVICE_DID_NOT_GIVE_IT_THE_REQUIRED_RESOURCES."></span>**This device is disabled because the firmware of the device did not give it the required resources.** (29)
-
-
-</dt> <dd>
-
-Device is disabled. The device firmware did not provide the required resources.
-
-</dd> <dt>
-
-<span id="This_device_is_using_an_Interrupt_Request__IRQ__resource_that_another_device_is_using."></span><span id="this_device_is_using_an_interrupt_request__irq__resource_that_another_device_is_using."></span><span id="THIS_DEVICE_IS_USING_AN_INTERRUPT_REQUEST__IRQ__RESOURCE_THAT_ANOTHER_DEVICE_IS_USING."></span>
-
-<span id="this_device_is_using_an_interrupt_request__irq__resource_that_another_device_is_using."></span><span id="THIS_DEVICE_IS_USING_AN_INTERRUPT_REQUEST__IRQ__RESOURCE_THAT_ANOTHER_DEVICE_IS_USING."></span>**This device is using an Interrupt Request (IRQ) resource that another device is using.** (30)
-
-
-</dt> <dd>
-
-Device is using an IRQ resource that another device is using.
-
-</dd> <dt>
-
-<span id="This_device_is_not_working_properly_because_Windows_cannot_load_the_drivers_required_for_this_device."></span><span id="this_device_is_not_working_properly_because_windows_cannot_load_the_drivers_required_for_this_device."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_WINDOWS_CANNOT_LOAD_THE_DRIVERS_REQUIRED_FOR_THIS_DEVICE."></span>
-
-<span id="this_device_is_not_working_properly_because_windows_cannot_load_the_drivers_required_for_this_device."></span><span id="THIS_DEVICE_IS_NOT_WORKING_PROPERLY_BECAUSE_WINDOWS_CANNOT_LOAD_THE_DRIVERS_REQUIRED_FOR_THIS_DEVICE."></span>**This device is not working properly because Windows cannot load the drivers required for this device.** (31)
-
-
-</dt> <dd>
-
-Device is not working properly. Windows cannot load the required device drivers.
-
-</dd> </dl>
-
-</dd> <dt>
-
-**ConfigManagerUserConfig**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Schema**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Win32")
-</dt> </dl>
-
-If **TRUE**, the device is using a configuration that the user defines.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**CpuStatus**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Status")
-</dt> </dl>
-
-Current status of the processor. Status changes indicate processor usage, but not the physical condition of the processor.
-
-This value comes from the **Status** member of the **Processor Information** structure in the SMBIOS information.
-
-<dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-**Unknown** (0)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="CPU_Enabled"></span><span id="cpu_enabled"></span><span id="CPU_ENABLED"></span>
-
-**CPU Enabled** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="CPU_Disabled_by_User_via_BIOS_Setup"></span><span id="cpu_disabled_by_user_via_bios_setup"></span><span id="CPU_DISABLED_BY_USER_VIA_BIOS_SETUP"></span>
-
-**CPU Disabled by User via BIOS Setup** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="CPU_Disabled_By_BIOS__POST_Error_"></span><span id="cpu_disabled_by_bios__post_error_"></span><span id="CPU_DISABLED_BY_BIOS__POST_ERROR_"></span>
-
-**CPU Disabled By BIOS (POST Error)** (3)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="CPU_is_Idle"></span><span id="cpu_is_idle"></span><span id="CPU_IS_IDLE"></span>
-
-**CPU is Idle** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved"></span><span id="reserved"></span><span id="RESERVED"></span>
-
-**Reserved** (5)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved"></span><span id="reserved"></span><span id="RESERVED"></span>
-
-**Reserved** (6)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-**Other** (7)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**CreationClassName**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**CIM\_Key**](https://msdn.microsoft.com/library/Aa393651(v=VS.85).aspx)
-</dt> </dl>
-
+This value comes from the <b>Processor Characteristics</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+
+<b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.
+  </dd>
+  <dt><b>ConfigManagerErrorCode</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Schema</b>][1] ("Win32")</dt>
+    </dl>
+    <dl>Windows API Configuration Manager error code.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).
+      <dt><b>This device is working properly.</b> (0)</dt>
+      <dd>
+Device is working properly.</dd>
+      <dt><b>This device is not configured correctly.</b> (1)</dt>
+      <dd>Device is not configured correctly.</dd>
+      <dt><b>Windows cannot load the driver for this device.</b> (2)</dt>
+      <dt><b>The driver for this device might be corrupted, or your system may be running low on memory or other resources.</b> (3)</dt>
+      <dd>Driver for this device might be corrupted or the system may be low on memory or other resources.</dd>
+      <dt><b>This device is not working properly. One of its drivers or your registry might be corrupted.</b> (4)</dt>
+      <dd>Device is not working properly. One of its drivers or the registry might be corrupted.</dd>
+      <dt><b>The driver for this device needs a resource that Windows cannot manage.</b> (5)</dt>
+      <dd>Driver for the device requires a resource that Windows cannot manage.</dd>
+      <dt><b>The boot configuration for this device conflicts with other devices.</b> (6)</dt>
+      <dd>Boot configuration for the device conflicts with other devices.</dd>
+      <dt><b>Cannot filter.</b> (7)</dt>
+      <dt><b>The driver loader for the device is missing.</b> (8)</dt>
+      <dd>Driver loader for the device is missing.</dd>
+      <dt><b>This device is not working properly because the controlling firmware is reporting the resources for the device incorrectly.</b> (9)</dt>
+      <dd>Device is not working properly. The controlling firmware is incorrectly reporting the resources for the device.</dd>
+      <dt><b>This device cannot start.</b> (10)</dt>
+      <dd>Device cannot start.</dd>
+      <dt><b>This device failed.</b> (11)</dt>
+      <dd>Device failed.</dd>
+      <dt><b>This device cannot find enough free resources that it can use.</b> (12)</dt>
+      <dd>Device cannot find enough free resources to use.</dd>
+      <dt><b>Windows cannot verify this device's resources.</b> (13)</dt>
+      <dd>Windows cannot verify the device's resources.</dd>
+      <dt><b>This device cannot work properly until you restart your computer.</b> (14)</dt>
+      <dd>Device cannot work properly until the computer is restarted.</dd>
+      <dt><b>This device is not working properly because there is probably a re-enumeration problem.</b> (15)</dt>
+      <dd>Device is not working properly due to a possible re-enumeration problem.</dd>
+      <dt><b>Windows cannot identify all the resources this device uses.</b> (16)</dt>
+      <dd>Windows cannot identify all of the resources that the device uses.</dd>
+      <dt><b>This device is asking for an unknown resource type.</b> (17)</dt>
+      <dd>Device is requesting an unknown resource type.</dd>
+      <dt><b>Reinstall the drivers for this device.</b> (18)</dt>
+      <dd>Device drivers must be reinstalled.</dd>
+      <dt><b>Failure using the VxD loader.</b> (19)</dt>
+      <dt><b>Your registry might be corrupted.</b> (20)</dt>
+      <dd>Registry might be corrupted.</dd>
+      <dt><b>System failure: Try changing the driver for this device. If that does not work, see your hardware documentation. Windows is removing this device.</b> (21)</dt>
+      <dd>System failure. If changing the device driver is ineffective, see the hardware documentation. Windows is removing the device.</dd>
+      <dt><b>This device is disabled.</b> (22)</dt>
+      <dd>Device is disabled.</dd>
+      <dt><b>System failure: Try changing the driver for this device. If that doesn't work, see your hardware documentation.</b> (23)</dt>
+      <dd>System failure. If changing the device driver is ineffective, see the hardware documentation.</dd>
+      <dt><b>This device is not present, is not working properly, or does not have all its drivers installed.</b> (24)</dt>
+      <dd>Device is not present, not working properly, or does not have all of its drivers installed.</dd>
+      <dt><b>Windows is still setting up this device.</b> (25)</dt>
+      <dd>Windows is still setting up the device.</dd>
+      <dt><b>Windows is still setting up this device.</b> (26)</dt>
+      <dd>Windows is still setting up the device.</dd>
+      <dt><b>This device does not have valid log configuration.</b> (27)</dt>
+      <dd>Device does not have valid log configuration.</dd>
+      <dt><b>The drivers for this device are not installed.</b> (28)</dt>
+      <dd>Device drivers are not installed.</dd>
+      <dt><b>This device is disabled because the firmware of the device did not give it the required resources.</b> (29)</dt>
+      <dd>Device is disabled. The device firmware did not provide the required resources.</dd>
+      <dt><b>This device is using an Interrupt Request (IRQ) resource that another device is using.</b> (30)</dt>
+      <dd>Device is using an IRQ resource that another device is using.</dd>
+      <dt><b>This device is not working properly because Windows cannot load the drivers required for this device.</b> (31)</dt>
+      <dd>Device is not working properly. Windows cannot load the required device drivers.</dd>
+    </dl>
+  </dd>
+  <dt><b>ConfigManagerUserConfig</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Schema</b>][1] ("Win32")</dt>
+    </dl>
+If <b>TRUE</b>, the device is using a configuration that the user defines.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>CpuStatus</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Status")</dt>
+    </dl>
+    <dl>Current status of the processor. Status changes indicate processor usage, but not the physical condition of the processor.
+
+This value comes from the <b>Status</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+      <dt><b>Unknown</b> (0)</dt>
+      <dt><b>CPU Enabled</b> (1)</dt>
+      <dt><b>CPU Disabled by User via BIOS Setup</b> (2)</dt>
+      <dt><b>CPU Disabled By BIOS (POST Error)</b> (3)</dt>
+      <dt><b>CPU is Idle</b> (4)</dt>
+      <dt><b>Reserved</b> (5)</dt>
+      <dt><b>Reserved</b> (6)</dt>
+      <dt><b>Other</b> (7)</dt>
+    </dl></dd>
+  <dt><b>CreationClassName</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>CIM_Key</b>][2]</dt>
+    </dl>
 Name of the first concrete class that appears in the inheritance chain used to create an instance. When used with the other key properties of the class, the property allows all instances of this class and its subclasses to be identified uniquely.
 
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**CurrentClockSpeed**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Processor\|006.6"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("megahertz")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>CurrentClockSpeed</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Processor\|006.6"), [<b>Units</b>][1] ("megahertz")</dt>
+    </dl>
 Current speed of the processor, in MHz.
+This value comes from the <b>Current Speed</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
 
-This value comes from the **Current Speed** member of the **Processor Information** structure in the SMBIOS information.
-
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**CurrentVoltage**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Voltage"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("tenth-volts")
-</dt> </dl>
-
-Voltage of the processor. If the eighth bit is set, bits 0-6 contain the voltage multiplied by 10. If the eighth bit is not set, then the bit setting in **VoltageCaps** represents the voltage value. **CurrentVoltage** is only set when SMBIOS designates a voltage value.
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>CurrentVoltage</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Voltage"), [<b>Units</b>][1] ("tenth-volts")</dt>
+    </dl>
+Voltage of the processor. If the eighth bit is set, bits 0-6 contain the voltage multiplied by 10. If the eighth bit is not set, then the bit setting in <b>VoltageCaps</b> represents the voltage value. <b>CurrentVoltage</b> is only set when SMBIOS designates a voltage value.
 
 Example: Value for a processor voltage of 1.8 volts is 0x12 (1.8 x 10).
 
-This value comes from the **Voltage** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**DataWidth**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("bits")
-</dt> </dl>
-
+This value comes from the <b>Voltage</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>DataWidth</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Units</b>][1] ("bits")</dt>
+    </dl>
 On a 32-bit processor, the value is 32 and on a 64-bit processor it is 64.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**Description**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**DisplayName**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Description")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>Description</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>DisplayName</b>][1] ("Description")</dt>
+    </dl>
 Description of the object.
 
-This property is inherited from [**CIM\_ManagedSystemElement**](cim-managedsystemelement.md).
-
-</dd> <dt>
-
-**DeviceID**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Key**](https://msdn.microsoft.com/library/Aa392157(v=VS.85).aspx), [**Override**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("DeviceId"), [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Win32API\|System Information Structures\|[**SYSTEM\_INFO**](https://msdn.microsoft.com/library/ms724958(v=VS.85).aspx)\|dwNumberOfProcessors")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_ManagedSystemElement</b>](cim-managedsystemelement.md).</dd>
+  <dt><b>DeviceID</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Key</b>][3], [<b>Override</b>][1] ("DeviceId"), [<b>MappingStrings</b>][1] ("Win32API\|System Information Structures\|[<b>SYSTEM_INFO</b>][4]\|dwNumberOfProcessors")</dt>
+    </dl>
 Unique identifier of a processor on the system.
 
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**ErrorCleared**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
-If **TRUE**, the error reported in **LastErrorCode** is clear.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**ErrorDescription**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
-More information about the error recorded in **LastErrorCode**, and information about corrective actions that can be taken.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**ExtClock**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|External Clock"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("megahertz")
-</dt> </dl>
-
-External clock frequency, in MHz. If the frequency is unknown, this property is set to **NULL**.
-
-This value comes from the **External Clock** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**Family**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Processor\|014.3"), [**ModelCorrespondence**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("[**CIM\_Processor**](cim-processor.md).**OtherFamilyDescription**")
-</dt> </dl>
-
-Processor family type.
-
-This value comes from the **Processor Information** structure in the SMBIOS version information. For SMBIOS versions 2.0 thru 2.5 the value comes from the **Processor Family** member. For SMBIOS version 2.6+ the value comes from the **Processor Family 2** member.
-
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-<dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-**Other** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-**Unknown** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="8086"></span>
-
-**8086** (3)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80286"></span>
-
-**80286** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80386"></span>
-
-**80386** (5)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80486"></span>
-
-**80486** (6)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="8087"></span>
-
-**8087** (7)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80287"></span>
-
-**80287** (8)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80387"></span>
-
-**80387** (9)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="80487"></span>
-
-**80487** (10)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__brand"></span><span id="pentium_r__brand"></span><span id="PENTIUM_R__BRAND"></span>
-
-**Pentium(R) brand** (11)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__Pro"></span><span id="pentium_r__pro"></span><span id="PENTIUM_R__PRO"></span>
-
-**Pentium(R) Pro** (12)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__II"></span><span id="pentium_r__ii"></span><span id="PENTIUM_R__II"></span>
-
-**Pentium(R) II** (13)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__processor_with_MMX_TM__technology"></span><span id="pentium_r__processor_with_mmx_tm__technology"></span><span id="PENTIUM_R__PROCESSOR_WITH_MMX_TM__TECHNOLOGY"></span>
-
-**Pentium(R) processor with MMX(TM) technology** (14)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Celeron_TM_"></span><span id="celeron_tm_"></span><span id="CELERON_TM_"></span>
-
-**Celeron(TM)** (15)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__II_Xeon_TM_"></span><span id="pentium_r__ii_xeon_tm_"></span><span id="PENTIUM_R__II_XEON_TM_"></span>
-
-**Pentium(R) II Xeon(TM)** (16)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__III"></span><span id="pentium_r__iii"></span><span id="PENTIUM_R__III"></span>
-
-**Pentium(R) III** (17)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="M1_Family"></span><span id="m1_family"></span><span id="M1_FAMILY"></span>
-
-**M1 Family** (18)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="M2_Family"></span><span id="m2_family"></span><span id="M2_FAMILY"></span>
-
-**M2 Family** (19)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Celeron_R__M_processor"></span><span id="intel_r__celeron_r__m_processor"></span><span id="INTEL_R__CELERON_R__M_PROCESSOR"></span>
-
-**Intel(R) Celeron(R) M processor** (20)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Pentium_R__4_HT_processor"></span><span id="intel_r__pentium_r__4_ht_processor"></span><span id="INTEL_R__PENTIUM_R__4_HT_PROCESSOR"></span>
-
-**Intel(R) Pentium(R) 4 HT processor** (21)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K5_Family"></span><span id="k5_family"></span><span id="K5_FAMILY"></span>
-
-**K5 Family** (24)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K6_Family"></span><span id="k6_family"></span><span id="K6_FAMILY"></span>
-
-**K6 Family** (25)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K6-2"></span><span id="k6-2"></span>
-
-**K6-2** (26)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K6-3"></span><span id="k6-3"></span>
-
-**K6-3** (27)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__Processor_Family"></span><span id="amd_athlon_tm__processor_family"></span><span id="AMD_ATHLON_TM__PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) Processor Family** (28)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_R__Duron_TM__Processor"></span><span id="amd_r__duron_tm__processor"></span><span id="AMD_R__DURON_TM__PROCESSOR"></span>
-
-**AMD(R) Duron(TM) Processor** (29)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD29000_Family"></span><span id="amd29000_family"></span><span id="AMD29000_FAMILY"></span>
-
-**AMD29000 Family** (30)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K6-2_"></span><span id="k6-2_"></span>
-
-**K6-2+** (31)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_Family"></span><span id="power_pc_family"></span><span id="POWER_PC_FAMILY"></span>
-
-**Power PC Family** (32)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_601"></span><span id="power_pc_601"></span><span id="POWER_PC_601"></span>
-
-**Power PC 601** (33)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_603"></span><span id="power_pc_603"></span><span id="POWER_PC_603"></span>
-
-**Power PC 603** (34)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_603_"></span><span id="power_pc_603_"></span><span id="POWER_PC_603_"></span>
-
-**Power PC 603+** (35)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_604"></span><span id="power_pc_604"></span><span id="POWER_PC_604"></span>
-
-**Power PC 604** (36)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_620"></span><span id="power_pc_620"></span><span id="POWER_PC_620"></span>
-
-**Power PC 620** (37)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_X704"></span><span id="power_pc_x704"></span><span id="POWER_PC_X704"></span>
-
-**Power PC X704** (38)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Power_PC_750"></span><span id="power_pc_750"></span><span id="POWER_PC_750"></span>
-
-**Power PC 750** (39)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__Duo_processor"></span><span id="intel_r__core_tm__duo_processor"></span><span id="INTEL_R__CORE_TM__DUO_PROCESSOR"></span>
-
-**Intel(R) Core(TM) Duo processor** (40)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__Duo_mobile_processor"></span><span id="intel_r__core_tm__duo_mobile_processor"></span><span id="INTEL_R__CORE_TM__DUO_MOBILE_PROCESSOR"></span>
-
-**Intel(R) Core(TM) Duo mobile processor** (41)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__Solo_mobile_processor"></span><span id="intel_r__core_tm__solo_mobile_processor"></span><span id="INTEL_R__CORE_TM__SOLO_MOBILE_PROCESSOR"></span>
-
-**Intel(R) Core(TM) Solo mobile processor** (42)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Atom_TM__processor"></span><span id="intel_r__atom_tm__processor"></span><span id="INTEL_R__ATOM_TM__PROCESSOR"></span>
-
-**Intel(R) Atom(TM) processor** (43)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_Family"></span><span id="alpha_family"></span><span id="ALPHA_FAMILY"></span>
-
-**Alpha Family** (48)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21064"></span><span id="alpha_21064"></span><span id="ALPHA_21064"></span>
-
-**Alpha 21064** (49)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21066"></span><span id="alpha_21066"></span><span id="ALPHA_21066"></span>
-
-**Alpha 21066** (50)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21164"></span><span id="alpha_21164"></span><span id="ALPHA_21164"></span>
-
-**Alpha 21164** (51)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21164PC"></span><span id="alpha_21164pc"></span><span id="ALPHA_21164PC"></span>
-
-**Alpha 21164PC** (52)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21164a"></span><span id="alpha_21164a"></span><span id="ALPHA_21164A"></span>
-
-**Alpha 21164a** (53)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21264"></span><span id="alpha_21264"></span><span id="ALPHA_21264"></span>
-
-**Alpha 21264** (54)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Alpha_21364"></span><span id="alpha_21364"></span><span id="ALPHA_21364"></span>
-
-**Alpha 21364** (55)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__II_Ultra_Dual-Core_Mobile_M_Processor_Family"></span><span id="amd_turion_tm__ii_ultra_dual-core_mobile_m_processor_family"></span><span id="AMD_TURION_TM__II_ULTRA_DUAL-CORE_MOBILE_M_PROCESSOR_FAMILY"></span>
-
-**AMD Turion(TM) II Ultra Dual-Core Mobile M Processor Family** (56)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__II_Dual-Core_Mobile_M_Processor_Family"></span><span id="amd_turion_tm__ii_dual-core_mobile_m_processor_family"></span><span id="AMD_TURION_TM__II_DUAL-CORE_MOBILE_M_PROCESSOR_FAMILY"></span>
-
-**AMD Turion(TM) II Dual-Core Mobile M Processor Family** (57)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__II_Dual-Core_Mobile_M_Processor_Family"></span><span id="amd_athlon_tm__ii_dual-core_mobile_m_processor_family"></span><span id="AMD_ATHLON_TM__II_DUAL-CORE_MOBILE_M_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) II Dual-Core Mobile M Processor Family** (58)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Opteron_TM__6100_Series_Processor"></span><span id="amd_opteron_tm__6100_series_processor"></span><span id="AMD_OPTERON_TM__6100_SERIES_PROCESSOR"></span>
-
-**AMD Opteron(TM) 6100 Series Processor** (59)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Opteron_TM__4100_Series_Processor"></span><span id="amd_opteron_tm__4100_series_processor"></span><span id="AMD_OPTERON_TM__4100_SERIES_PROCESSOR"></span>
-
-**AMD Opteron(TM) 4100 Series Processor** (60)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_Family"></span><span id="mips_family"></span><span id="MIPS_FAMILY"></span>
-
-**MIPS Family** (64)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_R4000"></span><span id="mips_r4000"></span>
-
-**MIPS R4000** (65)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_R4200"></span><span id="mips_r4200"></span>
-
-**MIPS R4200** (66)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_R4400"></span><span id="mips_r4400"></span>
-
-**MIPS R4400** (67)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_R4600"></span><span id="mips_r4600"></span>
-
-**MIPS R4600** (68)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MIPS_R10000"></span><span id="mips_r10000"></span>
-
-**MIPS R10000** (69)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="SPARC_Family"></span><span id="sparc_family"></span><span id="SPARC_FAMILY"></span>
-
-**SPARC Family** (80)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="SuperSPARC"></span><span id="supersparc"></span><span id="SUPERSPARC"></span>
-
-**SuperSPARC** (81)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="microSPARC_II"></span><span id="microsparc_ii"></span><span id="MICROSPARC_II"></span>
-
-**microSPARC II** (82)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="microSPARC_IIep"></span><span id="microsparc_iiep"></span><span id="MICROSPARC_IIEP"></span>
-
-**microSPARC IIep** (83)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="UltraSPARC"></span><span id="ultrasparc"></span><span id="ULTRASPARC"></span>
-
-**UltraSPARC** (84)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="UltraSPARC_II"></span><span id="ultrasparc_ii"></span><span id="ULTRASPARC_II"></span>
-
-**UltraSPARC II** (85)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="UltraSPARC_IIi"></span><span id="ultrasparc_iii"></span><span id="ULTRASPARC_III"></span>
-
-**UltraSPARC IIi** (86)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="UltraSPARC_III"></span><span id="ultrasparc_iii"></span><span id="ULTRASPARC_III"></span>
-
-**UltraSPARC III** (87)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="UltraSPARC_IIIi"></span><span id="ultrasparc_iiii"></span><span id="ULTRASPARC_IIII"></span>
-
-**UltraSPARC IIIi** (88)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68040"></span>
-
-**68040** (96)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68xxx_Family"></span><span id="68xxx_family"></span><span id="68XXX_FAMILY"></span>
-
-**68xxx Family** (97)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68000"></span>
-
-**68000** (98)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68010"></span>
-
-**68010** (99)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68020"></span>
-
-**68020** (100)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="68030"></span>
-
-**68030** (101)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Hobbit_Family"></span><span id="hobbit_family"></span><span id="HOBBIT_FAMILY"></span>
-
-**Hobbit Family** (112)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Crusoe_TM__TM5000_Family"></span><span id="crusoe_tm__tm5000_family"></span><span id="CRUSOE_TM__TM5000_FAMILY"></span>
-
-**Crusoe(TM) TM5000 Family** (120)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Crusoe_TM__TM3000_Family"></span><span id="crusoe_tm__tm3000_family"></span><span id="CRUSOE_TM__TM3000_FAMILY"></span>
-
-**Crusoe(TM) TM3000 Family** (121)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Efficeon_TM__TM8000_Family"></span><span id="efficeon_tm__tm8000_family"></span><span id="EFFICEON_TM__TM8000_FAMILY"></span>
-
-**Efficeon(TM) TM8000 Family** (122)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Weitek"></span><span id="weitek"></span><span id="WEITEK"></span>
-
-**Weitek** (128)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Itanium_TM__Processor"></span><span id="itanium_tm__processor"></span><span id="ITANIUM_TM__PROCESSOR"></span>
-
-**Itanium(TM) Processor** (130)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__64_Processor_Family"></span><span id="amd_athlon_tm__64_processor_family"></span><span id="AMD_ATHLON_TM__64_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) 64 Processor Family** (131)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Opteron_TM__Processor_Family"></span><span id="amd_opteron_tm__processor_family"></span><span id="AMD_OPTERON_TM__PROCESSOR_FAMILY"></span>
-
-**AMD Opteron(TM) Processor Family** (132)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Sempron_TM__Processor_Family"></span><span id="amd_sempron_tm__processor_family"></span><span id="AMD_SEMPRON_TM__PROCESSOR_FAMILY"></span>
-
-**AMD Sempron(TM) Processor Family** (133)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__64_Mobile_Technology"></span><span id="amd_turion_tm__64_mobile_technology"></span><span id="AMD_TURION_TM__64_MOBILE_TECHNOLOGY"></span>
-
-**AMD Turion(TM) 64 Mobile Technology** (134)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_AMD_Opteron_TM__Processor_Family"></span><span id="dual-core_amd_opteron_tm__processor_family"></span><span id="DUAL-CORE_AMD_OPTERON_TM__PROCESSOR_FAMILY"></span>
-
-**Dual-Core AMD Opteron(TM) Processor Family** (135)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__64_X2_Dual-Core_Processor_Family"></span><span id="amd_athlon_tm__64_x2_dual-core_processor_family"></span><span id="AMD_ATHLON_TM__64_X2_DUAL-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) 64 X2 Dual-Core Processor Family** (136)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__64_X2_Mobile_Technology"></span><span id="amd_turion_tm__64_x2_mobile_technology"></span><span id="AMD_TURION_TM__64_X2_MOBILE_TECHNOLOGY"></span>
-
-**AMD Turion(TM) 64 X2 Mobile Technology** (137)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_AMD_Opteron_TM__Processor_Family"></span><span id="quad-core_amd_opteron_tm__processor_family"></span><span id="QUAD-CORE_AMD_OPTERON_TM__PROCESSOR_FAMILY"></span>
-
-**Quad-Core AMD Opteron(TM) Processor Family** (138)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Third-Generation_AMD_Opteron_TM__Processor_Family"></span><span id="third-generation_amd_opteron_tm__processor_family"></span><span id="THIRD-GENERATION_AMD_OPTERON_TM__PROCESSOR_FAMILY"></span>
-
-**Third-Generation AMD Opteron(TM) Processor Family** (139)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Phenom_TM__FX_Quad-Core_Processor_Family"></span><span id="amd_phenom_tm__fx_quad-core_processor_family"></span><span id="AMD_PHENOM_TM__FX_QUAD-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Phenom(TM) FX Quad-Core Processor Family** (140)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Phenom_TM__X4_Quad-Core_Processor_Family"></span><span id="amd_phenom_tm__x4_quad-core_processor_family"></span><span id="AMD_PHENOM_TM__X4_QUAD-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Phenom(TM) X4 Quad-Core Processor Family** (141)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Phenom_TM__X2_Dual-Core_Processor_Family"></span><span id="amd_phenom_tm__x2_dual-core_processor_family"></span><span id="AMD_PHENOM_TM__X2_DUAL-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Phenom(TM) X2 Dual-Core Processor Family** (142)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__X2_Dual-Core_Processor_Family"></span><span id="amd_athlon_tm__x2_dual-core_processor_family"></span><span id="AMD_ATHLON_TM__X2_DUAL-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) X2 Dual-Core Processor Family** (143)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_Family"></span><span id="pa-risc_family"></span><span id="PA-RISC_FAMILY"></span>
-
-**PA-RISC Family** (144)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_8500"></span><span id="pa-risc_8500"></span>
-
-**PA-RISC 8500** (145)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_8000"></span><span id="pa-risc_8000"></span>
-
-**PA-RISC 8000** (146)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_7300LC"></span><span id="pa-risc_7300lc"></span>
-
-**PA-RISC 7300LC** (147)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_7200"></span><span id="pa-risc_7200"></span>
-
-**PA-RISC 7200** (148)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_7100LC"></span><span id="pa-risc_7100lc"></span>
-
-**PA-RISC 7100LC** (149)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="PA-RISC_7100"></span><span id="pa-risc_7100"></span>
-
-**PA-RISC 7100** (150)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="V30_Family"></span><span id="v30_family"></span><span id="V30_FAMILY"></span>
-
-**V30 Family** (160)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_3200_Series"></span><span id="quad-core_intel_r__xeon_r__processor_3200_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_3200_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 3200 Series** (161)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_3000_Series"></span><span id="dual-core_intel_r__xeon_r__processor_3000_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_3000_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 3000 Series** (162)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_5300_Series"></span><span id="quad-core_intel_r__xeon_r__processor_5300_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_5300_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 5300 Series** (163)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_5100_Series"></span><span id="dual-core_intel_r__xeon_r__processor_5100_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_5100_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 5100 Series** (164)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_5000_Series"></span><span id="dual-core_intel_r__xeon_r__processor_5000_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_5000_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 5000 Series** (165)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_LV"></span><span id="dual-core_intel_r__xeon_r__processor_lv"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_LV"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor LV** (166)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_ULV"></span><span id="dual-core_intel_r__xeon_r__processor_ulv"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_ULV"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor ULV** (167)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_7100_Series"></span><span id="dual-core_intel_r__xeon_r__processor_7100_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_7100_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 7100 Series** (168)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_5400_Series"></span><span id="quad-core_intel_r__xeon_r__processor_5400_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_5400_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 5400 Series** (169)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor"></span><span id="quad-core_intel_r__xeon_r__processor"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor** (170)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_5200_Series"></span><span id="dual-core_intel_r__xeon_r__processor_5200_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_5200_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 5200 Series** (171)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_7200_Series"></span><span id="dual-core_intel_r__xeon_r__processor_7200_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_7200_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 7200 Series** (172)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_7300_Series"></span><span id="quad-core_intel_r__xeon_r__processor_7300_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_7300_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 7300 Series** (173)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_7400_Series"></span><span id="quad-core_intel_r__xeon_r__processor_7400_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_7400_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 7400 Series** (174)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Multi-Core_Intel_R__Xeon_R__processor_7400_Series"></span><span id="multi-core_intel_r__xeon_r__processor_7400_series"></span><span id="MULTI-CORE_INTEL_R__XEON_R__PROCESSOR_7400_SERIES"></span>
-
-**Multi-Core Intel(R) Xeon(R) processor 7400 Series** (175)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__III_Xeon_TM_"></span><span id="pentium_r__iii_xeon_tm_"></span><span id="PENTIUM_R__III_XEON_TM_"></span>
-
-**Pentium(R) III Xeon(TM)** (176)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__III_Processor_with_Intel_R__SpeedStep_TM__Technology"></span><span id="pentium_r__iii_processor_with_intel_r__speedstep_tm__technology"></span><span id="PENTIUM_R__III_PROCESSOR_WITH_INTEL_R__SPEEDSTEP_TM__TECHNOLOGY"></span>
-
-**Pentium(R) III Processor with Intel(R) SpeedStep(TM) Technology** (177)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pentium_R__4"></span><span id="pentium_r__4"></span><span id="PENTIUM_R__4"></span>
-
-**Pentium(R) 4** (178)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Xeon_TM_"></span><span id="intel_r__xeon_tm_"></span><span id="INTEL_R__XEON_TM_"></span>
-
-**Intel(R) Xeon(TM)** (179)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AS400_Family"></span><span id="as400_family"></span><span id="AS400_FAMILY"></span>
-
-**AS400 Family** (180)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Xeon_TM__processor_MP"></span><span id="intel_r__xeon_tm__processor_mp"></span><span id="INTEL_R__XEON_TM__PROCESSOR_MP"></span>
-
-**Intel(R) Xeon(TM) processor MP** (181)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__XP_Family"></span><span id="amd_athlon_tm__xp_family"></span><span id="AMD_ATHLON_TM__XP_FAMILY"></span>
-
-**AMD Athlon(TM) XP Family** (182)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__MP_Family"></span><span id="amd_athlon_tm__mp_family"></span><span id="AMD_ATHLON_TM__MP_FAMILY"></span>
-
-**AMD Athlon(TM) MP Family** (183)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Itanium_R__2"></span><span id="intel_r__itanium_r__2"></span><span id="INTEL_R__ITANIUM_R__2"></span>
-
-**Intel(R) Itanium(R) 2** (184)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Pentium_R__M_processor"></span><span id="intel_r__pentium_r__m_processor"></span><span id="INTEL_R__PENTIUM_R__M_PROCESSOR"></span>
-
-**Intel(R) Pentium(R) M processor** (185)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Celeron_R__D_processor"></span><span id="intel_r__celeron_r__d_processor"></span><span id="INTEL_R__CELERON_R__D_PROCESSOR"></span>
-
-**Intel(R) Celeron(R) D processor** (186)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Pentium_R__D_processor"></span><span id="intel_r__pentium_r__d_processor"></span><span id="INTEL_R__PENTIUM_R__D_PROCESSOR"></span>
-
-**Intel(R) Pentium(R) D processor** (187)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Pentium_R__Processor_Extreme_Edition"></span><span id="intel_r__pentium_r__processor_extreme_edition"></span><span id="INTEL_R__PENTIUM_R__PROCESSOR_EXTREME_EDITION"></span>
-
-**Intel(R) Pentium(R) Processor Extreme Edition** (188)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__Solo_Processor"></span><span id="intel_r__core_tm__solo_processor"></span><span id="INTEL_R__CORE_TM__SOLO_PROCESSOR"></span>
-
-**Intel(R) Core(TM) Solo Processor** (189)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="K7"></span><span id="k7"></span>
-
-**K7** (190)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Duo_Processor"></span><span id="intel_r__core_tm_2_duo_processor"></span><span id="INTEL_R__CORE_TM_2_DUO_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Duo Processor** (191)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Solo_processor"></span><span id="intel_r__core_tm_2_solo_processor"></span><span id="INTEL_R__CORE_TM_2_SOLO_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Solo processor** (192)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Extreme_processor"></span><span id="intel_r__core_tm_2_extreme_processor"></span><span id="INTEL_R__CORE_TM_2_EXTREME_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Extreme processor** (193)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Quad_processor"></span><span id="intel_r__core_tm_2_quad_processor"></span><span id="INTEL_R__CORE_TM_2_QUAD_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Quad processor** (194)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Extreme_mobile_processor"></span><span id="intel_r__core_tm_2_extreme_mobile_processor"></span><span id="INTEL_R__CORE_TM_2_EXTREME_MOBILE_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Extreme mobile processor** (195)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Duo_mobile_processor"></span><span id="intel_r__core_tm_2_duo_mobile_processor"></span><span id="INTEL_R__CORE_TM_2_DUO_MOBILE_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Duo mobile processor** (196)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM_2_Solo_mobile_processor"></span><span id="intel_r__core_tm_2_solo_mobile_processor"></span><span id="INTEL_R__CORE_TM_2_SOLO_MOBILE_PROCESSOR"></span>
-
-**Intel(R) Core(TM)2 Solo mobile processor** (197)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__i7_processor"></span><span id="intel_r__core_tm__i7_processor"></span><span id="INTEL_R__CORE_TM__I7_PROCESSOR"></span>
-
-**Intel(R) Core(TM) i7 processor** (198)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Celeron_R__Processor"></span><span id="dual-core_intel_r__celeron_r__processor"></span><span id="DUAL-CORE_INTEL_R__CELERON_R__PROCESSOR"></span>
-
-**Dual-Core Intel(R) Celeron(R) Processor** (199)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="S_390_and_zSeries_Family"></span><span id="s_390_and_zseries_family"></span><span id="S_390_AND_ZSERIES_FAMILY"></span>
-
-**S/390 and zSeries Family** (200)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="ESA_390_G4"></span><span id="esa_390_g4"></span>
-
-**ESA/390 G4** (201)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="ESA_390_G5"></span><span id="esa_390_g5"></span>
-
-**ESA/390 G5** (202)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="ESA_390_G6"></span><span id="esa_390_g6"></span>
-
-**ESA/390 G6** (203)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="z_Architectur_base"></span><span id="z_architectur_base"></span><span id="Z_ARCHITECTUR_BASE"></span>
-
-**z/Architectur base** (204)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__i5_processor"></span><span id="intel_r__core_tm__i5_processor"></span><span id="INTEL_R__CORE_TM__I5_PROCESSOR"></span>
-
-**Intel(R) Core(TM) i5 processor** (205)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Intel_R__Core_TM__i3_processor"></span><span id="intel_r__core_tm__i3_processor"></span><span id="INTEL_R__CORE_TM__I3_PROCESSOR"></span>
-
-**Intel(R) Core(TM) i3 processor** (206)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="VIA_C7_TM_-M_Processor_Family"></span><span id="via_c7_tm_-m_processor_family"></span><span id="VIA_C7_TM_-M_PROCESSOR_FAMILY"></span>
-
-**VIA C7(TM)-M Processor Family** (210)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="VIA_C7_TM_-D_Processor_Family"></span><span id="via_c7_tm_-d_processor_family"></span><span id="VIA_C7_TM_-D_PROCESSOR_FAMILY"></span>
-
-**VIA C7(TM)-D Processor Family** (211)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="VIA_C7_TM__Processor_Family"></span><span id="via_c7_tm__processor_family"></span><span id="VIA_C7_TM__PROCESSOR_FAMILY"></span>
-
-**VIA C7(TM) Processor Family** (212)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="VIA_Eden_TM__Processor_Family"></span><span id="via_eden_tm__processor_family"></span><span id="VIA_EDEN_TM__PROCESSOR_FAMILY"></span>
-
-**VIA Eden(TM) Processor Family** (213)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Multi-Core_Intel_R__Xeon_R__processor"></span><span id="multi-core_intel_r__xeon_r__processor"></span><span id="MULTI-CORE_INTEL_R__XEON_R__PROCESSOR"></span>
-
-**Multi-Core Intel(R) Xeon(R) processor** (214)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_3xxx_Series"></span><span id="dual-core_intel_r__xeon_r__processor_3xxx_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_3XXX_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 3xxx Series** (215)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_3xxx_Series"></span><span id="quad-core_intel_r__xeon_r__processor_3xxx_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_3XXX_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 3xxx Series** (216)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="VIA_Nano_TM__Processor_Family"></span><span id="via_nano_tm__processor_family"></span><span id="VIA_NANO_TM__PROCESSOR_FAMILY"></span>
-
-**VIA Nano(TM) Processor Family** (217)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_5xxx_Series"></span><span id="dual-core_intel_r__xeon_r__processor_5xxx_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_5XXX_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 5xxx Series** (218)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_5xxx_Series"></span><span id="quad-core_intel_r__xeon_r__processor_5xxx_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_5XXX_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 5xxx Series** (219)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Dual-Core_Intel_R__Xeon_R__processor_7xxx_Series"></span><span id="dual-core_intel_r__xeon_r__processor_7xxx_series"></span><span id="DUAL-CORE_INTEL_R__XEON_R__PROCESSOR_7XXX_SERIES"></span>
-
-**Dual-Core Intel(R) Xeon(R) processor 7xxx Series** (221)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Quad-Core_Intel_R__Xeon_R__processor_7xxx_Series"></span><span id="quad-core_intel_r__xeon_r__processor_7xxx_series"></span><span id="QUAD-CORE_INTEL_R__XEON_R__PROCESSOR_7XXX_SERIES"></span>
-
-**Quad-Core Intel(R) Xeon(R) processor 7xxx Series** (222)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Multi-Core_Intel_R__Xeon_R__processor_7xxx_Series"></span><span id="multi-core_intel_r__xeon_r__processor_7xxx_series"></span><span id="MULTI-CORE_INTEL_R__XEON_R__PROCESSOR_7XXX_SERIES"></span>
-
-**Multi-Core Intel(R) Xeon(R) processor 7xxx Series** (223)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Multi-Core_Intel_R__Xeon_R__processor_3400_Series"></span><span id="multi-core_intel_r__xeon_r__processor_3400_series"></span><span id="MULTI-CORE_INTEL_R__XEON_R__PROCESSOR_3400_SERIES"></span>
-
-**Multi-Core Intel(R) Xeon(R) processor 3400 Series** (224)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Embedded_AMD_Opteron_TM__Quad-Core_Processor_Family"></span><span id="embedded_amd_opteron_tm__quad-core_processor_family"></span><span id="EMBEDDED_AMD_OPTERON_TM__QUAD-CORE_PROCESSOR_FAMILY"></span>
-
-**Embedded AMD Opteron(TM) Quad-Core Processor Family** (230)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Phenom_TM__Triple-Core_Processor_Family"></span><span id="amd_phenom_tm__triple-core_processor_family"></span><span id="AMD_PHENOM_TM__TRIPLE-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Phenom(TM) Triple-Core Processor Family** (231)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__Ultra_Dual-Core_Mobile_Processor_Family"></span><span id="amd_turion_tm__ultra_dual-core_mobile_processor_family"></span><span id="AMD_TURION_TM__ULTRA_DUAL-CORE_MOBILE_PROCESSOR_FAMILY"></span>
-
-**AMD Turion(TM) Ultra Dual-Core Mobile Processor Family** (232)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Turion_TM__Dual-Core_Mobile_Processor_Family"></span><span id="amd_turion_tm__dual-core_mobile_processor_family"></span><span id="AMD_TURION_TM__DUAL-CORE_MOBILE_PROCESSOR_FAMILY"></span>
-
-**AMD Turion(TM) Dual-Core Mobile Processor Family** (233)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__Dual-Core_Processor_Family"></span><span id="amd_athlon_tm__dual-core_processor_family"></span><span id="AMD_ATHLON_TM__DUAL-CORE_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) Dual-Core Processor Family** (234)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Sempron_TM__SI_Processor_Family"></span><span id="amd_sempron_tm__si_processor_family"></span><span id="AMD_SEMPRON_TM__SI_PROCESSOR_FAMILY"></span>
-
-**AMD Sempron(TM) SI Processor Family** (235)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Phenom_TM__II_Processor_Family"></span><span id="amd_phenom_tm__ii_processor_family"></span><span id="AMD_PHENOM_TM__II_PROCESSOR_FAMILY"></span>
-
-**AMD Phenom(TM) II Processor Family** (236)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Athlon_TM__II_Processor_Family"></span><span id="amd_athlon_tm__ii_processor_family"></span><span id="AMD_ATHLON_TM__II_PROCESSOR_FAMILY"></span>
-
-**AMD Athlon(TM) II Processor Family** (237)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Six-Core_AMD_Opteron_TM__Processor_Family"></span><span id="six-core_amd_opteron_tm__processor_family"></span><span id="SIX-CORE_AMD_OPTERON_TM__PROCESSOR_FAMILY"></span>
-
-**Six-Core AMD Opteron(TM) Processor Family** (238)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="AMD_Sempron_TM__M_Processor_Family"></span><span id="amd_sempron_tm__m_processor_family"></span><span id="AMD_SEMPRON_TM__M_PROCESSOR_FAMILY"></span>
-
-**AMD Sempron(TM) M Processor Family** (239)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="i860"></span><span id="I860"></span>
-
-**i860** (250)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="i960"></span><span id="I960"></span>
-
-**i960** (251)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved__SMBIOS_Extension_"></span><span id="reserved__smbios_extension_"></span><span id="RESERVED__SMBIOS_EXTENSION_"></span>
-
-**Reserved (SMBIOS Extension)** (254)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved__Un-initialized_Flash_Content_-_Lo_"></span><span id="reserved__un-initialized_flash_content_-_lo_"></span><span id="RESERVED__UN-INITIALIZED_FLASH_CONTENT_-_LO_"></span>
-
-**Reserved (Un-initialized Flash Content - Lo)** (255)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="SH-3"></span><span id="sh-3"></span>
-
-**SH-3** (260)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="SH-4"></span><span id="sh-4"></span>
-
-**SH-4** (261)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="ARM"></span><span id="arm"></span>
-
-**ARM** (280)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="StrongARM"></span><span id="strongarm"></span><span id="STRONGARM"></span>
-
-**StrongARM** (281)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="6x86"></span><span id="6X86"></span>
-
-**6x86** (300)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MediaGX"></span><span id="mediagx"></span><span id="MEDIAGX"></span>
-
-**MediaGX** (301)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="MII"></span><span id="mii"></span>
-
-**MII** (302)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="WinChip"></span><span id="winchip"></span><span id="WINCHIP"></span>
-
-**WinChip** (320)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="DSP"></span><span id="dsp"></span>
-
-**DSP** (350)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Video_Processor"></span><span id="video_processor"></span><span id="VIDEO_PROCESSOR"></span>
-
-**Video Processor** (500)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved__For_Future_Special_Purpose_Assignment_"></span><span id="reserved__for_future_special_purpose_assignment_"></span><span id="RESERVED__FOR_FUTURE_SPECIAL_PURPOSE_ASSIGNMENT_"></span>
-
-**Reserved (For Future Special Purpose Assignment)** (65534)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Reserved__Un-initialized_Flash_Content_-_Hi_"></span><span id="reserved__un-initialized_flash_content_-_hi_"></span><span id="RESERVED__UN-INITIALIZED_FLASH_CONTENT_-_HI_"></span>
-
-**Reserved (Un-initialized Flash Content - Hi)** (65535)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**InstallDate**
-</dt> <dd> <dl> <dt>
-
-Data type: **datetime**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|ComponentID\|001.5"), [**DisplayName**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Install Date")
-</dt> </dl>
-
-Date and time the object is installed. This property does not require a value to indicate that the object is installed. This property is inherited from [**CIM\_ManagedSystemElement**](cim-managedsystemelement.md).
-
-</dd> <dt>
-
-**L2CacheSize**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("kilobytes")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>ErrorCleared</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
+If <b>TRUE</b>, the error reported in <b>LastErrorCode</b> is clear.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>ErrorDescription</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
+More information about the error recorded in <b>LastErrorCode</b>, and information about corrective actions that can be taken.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>ExtClock</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|External Clock"), [<b>Units</b>][1] ("megahertz")</dt>
+    </dl>
+External clock frequency, in MHz. If the frequency is unknown, this property is set to <b>NULL</b>.
+
+This value comes from the <b>External Clock</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>Family</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Processor\|014.3"), [<b>ModelCorrespondence</b>][1] ("[<b>CIM_Processor</b>](cim-processor.md).<b>OtherFamilyDescription</b>")</dt>
+    </dl>
+    <dl>Processor family type.
+
+This value comes from the <b>Processor Information</b> structure in the SMBIOS version information. For SMBIOS versions 2.0 thru 2.5 the value comes from the <b>Processor Family</b> member. For SMBIOS version 2.6+ the value comes from the <b>Processor Family 2</b> member.
+
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).
+      <dt><b>Other</b> (1)</dt>
+      <dt><b>Unknown</b> (2)</dt>
+      <dt><b>8086</b> (3)</dt>
+      <dt><b>80286</b> (4)</dt>
+      <dt><b>80386</b> (5)</dt>
+      <dt><b>80486</b> (6)</dt>
+      <dt><b>8087</b> (7)</dt>
+      <dt><b>80287</b> (8)</dt>
+      <dt><b>80387</b> (9)</dt>
+      <dt><b>80487</b> (10)</dt>
+      <dt><b>Pentium(R) brand</b> (11)</dt>
+      <dt><b>Pentium(R) Pro</b> (12)</dt>
+      <dt><b>Pentium(R) II</b> (13)</dt>
+      <dt><b>Pentium(R) processor with MMX(TM) technology</b> (14)</dt>
+      <dt><b>Celeron(TM)</b> (15)</dt>
+      <dt><b>Pentium(R) II Xeon(TM)</b> (16)</dt>
+      <dt><b>Pentium(R) III</b> (17)</dt>
+      <dt><b>M1 Family</b> (18)</dt>
+      <dt><b>M2 Family</b> (19)</dt>
+      <dt><b>Intel(R) Celeron(R) M processor</b> (20)</dt>
+      <dt><b>Intel(R) Pentium(R) 4 HT processor</b> (21)</dt>
+      <dt><b>K5 Family</b> (24)</dt>
+      <dt><b>K6 Family</b> (25)</dt>
+      <dt><b>K6-2</b> (26)</dt>
+      <dt><b>K6-3</b> (27)</dt>
+      <dt><b>AMD Athlon(TM) Processor Family</b> (28)</dt>
+      <dt><b>AMD(R) Duron(TM) Processor</b> (29)</dt>
+      <dt><b>AMD29000 Family</b> (30)</dt>
+      <dt><b>K6-2+</b> (31)</dt>
+      <dt><b>Power PC Family</b> (32)</dt>
+      <dt><b>Power PC 601</b> (33)</dt>
+      <dt><b>Power PC 603</b> (34)</dt>
+      <dt><b>Power PC 603+</b> (35)</dt>
+      <dt><b>Power PC 604</b> (36)</dt>
+      <dt><b>Power PC 620</b> (37)</dt>
+      <dt><b>Power PC X704</b> (38)</dt>
+      <dt><b>Power PC 750</b> (39)</dt>
+      <dt><b>Intel(R) Core(TM) Duo processor</b> (40)</dt>
+      <dt><b>Intel(R) Core(TM) Duo mobile processor</b> (41)</dt>
+      <dt><b>Intel(R) Core(TM) Solo mobile processor</b> (42)</dt>
+      <dt><b>Intel(R) Atom(TM) processor</b> (43)</dt>
+      <dt><b>Alpha Family</b> (48)</dt>
+      <dt><b>Alpha 21064</b> (49)</dt>
+      <dt><b>Alpha 21066</b> (50)</dt>
+      <dt><b>Alpha 21164</b> (51)</dt>
+      <dt><b>Alpha 21164PC</b> (52)</dt>
+      <dt><b>Alpha 21164a</b> (53)</dt>
+      <dt><b>Alpha 21264</b> (54)</dt>
+      <dt><b>Alpha 21364</b> (55)</dt>
+      <dt><b>AMD Turion(TM) II Ultra Dual-Core Mobile M Processor Family</b> (56)</dt>
+      <dt><b>AMD Turion(TM) II Dual-Core Mobile M Processor Family</b> (57)</dt>
+      <dt><b>AMD Athlon(TM) II Dual-Core Mobile M Processor Family</b> (58)</dt>
+      <dt><b>AMD Opteron(TM) 6100 Series Processor</b> (59)</dt>
+      <dt><b>AMD Opteron(TM) 4100 Series Processor</b> (60)</dt>
+      <dt><b>MIPS Family</b> (64)</dt>
+      <dt><b>MIPS R4000</b> (65)</dt>
+      <dt><b>MIPS R4200</b> (66)</dt>
+      <dt><b>MIPS R4400</b> (67)</dt>
+      <dt><b>MIPS R4600</b> (68)</dt>
+      <dt><b>MIPS R10000</b> (69)</dt>
+      <dt><b>SPARC Family</b> (80)</dt>
+      <dt><b>SuperSPARC</b> (81)</dt>
+      <dt><b>microSPARC II</b> (82)</dt>
+      <dt><b>microSPARC IIep</b> (83)</dt>
+      <dt><b>UltraSPARC</b> (84)</dt>
+      <dt><b>UltraSPARC II</b> (85)</dt>
+      <dt><b>UltraSPARC IIi</b> (86)</dt>
+      <dt><b>UltraSPARC III</b> (87)</dt>
+      <dt><b>UltraSPARC IIIi</b> (88)</dt>
+      <dt><b>68040</b> (96)</dt>
+      <dt><b>68xxx Family</b> (97)</dt>
+      <dt><b>68000</b> (98)</dt>
+      <dt><b>68010</b> (99)</dt>
+      <dt><b>68020</b> (100)</dt>
+      <dt><b>68030</b> (101)</dt>
+      <dt><b>Hobbit Family</b> (112)</dt>
+      <dt><b>Crusoe(TM) TM5000 Family</b> (120)</dt>
+      <dt><b>Crusoe(TM) TM3000 Family</b> (121)</dt>
+      <dt><b>Efficeon(TM) TM8000 Family</b> (122)</dt>
+      <dt><b>Weitek</b> (128)</dt>
+      <dt><b>Itanium(TM) Processor</b> (130)</dt>
+      <dt><b>AMD Athlon(TM) 64 Processor Family</b> (131)</dt>
+      <dt><b>AMD Opteron(TM) Processor Family</b> (132)</dt>
+      <dt><b>AMD Sempron(TM) Processor Family</b> (133)</dt>
+      <dt><b>AMD Turion(TM) 64 Mobile Technology</b> (134)</dt>
+      <dt><b>Dual-Core AMD Opteron(TM) Processor Family</b> (135)</dt>
+      <dt><b>AMD Athlon(TM) 64 X2 Dual-Core Processor Family</b> (136)</dt>
+      <dt><b>AMD Turion(TM) 64 X2 Mobile Technology</b> (137)</dt>
+      <dt><b>Quad-Core AMD Opteron(TM) Processor Family</b> (138)</dt>
+      <dt><b>Third-Generation AMD Opteron(TM) Processor Family</b> (139)</dt>
+      <dt><b>AMD Phenom(TM) FX Quad-Core Processor Family</b> (140)</dt>
+      <dt><b>AMD Phenom(TM) X4 Quad-Core Processor Family</b> (141)</dt>
+      <dt><b>AMD Phenom(TM) X2 Dual-Core Processor Family</b> (142)</dt>
+      <dt><b>AMD Athlon(TM) X2 Dual-Core Processor Family</b> (143)</dt>
+      <dt><b>PA-RISC Family</b> (144)</dt>
+      <dt><b>PA-RISC 8500</b> (145)</dt>
+      <dt><b>PA-RISC 8000</b> (146)</dt>
+      <dt><b>PA-RISC 7300LC</b> (147)</dt>
+      <dt><b>PA-RISC 7200</b> (148)</dt>
+      <dt><b>PA-RISC 7100LC</b> (149)</dt>
+      <dt><b>PA-RISC 7100</b> (150)</dt>
+      <dt><b>V30 Family</b> (160)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 3200 Series</b> (161)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 3000 Series</b> (162)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 5300 Series</b> (163)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 5100 Series</b> (164)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 5000 Series</b> (165)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor LV</b> (166)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor ULV</b> (167)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 7100 Series</b> (168)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 5400 Series</b> (169)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor</b> (170)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 5200 Series</b> (171)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 7200 Series</b> (172)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 7300 Series</b> (173)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 7400 Series</b> (174)</dt>
+      <dt><b>Multi-Core Intel(R) Xeon(R) processor 7400 Series</b> (175)</dt>
+      <dt><b>Pentium(R) III Xeon(TM)</b> (176)</dt>
+      <dt><b>Pentium(R) III Processor with Intel(R) SpeedStep(TM) Technology</b> (177)</dt>
+      <dt><b>Pentium(R) 4</b> (178)</dt>
+      <dt><b>Intel(R) Xeon(TM)</b> (179)</dt>
+      <dt><b>AS400 Family</b> (180)</dt>
+      <dt><b>Intel(R) Xeon(TM) processor MP</b> (181)</dt>
+      <dt><b>AMD Athlon(TM) XP Family</b> (182)</dt>
+      <dt><b>AMD Athlon(TM) MP Family</b> (183)</dt>
+      <dt><b>Intel(R) Itanium(R) 2</b> (184)</dt>
+      <dt><b>Intel(R) Pentium(R) M processor</b> (185)</dt>
+      <dt><b>Intel(R) Celeron(R) D processor</b> (186)</dt>
+      <dt><b>Intel(R) Pentium(R) D processor</b> (187)</dt>
+      <dt><b>Intel(R) Pentium(R) Processor Extreme Edition</b> (188)</dt>
+      <dt><b>Intel(R) Core(TM) Solo Processor</b> (189)</dt>
+      <dt><b>K7</b> (190)</dt>
+      <dt><b>Intel(R) Core(TM)2 Duo Processor</b> (191)</dt>
+      <dt><b>Intel(R) Core(TM)2 Solo processor</b> (192)</dt>
+      <dt><b>Intel(R) Core(TM)2 Extreme processor</b> (193)</dt>
+      <dt><b>Intel(R) Core(TM)2 Quad processor</b> (194)</dt>
+      <dt><b>Intel(R) Core(TM)2 Extreme mobile processor</b> (195)</dt>
+      <dt><b>Intel(R) Core(TM)2 Duo mobile processor</b> (196)</dt>
+      <dt><b>Intel(R) Core(TM)2 Solo mobile processor</b> (197)</dt>
+      <dt><b>Intel(R) Core(TM) i7 processor</b> (198)</dt>
+      <dt><b>Dual-Core Intel(R) Celeron(R) Processor</b> (199)</dt>
+      <dt><b>S/390 and zSeries Family</b> (200)</dt>
+      <dt><b>ESA/390 G4</b> (201)</dt>
+      <dt><b>ESA/390 G5</b> (202)</dt>
+      <dt><b>ESA/390 G6</b> (203)</dt>
+      <dt><b>z/Architectur base</b> (204)</dt>
+      <dt><b>Intel(R) Core(TM) i5 processor</b> (205)</dt>
+      <dt><b>Intel(R) Core(TM) i3 processor</b> (206)</dt>
+      <dt><b>VIA C7(TM)-M Processor Family</b> (210)</dt>
+      <dt><b>VIA C7(TM)-D Processor Family</b> (211)</dt>
+      <dt><b>VIA C7(TM) Processor Family</b> (212)</dt>
+      <dt><b>VIA Eden(TM) Processor Family</b> (213)</dt>
+      <dt><b>Multi-Core Intel(R) Xeon(R) processor</b> (214)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 3xxx Series</b> (215)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 3xxx Series</b> (216)</dt>
+      <dt><b>VIA Nano(TM) Processor Family</b> (217)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 5xxx Series</b> (218)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 5xxx Series</b> (219)</dt>
+      <dt><b>Dual-Core Intel(R) Xeon(R) processor 7xxx Series</b> (221)</dt>
+      <dt><b>Quad-Core Intel(R) Xeon(R) processor 7xxx Series</b> (222)</dt>
+      <dt><b>Multi-Core Intel(R) Xeon(R) processor 7xxx Series</b> (223)</dt>
+      <dt><b>Multi-Core Intel(R) Xeon(R) processor 3400 Series</b> (224)</dt>
+      <dt><b>Embedded AMD Opteron(TM) Quad-Core Processor Family</b> (230)</dt>
+      <dt><b>AMD Phenom(TM) Triple-Core Processor Family</b> (231)</dt>
+      <dt><b>AMD Turion(TM) Ultra Dual-Core Mobile Processor Family</b> (232)</dt>
+      <dt><b>AMD Turion(TM) Dual-Core Mobile Processor Family</b> (233)</dt>
+      <dt><b>AMD Athlon(TM) Dual-Core Processor Family</b> (234)</dt>
+      <dt><b>AMD Sempron(TM) SI Processor Family</b> (235)</dt>
+      <dt><b>AMD Phenom(TM) II Processor Family</b> (236)</dt>
+      <dt><b>AMD Athlon(TM) II Processor Family</b> (237)</dt>
+      <dt><b>Six-Core AMD Opteron(TM) Processor Family</b> (238)</dt>
+      <dt><b>AMD Sempron(TM) M Processor Family</b> (239)</dt>
+      <dt><b>i860</b> (250)</dt>
+      <dt><b>i960</b> (251)</dt>
+      <dt><b>Reserved (SMBIOS Extension)</b> (254)</dt>
+      <dt><b>Reserved (Un-initialized Flash Content - Lo)</b> (255)</dt>
+      <dt><b>SH-3</b> (260)</dt>
+      <dt><b>SH-4</b> (261)</dt>
+      <dt><b>ARM</b> (280)</dt>
+      <dt><b>StrongARM</b> (281)</dt>
+      <dt><b>6x86</b> (300)</dt>
+      <dt><b>MediaGX</b> (301)</dt>
+      <dt><b>MII</b> (302)</dt>
+      <dt><b>WinChip</b> (320)</dt>
+      <dt><b>DSP</b> (350)</dt>
+      <dt><b>Video Processor</b> (500)</dt>
+      <dt><b>Reserved (For Future Special Purpose Assignment)</b> (65534)</dt>
+      <dt><b>Reserved (Un-initialized Flash Content - Hi)</b> (65535)</dt>
+    </dl></dd>
+  <dt><b>InstallDate</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>datetime</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|ComponentID\|001.5"), [<b>DisplayName</b>][1] ("Install Date")</dt>
+    </dl>
+Date and time the object is installed. This property does not require a value to indicate that the object is installed. This property is inherited from [<b>CIM_ManagedSystemElement</b>](cim-managedsystemelement.md).</dd>
+  <dt><b>L2CacheSize</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI"), [<b>Units</b>][1] ("kilobytes")</dt>
+    </dl>
 Size of the Level 2 processor cache. A Level 2 cache is an external memory area that has a faster access time than the main RAM memory.
-
-This value comes from the **L2 Cache Handle** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**L2CacheSpeed**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("megahertz")
-</dt> </dl>
-
+This value comes from the <b>L2 Cache Handle</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>L2CacheSpeed</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI"), [<b>Units</b>][1] ("megahertz")</dt>
+    </dl>
 Clock speed of the Level 2 processor cache. A Level 2 cache is an external memory area that has a faster access time than the main RAM memory.
 
-This value comes from the **L2 Cache Handle** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**L3CacheSize**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("kilobytes")
-</dt> </dl>
-
+This value comes from the <b>L2 Cache Handle</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>L3CacheSize</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI"), [<b>Units</b>][1] ("kilobytes")</dt>
+    </dl>
 Size of the Level 3 processor cache. A Level 3 cache is an external memory area that has a faster access time than the main RAM memory.
 
-This value comes from the **L3 Cache Handle** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**L3CacheSpeed**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("megahertz")
-</dt> </dl>
-
+This value comes from the <b>L3 Cache Handle</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>L3CacheSpeed</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI"), [<b>Units</b>][1] ("megahertz")</dt>
+    </dl>
 Clockspeed of the Level 3 property cache. A Level 3 cache is an external memory area that has a faster access time than the main RAM memory.
 
-This value comes from the **L3 Cache Handle** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**LastErrorCode**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
+This value comes from the <b>L3 Cache Handle</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>LastErrorCode</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
 Last error code reported by the logical device.
 
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**Level**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-Definition of the processor type. The value depends on the architecture of the processor.
-
-</dd> <dt>
-
-**LoadPercentage**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Override**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("LoadPercentage"), [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Win32API\|Performance Data"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("percent")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>Level</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+Definition of the processor type. The value depends on the architecture of the processor.</dd>
+  <dt><b>LoadPercentage</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Override</b>][1] ("LoadPercentage"), [<b>MappingStrings</b>][1] ("Win32API\|Performance Data"), [<b>Units</b>][1] ("percent")</dt>
+    </dl>
 Load capacity of each processor, averaged to the last second. Processor loading refers to the total computing burden for each processor at one time.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**Manufacturer**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>Manufacturer</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
 Name of the processor manufacturer.
-
 Example: A. Datum Corporation
-
-This value comes from the **Processor Manufacturer** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**MaxClockSpeed**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Processor\|006.5"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("megahertz")
-</dt> </dl>
-
+This value comes from the <b>Processor Manufacturer</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>MaxClockSpeed</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Processor\|006.5"), [<b>Units</b>][1] ("megahertz")</dt>
+    </dl>
 Maximum speed of the processor, in MHz.
+This value comes from the <b>Max Speed</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
 
-This value comes from the **Max Speed** member of the **Processor Information** structure in the SMBIOS information.
-
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**Name**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**DisplayName**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Name")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>Name</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>DisplayName</b>][1] ("Name")</dt>
+    </dl>
 Label by which the object is known. When this property is a subclass, it can be overridden to be a key property.
 
-This value comes from the **Processor Version** member of the **Processor Information** structure in the SMBIOS information.
+This value comes from the <b>Processor Version</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
 
-This property is inherited from [**CIM\_ManagedSystemElement**](cim-managedsystemelement.md).
-
-</dd> <dt>
-
-**NumberOfCores**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_ManagedSystemElement</b>](cim-managedsystemelement.md).</dd>
+  <dt><b>NumberOfCores</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
 Number of cores for the current instance of the processor. A core is a physical processor on the integrated circuit. For example, in a dual-core processor this property has a value of 2. For more information, see Remarks.
 
-This value comes from the **Processor Information** structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the **Core Count** member. For SMBIOS version 3.0+ the value comes from the **Core Count 2** member.
-
-</dd> <dt>
-
-**NumberOfEnabledCore**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Core Enabled")
-</dt> </dl>
-
+This value comes from the <b>Processor Information</b> structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the <b>Core Count</b> member. For SMBIOS version 3.0+ the value comes from the <b>Core Count 2</b> member.</dd>
+  <dt><b>NumberOfEnabledCore</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Core Enabled")</dt>
+    </dl>
 The number of enabled cores per processor socket.
 
-This value comes from the **Processor Information** structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the **Core Enabled** member. For SMBIOS version 3.0+ the value comes from the **Core Enabled 2** member.
+This value comes from the <b>Processor Information</b> structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the <b>Core Enabled</b> member. For SMBIOS version 3.0+ the value comes from the <b>Core Enabled 2</b> member.
+    <b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.</dd>
+  <dt><b>NumberOfLogicalProcessors</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+Number of logical processors for the current instance of the processor. For processors capable of hyperthreading, this value includes only the processors which have hyperthreading enabled. For more information, see Remarks.</dd>
+  <dt><b>OtherFamilyDescription</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MaxLen</b>][1] (64), [<b>ModelCorrespondence</b>][1] ("[<b>CIM_Processor</b>](cim-processor.md).<b>Family</b>")</dt>
+    </dl>
+Processor family type. Used when the <b>Family</b> property is set to 1, which means Other. This string should be set to <b>NULL</b> when the <b>Family</b> property is a value that is not 1.
 
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**NumberOfLogicalProcessors**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-Number of logical processors for the current instance of the processor. For processors capable of hyperthreading, this value includes only the processors which have hyperthreading enabled. For more information, see Remarks.
-
-</dd> <dt>
-
-**OtherFamilyDescription**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MaxLen**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) (64), [**ModelCorrespondence**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("[**CIM\_Processor**](cim-processor.md).**Family**")
-</dt> </dl>
-
-Processor family type. Used when the **Family** property is set to 1, which means Other. This string should be set to **NULL** when the **Family** property is a value that is not 1.
-
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**PartNumber**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Part Number")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>PartNumber</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Part Number")</dt>
+    </dl>
 The part number of this processor as set by the manufacturer.
 
-This value comes from the **Part Number** member of the **Processor Information** structure in the SMBIOS information.
-
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**PNPDeviceID**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Schema**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Win32")
-</dt> </dl>
-
+This value comes from the <b>Part Number</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+    <b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.</dd>
+  <dt><b>PNPDeviceID</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Schema</b>][1] ("Win32")</dt>
+    </dl>
 Windows Plug and Play device identifier of the logical device.
 
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-Example: \*PNP030b
-
-</dd> <dt>
-
-**PowerManagementCapabilities**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16** array
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
-Array of the specific power-related capabilities of a logical device.
-
-This property is inherited from **CIM\_LogicalDevice**.
-
-<dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>**Unknown** (0)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Not_Supported"></span><span id="not_supported"></span><span id="NOT_SUPPORTED"></span>
-
-<span id="Not_Supported"></span><span id="not_supported"></span><span id="NOT_SUPPORTED"></span>**Not Supported** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Disabled"></span><span id="disabled"></span><span id="DISABLED"></span>
-
-<span id="Disabled"></span><span id="disabled"></span><span id="DISABLED"></span>**Disabled** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Enabled"></span><span id="enabled"></span><span id="ENABLED"></span>
-
-<span id="Enabled"></span><span id="enabled"></span><span id="ENABLED"></span>**Enabled** (3)
-
-
-</dt> <dd>
-
-The power management features are currently enabled but the exact feature set is unknown or the information is unavailable.
-
-</dd> <dt>
-
-<span id="Power_Saving_Modes_Entered_Automatically"></span><span id="power_saving_modes_entered_automatically"></span><span id="POWER_SAVING_MODES_ENTERED_AUTOMATICALLY"></span>
-
-<span id="Power_Saving_Modes_Entered_Automatically"></span><span id="power_saving_modes_entered_automatically"></span><span id="POWER_SAVING_MODES_ENTERED_AUTOMATICALLY"></span>**Power Saving Modes Entered Automatically** (4)
-
-
-</dt> <dd>
-
-The device can change its power state based on usage or other criteria.
-
-</dd> <dt>
-
-<span id="Power_State_Settable"></span><span id="power_state_settable"></span><span id="POWER_STATE_SETTABLE"></span>
-
-<span id="Power_State_Settable"></span><span id="power_state_settable"></span><span id="POWER_STATE_SETTABLE"></span>**Power State Settable** (5)
-
-
-</dt> <dd>
-
-The [**SetPowerState**](setpowerstate-method-in-class-cim-controller.md) method is supported. This method is found on the parent **CIM\_LogicalDevice** class and can be implemented. For more information, see [Designing Managed Object Format (MOF) Classes](https://msdn.microsoft.com/library/Aa390351(v=VS.85).aspx).
-
-</dd> <dt>
-
-<span id="Power_Cycling_Supported"></span><span id="power_cycling_supported"></span><span id="POWER_CYCLING_SUPPORTED"></span>
-
-<span id="Power_Cycling_Supported"></span><span id="power_cycling_supported"></span><span id="POWER_CYCLING_SUPPORTED"></span>**Power Cycling Supported** (6)
-
-
-</dt> <dd>
-
-The [**SetPowerState**](setpowerstate-method-in-class-cim-controller.md) method can be invoked with the *PowerState* parameter set to 5 (Power Cycle).
-
-</dd> <dt>
-
-<span id="Timed_Power_On_Supported"></span><span id="timed_power_on_supported"></span><span id="TIMED_POWER_ON_SUPPORTED"></span>
-
-<span id="Timed_Power_On_Supported"></span><span id="timed_power_on_supported"></span><span id="TIMED_POWER_ON_SUPPORTED"></span>**Timed Power On Supported** (7)
-
-
-</dt> <dd>
-
-Timed Power-On Supported
-
-The [**SetPowerState**](setpowerstate-method-in-class-cim-controller.md) method can be invoked with the *PowerState* parameter set to 5 (Power Cycle) and *Time* set to a specific date and time, or interval, for power-on.
-
-</dd> </dl>
-
-</dd> <dt>
-
-**PowerManagementSupported**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
-If **TRUE**, the power of the device can be managed, which means that it can be put into suspend mode, and so on. The property does not indicate that power management features are enabled, but it does indicate that the logical device power can be managed.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**ProcessorId**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Processor ID")
-</dt> </dl>
-
-Processor information that describes the processor features. For an x86 class CPU, the field format depends on the processor support of the CPUID instruction. If the instruction is supported, the property contains 2 (two) **DWORD** formatted values. The first is an offset of 08h-0Bh, which is the EAX value that a CPUID instruction returns with input EAX set to 1. The second is an offset of 0Ch-0Fh, which is the EDX value that the instruction returns. Only the first two bytes of the property are significant and contain the contents of the DX register at CPU reset—all others are set to 0 (zero), and the contents are in **DWORD** format.
-
-This value comes from the **Processor ID** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**ProcessorType**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Processor Type")
-</dt> </dl>
-
-Primary function of the processor.
-
-This value comes from the **Processor Type** member of the **Processor Information** structure in the SMBIOS information.
-
-<dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-**Other** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-**Unknown** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Central_Processor"></span><span id="central_processor"></span><span id="CENTRAL_PROCESSOR"></span>
-
-**Central Processor** (3)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Math_Processor"></span><span id="math_processor"></span><span id="MATH_PROCESSOR"></span>
-
-**Math Processor** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="DSP_Processor"></span><span id="dsp_processor"></span><span id="DSP_PROCESSOR"></span>
-
-**DSP Processor** (5)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Video_Processor"></span><span id="video_processor"></span><span id="VIDEO_PROCESSOR"></span>
-
-**Video Processor** (6)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**Revision**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-System revision level that depends on the architecture. The system revision level contains the same values as the **Version** property, but in a numerical format.
-
-</dd> <dt>
-
-**Role**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).
+Example: \*PNP030b</dd>
+  <dt><b>PowerManagementCapabilities</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b> array</dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
+    <dl>Array of the specific power-related capabilities of a logical device.
+    
+This property is inherited from <b>CIM_LogicalDevice</b>.
+      <dt><b>Unknown</b> (0)</dt>
+      <dt><b>Not Supported</b> (1)</dt>
+      <dt><b>Disabled</b> (2)</dt>
+      <dt><b>Enabled</b> (3)</dt>
+      <dd>
+The power management features are currently enabled but the exact feature set is unknown or the information is unavailable.</dd>
+      <dt><b>Power Saving Modes Entered Automatically</b> (4)</dt>
+      <dd>The device can change its power state based on usage or other criteria.</dd>
+      <dt><b>Power State Settable</b> (5)</dt>
+      <dd>The [<b>SetPowerState</b>](setpowerstate-method-in-class-cim-controller.md) method is supported. This method is found on the parent <b>CIM_LogicalDevice</b> class and can be implemented. For more information, see [Designing Managed Object Format (MOF) Classes][5].</dd>
+      <dt><b>Power Cycling Supported</b> (6)</dt>
+      <dd>The [<b>SetPowerState</b>](setpowerstate-method-in-class-cim-controller.md) method can be invoked with the *PowerState* parameter set to 5 (Power Cycle).</dd>
+      <dt><b>Timed Power On Supported</b> (7)</dt>
+      <dd>Timed Power-On Supported
+The [<b>SetPowerState</b>](setpowerstate-method-in-class-cim-controller.md) method can be invoked with the *PowerState* parameter set to 5 (Power Cycle) and *Time* set to a specific date and time, or interval, for power-on.</dd>
+    </dl>
+  </dd>
+  <dt><b>PowerManagementSupported</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
+If <b>TRUE</b>, the power of the device can be managed, which means that it can be put into suspend mode, and so on. The property does not indicate that power management features are enabled, but it does indicate that the logical device power can be managed.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>ProcessorId</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Processor ID")</dt>
+    </dl>
+Processor information that describes the processor features. For an x86 class CPU, the field format depends on the processor support of the CPUID instruction. If the instruction is supported, the property contains 2 (two) <b>DWORD</b> formatted values. The first is an offset of 08h-0Bh, which is the EAX value that a CPUID instruction returns with input EAX set to 1. The second is an offset of 0Ch-0Fh, which is the EDX value that the instruction returns. Only the first two bytes of the property are significant and contain the contents of the DX register at CPU reset—all others are set to 0 (zero), and the contents are in <b>DWORD</b> format.
+
+This value comes from the <b>Processor ID</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>ProcessorType</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Processor Type")</dt>
+    </dl>
+    <dl>Primary function of the processor.
+
+This value comes from the <b>Processor Type</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+      <dt><b>Other</b> (1)</dt>
+      <dt><b>Unknown</b> (2)</dt>
+      <dt><b>Central Processor</b> (3)</dt>
+      <dt><b>Math Processor</b> (4)</dt>
+      <dt><b>DSP Processor</b> (5)</dt>
+      <dt><b>Video Processor</b> (6)</dt>
+    </dl></dd>
+  <dt><b>Revision</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+System revision level that depends on the architecture. The system revision level contains the same values as the <b>Version</b> property, but in a numerical format.</dd>
+  <dt><b>Role</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
 Role of the processor.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).
 
-Examples: Central Processor or Math Processor
-
-</dd> <dt>
-
-**SecondLevelAddressTranslationExtensions**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-If **True**, the processor supports address translation extensions used for virtualization.
-
-**Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows 8 and Windows Server 2012.
-
-</dd> <dt>
-
-**SerialNumber**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Serial Number")
-</dt> </dl>
-
+Examples: Central Processor or Math Processor</dd>
+  <dt><b>SecondLevelAddressTranslationExtensions</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+If <b>True</b>, the processor supports address translation extensions used for virtualization.
+    <b>Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows 8 and Windows Server 2012.</dd>
+  <dt><b>SerialNumber</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Serial Number")</dt>
+    </dl>
 The serial number of this processor This value is set by the manufacturer and normally not changeable.
 
-This value comes from the **Serial Number** member of the **Processor Information** structure in the SMBIOS information.
-
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**SocketDesignation**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Socket Designation")
-</dt> </dl>
-
+This value comes from the <b>Serial Number</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+    <b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.</dd>
+  <dt><b>SocketDesignation</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Socket Designation")</dt>
+    </dl>
 Type of chip socket used on the circuit.
-
 Example: J202
 
-This value comes from the **Socket Designation** member of the **Processor Information** structure in the SMBIOS information.
-
-</dd> <dt>
-
-**Status**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MaxLen**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) (10), [**DisplayName**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("Status")
-</dt> </dl>
-
-Current status of an object. This property is inherited from [**CIM\_ManagedSystemElement**](cim-managedsystemelement.md).
-
+This value comes from the <b>Socket Designation</b> member of the <b>Processor Information</b> structure in the SMBIOS information.</dd>
+  <dt><b>Status</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MaxLen</b>][1] (10), [<b>DisplayName</b>][1] ("Status")</dt>
+    </dl>
+    <dl>Current status of an object. This property is inherited from [<b>CIM_ManagedSystemElement</b>](cim-managedsystemelement.md).
 Values include the following:
-
-<dt>
-
-<span id="OK"></span><span id="ok"></span>
-
-**OK** ("OK")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Error"></span><span id="error"></span><span id="ERROR"></span>
-
-**Error** ("Error")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Degraded"></span><span id="degraded"></span><span id="DEGRADED"></span>
-
-**Degraded** ("Degraded")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-**Unknown** ("Unknown")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Pred_Fail"></span><span id="pred_fail"></span><span id="PRED_FAIL"></span>
-
-**Pred Fail** ("Pred Fail")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Starting"></span><span id="starting"></span><span id="STARTING"></span>
-
-**Starting** ("Starting")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Stopping"></span><span id="stopping"></span><span id="STOPPING"></span>
-
-**Stopping** ("Stopping")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Service"></span><span id="service"></span><span id="SERVICE"></span>
-
-**Service** ("Service")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Stressed"></span><span id="stressed"></span><span id="STRESSED"></span>
-
-**Stressed** ("Stressed")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="NonRecover"></span><span id="nonrecover"></span><span id="NONRECOVER"></span>
-
-**NonRecover** ("NonRecover")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="No_Contact"></span><span id="no_contact"></span><span id="NO_CONTACT"></span>
-
-**No Contact** ("No Contact")
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Lost_Comm"></span><span id="lost_comm"></span><span id="LOST_COMM"></span>
-
-**Lost Comm** ("Lost Comm")
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**StatusInfo**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Operational State\|003.3")
-</dt> </dl>
-
-State of the logical device. If this property does not apply to the logical device, use the value 5, which means Not Applicable.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-<dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-**Other** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-**Unknown** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Enabled"></span><span id="enabled"></span><span id="ENABLED"></span>
-
-**Enabled** (3)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Disabled"></span><span id="disabled"></span><span id="DISABLED"></span>
-
-**Disabled** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Not_Applicable"></span><span id="not_applicable"></span><span id="NOT_APPLICABLE"></span>
-
-**Not Applicable** (5)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**Stepping**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**ModelCorrespondence**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("[**CIM\_Processor**](cim-processor.md).**Family**")
-</dt> </dl>
-
+      <dt><b>OK</b> ("OK")</dt>
+      <dt><b>Error</b> ("Error")</dt>
+      <dt><b>Degraded</b> ("Degraded")</dt>
+      <dt><b>Unknown</b> ("Unknown")</dt>
+      <dt><b>Pred Fail</b> ("Pred Fail")</dt>
+      <dt><b>Starting</b> ("Starting")</dt>
+      <dt><b>Stopping</b> ("Stopping")</dt>
+      <dt><b>Service</b> ("Service")</dt>
+      <dt><b>Stressed</b> ("Stressed")</dt>
+      <dt><b>NonRecover</b> ("NonRecover")</dt>
+      <dt><b>No Contact</b> ("No Contact")</dt>
+      <dt><b>Lost Comm</b> ("Lost Comm")</dt>
+    </dl></dd>
+  <dt><b>StatusInfo</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Operational State\|003.3")</dt>
+    </dl>
+    <dl>State of the logical device. If this property does not apply to the logical device, use the value 5, which means Not Applicable.
+
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).
+      <dt><b>Other</b> (1)</dt>
+      <dt><b>Unknown</b> (2)</dt>
+      <dt><b>Enabled</b> (3)</dt>
+      <dt><b>Disabled</b> (4)</dt>
+      <dt><b>Not Applicable</b> (5)</dt>
+    </dl></dd>
+  <dt><b>Stepping</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>ModelCorrespondence</b>][1] ("[<b>CIM_Processor</b>](cim-processor.md).<b>Family</b>")</dt>
+    </dl>
 Revision level of the processor in the processor family.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>SystemCreationClassName</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Propagated</b>][1] ("[<b>CIM_System</b>](cim-system.md).<b>CreationClassName</b>"), [<b>CIM_Key</b>][2]</dt>
+    </dl>
+Value of the <b>CreationClassName</b> property for the scoping computer.
 
-</dd> <dt>
-
-**SystemCreationClassName**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Propagated**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("[**CIM\_System**](cim-system.md).**CreationClassName**"), [**CIM\_Key**](https://msdn.microsoft.com/library/Aa393651(v=VS.85).aspx)
-</dt> </dl>
-
-Value of the **CreationClassName** property for the scoping computer.
-
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**SystemName**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**Propagated**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("[**CIM\_System**](cim-system.md).**Name**"), [**CIM\_Key**](https://msdn.microsoft.com/library/Aa393651(v=VS.85).aspx)
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>SystemName</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>Propagated</b>][1] ("[<b>CIM_System</b>](cim-system.md).<b>Name</b>"), [<b>CIM_Key</b>][2]</dt>
+    </dl>
 Name of the scoping system.
 
-This property is inherited from [**CIM\_LogicalDevice**](cim-logicaldevice.md).
-
-</dd> <dt>
-
-**ThreadCount**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Thread Count")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_LogicalDevice</b>](cim-logicaldevice.md).</dd>
+  <dt><b>ThreadCount</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Thread Count")</dt>
+    </dl>
 The number of threads per processor socket.
 
-This value comes from the **Processor Information** structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the **Thread Count** member. For SMBIOS version 3.0+ the value comes from the **Thread Count 2** member.
-
-**Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows Server 2016 and Windows 10.
-
-</dd> <dt>
-
-**UniqueId**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> </dl>
-
+This value comes from the <b>Processor Information</b> structure in the SMBIOS version information. For SMBIOS versions 2.5 thru 2.9 the value comes from the <b>Thread Count</b> member. For SMBIOS version 3.0+ the value comes from the <b>Thread Count 2</b> member.
+    <b>Windows Server 2012 R2, Windows 8.1, Windows Server 2012, Windows 8, Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows Server 2016 and Windows 10.</dd>
+  <dt><b>UniqueId</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+    </dl>
 Globally unique identifier for the processor. This identifier may only be unique within a processor family.
 
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-</dd> <dt>
-
-**UpgradeMethod**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint16**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("MIF.DMTF\|Processor\|006.7")
-</dt> </dl>
-
-CPU socket information, including the method by which this processor can be upgraded, if upgrades are supported. This property is an integer enumeration.
-
-This value comes from the **Processor Upgrade** member of the **Processor Information** structure in the SMBIOS information.
-
-This property is inherited from [**CIM\_Processor**](cim-processor.md).
-
-<dt>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>
-
-<span id="Other"></span><span id="other"></span><span id="OTHER"></span>**Other** (1)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>
-
-<span id="Unknown"></span><span id="unknown"></span><span id="UNKNOWN"></span>**Unknown** (2)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Daughter_Board"></span><span id="daughter_board"></span><span id="DAUGHTER_BOARD"></span>
-
-<span id="Daughter_Board"></span><span id="daughter_board"></span><span id="DAUGHTER_BOARD"></span>**Daughter Board** (3)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="ZIF_Socket"></span><span id="zif_socket"></span><span id="ZIF_SOCKET"></span>
-
-<span id="ZIF_Socket"></span><span id="zif_socket"></span><span id="ZIF_SOCKET"></span>**ZIF Socket** (4)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Replacement_Piggy_Back"></span><span id="replacement_piggy_back"></span><span id="REPLACEMENT_PIGGY_BACK"></span>
-
-<span id="Replacement_Piggy_Back"></span><span id="replacement_piggy_back"></span><span id="REPLACEMENT_PIGGY_BACK"></span>**Replacement/Piggy Back** (5)
-
-
-</dt> <dd>
-
-Replacement or Piggy Back
-
-</dd> <dt>
-
-<span id="None"></span><span id="none"></span><span id="NONE"></span>
-
-<span id="None"></span><span id="none"></span><span id="NONE"></span>**None** (6)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="LIF_Socket"></span><span id="lif_socket"></span><span id="LIF_SOCKET"></span>
-
-<span id="LIF_Socket"></span><span id="lif_socket"></span><span id="LIF_SOCKET"></span>**LIF Socket** (7)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Slot_1"></span><span id="slot_1"></span><span id="SLOT_1"></span>
-
-<span id="Slot_1"></span><span id="slot_1"></span><span id="SLOT_1"></span>**Slot 1** (8)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Slot_2"></span><span id="slot_2"></span><span id="SLOT_2"></span>
-
-<span id="Slot_2"></span><span id="slot_2"></span><span id="SLOT_2"></span>**Slot 2** (9)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="370_Pin_Socket"></span><span id="370_pin_socket"></span><span id="370_PIN_SOCKET"></span>
-
-<span id="370_Pin_Socket"></span><span id="370_pin_socket"></span><span id="370_PIN_SOCKET"></span>**370 Pin Socket** (10)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Slot_A"></span><span id="slot_a"></span><span id="SLOT_A"></span>
-
-<span id="Slot_A"></span><span id="slot_a"></span><span id="SLOT_A"></span>**Slot A** (11)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Slot_M"></span><span id="slot_m"></span><span id="SLOT_M"></span>
-
-<span id="Slot_M"></span><span id="slot_m"></span><span id="SLOT_M"></span>**Slot M** (12)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_423"></span><span id="socket_423"></span><span id="SOCKET_423"></span>
-
-<span id="Socket_423"></span><span id="socket_423"></span><span id="SOCKET_423"></span>**Socket 423** (13)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_A__Socket_462_"></span><span id="socket_a__socket_462_"></span><span id="SOCKET_A__SOCKET_462_"></span>
-
-<span id="Socket_A__Socket_462_"></span><span id="socket_a__socket_462_"></span><span id="SOCKET_A__SOCKET_462_"></span>**Socket A (Socket 462)** (14)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_478"></span><span id="socket_478"></span><span id="SOCKET_478"></span>
-
-<span id="Socket_478"></span><span id="socket_478"></span><span id="SOCKET_478"></span>**Socket 478** (15)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_754"></span><span id="socket_754"></span><span id="SOCKET_754"></span>
-
-<span id="Socket_754"></span><span id="socket_754"></span><span id="SOCKET_754"></span>**Socket 754** (16)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_940"></span><span id="socket_940"></span><span id="SOCKET_940"></span>
-
-<span id="Socket_940"></span><span id="socket_940"></span><span id="SOCKET_940"></span>**Socket 940** (17)
-
-
-</dt> <dd></dd> <dt>
-
-<span id="Socket_939"></span><span id="socket_939"></span><span id="SOCKET_939"></span>
-
-<span id="Socket_939"></span><span id="socket_939"></span><span id="SOCKET_939"></span>**Socket 939** (18)
-
-
-</dt> <dd></dd> </dl>
-
-</dd> <dt>
-
-**Version**
-</dt> <dd> <dl> <dt>
-
-Data type: **string**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).</dd>
+  <dt><b>UpgradeMethod</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint16</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("MIF.DMTF\|Processor\|006.7")</dt>
+    </dl>
+    <dl>CPU socket information, including the method by which this processor can be upgraded, if upgrades are supported. This property is an integer enumeration.
+
+This value comes from the <b>Processor Upgrade</b> member of the <b>Processor Information</b> structure in the SMBIOS information.
+
+This property is inherited from [<b>CIM_Processor</b>](cim-processor.md).
+      <dt><b>Other</b> (1)</dt>
+      <dt><b>Unknown</b> (2)</dt>
+      <dt><b>Daughter Board</b> (3)</dt>
+      <dt><b>ZIF Socket</b> (4)</dt>
+      <dt><b>Replacement/Piggy Back</b> (5)</dt>
+      <dd>
+Replacement or Piggy Back</dd>
+      <dt><b>None</b> (6)</dt>
+      <dt><b>LIF Socket</b> (7)</dt>
+      <dt><b>Slot 1</b> (8)</dt>
+      <dt><b>Slot 2</b> (9)</dt>
+      <dt><b>370 Pin Socket</b> (10)</dt>
+      <dt><b>Slot A</b> (11)</dt>
+      <dt><b>Slot M</b> (12)</dt>
+      <dt><b>Socket 423</b> (13)</dt>
+      <dt><b>Socket A (Socket 462)</b> (14)</dt>
+      <dt><b>Socket 478</b> (15)</dt>
+      <dt><b>Socket 754</b> (16)</dt>
+      <dt><b>Socket 940</b> (17)</dt>
+      <dt><b>Socket 939</b> (18)</dt>
+    </dl>
+  </dd>
+  <dt><b>Version</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>string</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
 Processor revision number that depends on the architecture.
-
-Example: Model 2, Stepping 12
-
-</dd> <dt>
-
-**VirtualizationFirmwareEnabled**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-If **True**, the Firmware has enabled virtualization extensions.
-
-**Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows 8 and Windows Server 2012.
-
-</dd> <dt>
-
-**VMMonitorModeExtensions**
-</dt> <dd> <dl> <dt>
-
-Data type: **boolean**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("WMI")
-</dt> </dl>
-
-If **True**, the processor supports Intel or AMD Virtual Machine Monitor extensions.
-
-**Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:** This property is not supported before Windows 8 and Windows Server 2012.
-
-</dd> <dt>
-
-**VoltageCaps**
-</dt> <dd> <dl> <dt>
-
-Data type: **uint32**
-</dt> <dt>
-
-Access type: Read-only
-</dt> <dt>
-
-Qualifiers: [**MappingStrings**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("SMBIOS\|Type 4\|Processor Information\|Voltage"), [**Units**](https://msdn.microsoft.com/library/Aa393650(v=VS.85).aspx) ("volts")
-</dt> </dl>
-
-Voltage capabilities of the processor. Bits 0-3 of the field represent specific voltages that the processor socket can accept. All other bits should be set to 0 (zero). The socket is configurable if multiple bits are set. For more information about the actual voltage at which the processor is running, see **CurrentVoltage**. If the property is **NULL**, then the voltage capabilities are unknown.
-
-<dt>
-
-<span id="5"></span>
-
-<span id="5"></span>**5** (1)
-
-
-</dt> <dd>
-
-5 volts
-
-</dd> <dt>
-
-<span id="3.3"></span>
-
-**3.3** (2)
-
-
-</dt> <dd>
-
-3.3 volts
-
-</dd> <dt>
-
-<span id="2.9"></span>
-
-**2.9** (4)
-
-
-</dt> <dd>
-
-2.9 volts
-
-</dd> </dl>
-
-</dd> </dl>
+Example: Model 2, Stepping 12</dd>
+  <dt><b>VirtualizationFirmwareEnabled</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+If <b>True</b>, the Firmware has enabled virtualization extensions.
+    <b>Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows 8 and Windows Server 2012.
+  </dd>
+  <dt><b>VMMonitorModeExtensions</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>boolean</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("WMI")</dt>
+    </dl>
+If <b>True</b>, the processor supports Intel or AMD Virtual Machine Monitor extensions.
+    <b>Windows Server 2008 R2, Windows 7, Windows Server 2008 and Windows Vista:</b> This property is not supported before Windows 8 and Windows Server 2012.
+  </dd>
+  <dt><b>VoltageCaps</b></dt>
+  <dd>
+    <dl>
+      <dt>Data type: <b>uint32</b></dt>
+      <dt>Access type: Read-only</dt>
+      <dt>Qualifiers: [<b>MappingStrings</b>][1] ("SMBIOS\|Type 4\|Processor Information\|Voltage"), [<b>Units</b>][1] ("volts")</dt>
+    </dl>
+    <dl>Voltage capabilities of the processor. Bits 0-3 of the field represent specific voltages that the processor socket can accept. All other bits should be set to 0 (zero). The socket is configurable if multiple bits are set. For more information about the actual voltage at which the processor is running, see <b>CurrentVoltage</b>. If the property is <b>NULL</b>, then the voltage capabilities are unknown.
+      <dt><b>5</b> (1)</dt>
+      <dd>5 volts</dd>
+      <dt><b>3.3</b> (2)</dt>
+      <dd>3.3 volts</dd>
+      <dt><b>2.9</b> (4)</dt>
+      <dd>2.9 volts</dd>
+    </dl>
+  </dd>
+</dl>
 
 ## Remarks
 
-On a multiprocessor computer, one instance of the **Win32\_Processor** class exists for each processor.
+On a multiprocessor computer, one instance of the **Win32_Processor** class exists for each processor.
 
-To determine the total number of processor instances associated with a computer system object, use the [**Win32\_ComputerSystemProcessor**](win32-computersystemprocessor.md) association class.
+To determine the total number of processor instances associated with a computer system object, use the [**Win32_ComputerSystemProcessor**](win32-computersystemprocessor.md) association class.
 
 To determine if hyperthreading is enabled for the processor, compare **NumberOfLogicalProcessors** and **NumberOfCores**. If hyperthreading is enabled in the BIOS for the processor, then **NumberOfCores** is less than **NumberOfLogicalProcessors**. For example, a dual-processor system that contains two processors enabled for hyperthreading can run four threads or programs or simultaneously. In this case, **NumberOfCores** is 2 and **NumberOfLogicalProcessors** is 4.
 
-The **Win32\_Processor** class is derived from [**CIM\_Processor**](cim-processor.md).
+The **Win32_Processor** class is derived from [**CIM_Processor**](cim-processor.md).
 
 ## Examples
 
-The [WMI Information Retriever](https://Gallery.TechNet.Microsoft.Com/e493376c-1286-456b-bd4b-4ac3b0e9bb45) VBScript code example on the TechNet Gallery uses the [**Win32\_ComputerSystemProcessor**](win32-computersystemprocessor.md) class to retrieve processor information from a number of remote computers.
+The [WMI Information Retriever](https://Gallery.TechNet.Microsoft.Com/e493376c-1286-456b-bd4b-4ac3b0e9bb45) VBScript code example on the TechNet Gallery uses the [**Win32_ComputerSystemProcessor**](win32-computersystemprocessor.md) class to retrieve processor information from a number of remote computers.
 
-The [Get-ComputerInfo - Query Computer Info From Local/Remote Computers - (WMI)](https://Gallery.TechNet.Microsoft.Com/Get-ComputerInfo-Query-23dd6042) PowerShell sample on TechNet Gallery uses a number of calls to hardware and software, including [**Win32\_ComputerSystemProcessor**](win32-computersystemprocessor.md), to display information about a local or remote system.
+The [Get-ComputerInfo - Query Computer Info From Local/Remote Computers - (WMI)](https://Gallery.TechNet.Microsoft.Com/Get-ComputerInfo-Query-23dd6042) PowerShell sample on TechNet Gallery uses a number of calls to hardware and software, including [**Win32_ComputerSystemProcessor**](win32-computersystemprocessor.md), to display information about a local or remote system.
 
-The [Multithreaded System Asset Gathering with Powershell](https://Gallery.TechNet.Microsoft.Com/Multithreaded-System-Asset-856a8f7c) PowerShell example on TechNet gallery uses a number of classes, including [**Win32\_ComputerSystemProcessor**](win32-computersystemprocessor.md), to retrieve data from a system.
+The [Multithreaded System Asset Gathering with Powershell](https://Gallery.TechNet.Microsoft.Com/Multithreaded-System-Asset-856a8f7c) PowerShell example on TechNet gallery uses a number of classes, including [**Win32_ComputerSystemProcessor**](win32-computersystemprocessor.md), to retrieve data from a system.
 
-The following VBScript code example retrieves data about the operating system version and the processor it is running on from **Win32\_Processor**, [**Win32\_ComputerSystem**](win32-computersystem.md), and [**Win32\_OperatingSystem**](win32-operatingsystem.md). This example requires Windows Vista or later.
+The following VBScript code example retrieves data about the operating system version and the processor it is running on from **Win32_Processor**, [**Win32_ComputerSystem**](win32-computersystem.md), and [**Win32_OperatingSystem**](win32-operatingsystem.md). This example requires Windows Vista or later.
 
 
 ```VB
@@ -3642,10 +1190,7 @@ For Each objProcessor in colProcessors
 Next
 ```
 
-
-
-The following VBScript code example shows how to use **Win32\_Processor** to determine the computer architecture.
-
+The following VBScript code example shows how to use **Win32_Processor** to determine the computer architecture.
 
 ```VB
 Set objProc = GetObject("winmgmts:root\cimv2:Win32_Processor='cpu0'")
@@ -3660,38 +1205,29 @@ End If
 ```
 
 
-
 ## Requirements
 
-
-
-|                                     |                                                                                         |
-|-------------------------------------|-----------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows Vista<br/>                                                                |
-| Minimum supported server<br/> | Windows Server 2008<br/>                                                          |
-| Namespace<br/>                | Root\\CIMV2<br/>                                                                  |
-| MOF<br/>                      | <dl> <dt>CIMWin32.mof</dt> </dl> |
-| DLL<br/>                      | <dl> <dt>CIMWin32.dll</dt> </dl> |
-
-
+|                          |                                  |
+|--------------------------|----------------------------------|
+| Minimum supported client | Windows Vista                    |
+| Minimum supported server | Windows Server 2008              |
+| Namespace                | Root\\CIMV2                      |
+| MOF                      | <dl> <dt>CIMWin32.mof</dt> </dl> |
+| DLL                      | <dl> <dt>CIMWin32.dll</dt> </dl> |
 
 ## See also
 
-<dl> <dt>
+<dl>
+    <dt>[<b>CIM_Processor</b>](cim-processor.md)</dt>
+    <dt>[Computer System Hardware Classes](computer-system-hardware-classes.md)</dt>
+    <dt>[WMI Tasks: Computer Hardware](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-tasks--computer-hardware)</dt>
+</dl>
 
-[**CIM\_Processor**](cim-processor.md)
-</dt> <dt>
-
-[Computer System Hardware Classes](computer-system-hardware-classes.md)
-</dt> <dt>
-
-[WMI Tasks: Computer Hardware](https://msdn.microsoft.com/library/Aa394587(v=VS.85).aspx)
-</dt> </dl>
+  [0]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/retrieving-a-class
+  [1]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/standard-qualifiers
+  [2]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/standard-wmi-qualifiers
+  [3]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/key-qualifier
+  [4]: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info
+  [5]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/designing-managed-object-format--mof--classes
 
  
-
- 
-
-
-
-

--- a/desktop-src/CIMWin32Prov/win32-processor.md
+++ b/desktop-src/CIMWin32Prov/win32-processor.md
@@ -1220,14 +1220,12 @@ End If
 <dl>
     <dt>[<b>CIM_Processor</b>](cim-processor.md)</dt>
     <dt>[Computer System Hardware Classes](computer-system-hardware-classes.md)</dt>
-    <dt>[WMI Tasks: Computer Hardware](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-tasks--computer-hardware)</dt>
+    <dt>[WMI Tasks: Computer Hardware](/windows/win32/wmisdk/wmi-tasks--computer-hardware)</dt>
 </dl>
 
-  [0]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/retrieving-a-class
-  [1]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/standard-qualifiers
-  [2]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/standard-wmi-qualifiers
-  [3]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/key-qualifier
-  [4]: https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info
-  [5]: https://docs.microsoft.com/en-us/windows/win32/wmisdk/designing-managed-object-format--mof--classes
-
- 
+  [0]: /windows/win32/wmisdk/retrieving-a-class
+  [1]: /windows/win32/wmisdk/standard-qualifiers
+  [2]: /windows/win32/wmisdk/standard-wmi-qualifiers
+  [3]: /windows/win32/wmisdk/key-qualifier
+  [4]: /windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info
+  [5]: /windows/win32/wmisdk/designing-managed-object-format--mof--classes


### PR DESCRIPTION
There are more closing `</dl>` tags than opening ones (72 vs 61). In fact if a property has a list of values then it'll miss a `<dl>` tag. That makes the value list failed to be rendered and indented properly. It's impossible to differentiate between properties and their values, both are bold in the same font face/size and printed in the same indentation

![image](https://user-images.githubusercontent.com/9285512/79408183-e7f2fb80-7fc4-11ea-83d9-7d9d1a3072b0.png)

I've also fixed small errors like the broken ARM above, and updated the old msdn links to the redirected links too. The format may need some further refinement but now this list is completely readable compared to the previous version
