### PR TITLE
Typo "@CommandArguments"→"\@CommandArguments"

### DIFF
--- a/desktop-src/Debug/source-server-and-source-indexing.md
+++ b/desktop-src/Debug/source-server-and-source-indexing.md
@@ -51,7 +51,7 @@ The DbgHelp API provides access to source server functionality through the [**Sy
 
 To use the source server with WinDbg, KD, NTSD, or CDB, ensure that you have installed a recent version of the Debugging Tools for Windows package (version 6.3 or later). Then, include srv\* in the .srcpath command as follows:
 
-**.srcpath srv\*;***c:\\mysource*
+**\.srcpath srv\\\*;**_c:\\mysource_
 
 Note that this example also includes a traditional source path. If the debugger cannot retrieve the file from the source server, it will search the specified path.
 
@@ -226,7 +226,7 @@ Return value: None
 
 </dd> <dt>
 
-<span id="_objref____module__new__CommandArguments_"></span><span id="_objref____module__new__commandarguments_"></span><span id="_OBJREF____MODULE__NEW__COMMANDARGUMENTS_"></span>**$objref = $module::new(@CommandArguments)**
+<span id="_objref____module__new__CommandArguments_"></span><span id="_objref____module__new__commandarguments_"></span><span id="_OBJREF____MODULE__NEW__COMMANDARGUMENTS_"></span>**$objref = $module::new(\@CommandArguments)**
 </dt> <dd>
 
 Purpose: Initializes an instance of the provider module.


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/debug/source-server-and-source-indexing