### PR TITLE
Event log and ETW corrections and cleanup

### DIFF
--- a/desktop-src/ETW/logging-mode-constants.md
+++ b/desktop-src/ETW/logging-mode-constants.md
@@ -66,7 +66,7 @@ The constants are used in the **LogFileMode** members of [**EVENT\_TRACE\_LOGFIL
 <td><strong>EVENT_TRACE_DELAY_OPEN_FILE_MODE</strong>(0x00000200)</td>
 <td>This mode is used to delay opening the log file until an event occurs. <br/>
 <blockquote>
-[!Note]<br />
+[!NOTE]<br />
 On Windows Vista or later, this mode is not applicable should not be used.
 </blockquote>
 <br/></td>
@@ -90,7 +90,7 @@ Process ID filters and executable name filters can now be passed in to session c
 <td><strong>EVENT_TRACE_ADD_HEADER_MODE</strong>(0x00001000)</td>
 <td>This option adds a header to the log file.<br/>
 <blockquote>
-[!Note]<br />
+[!NOTE]<br />
 On Windows Vista or later, this mode is not applicable should not be used.
 </blockquote>
 <br/></td>
@@ -111,7 +111,7 @@ On Windows Vista or later, this mode is not applicable should not be used.
 <td><strong>EVENT_TRACE_RELOG_MODE</strong> (0x00010000)</td>
 <td>Logs the event without including <a href="event-trace-header.md"><strong>EVENT_TRACE_HEADER</strong></a>.
 <blockquote>
-[!Note]<br />
+[!NOTE]<br />
 This mode should not be used. It is reserved for internal use.
 </blockquote>
 <br/> <strong>Windows 2000:</strong> This value is not supported.<br/></td>
@@ -154,15 +154,3 @@ This mode should not be used. It is reserved for internal use.
 </tr>
 </tbody>
 </table>
-
-
-
- 
-
- 
-
- 
-
-
-
-

--- a/desktop-src/EventLog/about-event-logging.md
+++ b/desktop-src/EventLog/about-event-logging.md
@@ -14,7 +14,6 @@ When an error occurs, the system administrator or support representative must de
 > The Event Logging API was designed for applications that run on the Windows Server 2003, Windows XP, or Windows 2000 operating system. In Windows Vista, the event logging infrastructure was redesigned. Applications that are designed to run on the Windows Vista or later operating systems should now use [Windows Event Log](https://docs.microsoft.com/windows/desktop/WES/windows-event-log) to log events.
 
  
-
 This section discusses the programming interface for writing and consuming events using Event Logging.
 
 -   [Event types](event-types.md)
@@ -26,12 +25,3 @@ This section discusses the programming interface for writing and consuming event
 
 > [!Note]  
 > Applications that publish events that are larger than 64 kilobytes on a Windows Server 2003, Windows XP, or Windows 2000 computer will not be able to publish events on a Windows Vista or later computer.
-
- 
-
- 
-
- 
-
-
-

--- a/desktop-src/EventLog/event-logging.md
+++ b/desktop-src/EventLog/event-logging.md
@@ -18,12 +18,3 @@ Event logging provides a standard, centralized way for applications (and the ope
 
 > [!Note]  
 > The Event Logging API was designed for applications that run on the Windows Server 2003, Windows XP, or Windows 2000 operating system. In Windows Vista, the event logging infrastructure was redesigned. Applications that are designed to run on Windows Vista or later operating systems should use [Windows Event Log](https://docs.microsoft.com/windows/desktop/WES/windows-event-log) to log events.
-
- 
-
- 
-
- 
-
-
-

--- a/desktop-src/WES/accessing-remote-computers.md
+++ b/desktop-src/WES/accessing-remote-computers.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 You can use the Windows Event Log API to access data on the local computer or on a remote computer. To access data on a remote computer, you need to call the [**EvtOpenSession**](/windows/desktop/api/WinEvt/nf-winevt-evtopensession) function to create a remote session context. When you call this function, you specify the name of the remote computer that you want to connect to, the user credentials to use to make the connection, and the type of authentication to use to authenticate the user. To specify the current user, set the Domain, User, and Password members to **NULL**.
 
-When you call Windows Event Log API, you pass the handle to the remote session context that the [**EvtOpenSession**](/windows/desktop/api/WinEvt/nf-winevt-evtopensession) function returns. (To access data on the local computer, you pass **NULL** to specify the default session, which is used to access the local computer.) To access data on the remote computer, the remote computer must enable the "Remote Event Log Management" Windows Firewall exception; otherwise, when you try to use the session handle, the call will error with RPC\_S\_SERVER\_UNAVAILABLE. The computer to which you are connecting must be running Windows Vista or later.
+When you call Windows Event Log API, you pass the handle to the remote session context that the [**EvtOpenSession**](/windows/desktop/api/WinEvt/nf-winevt-evtopensession) function returns. (To access data on the local computer, pass **NULL** to specify the default session.) To access data on the remote computer, the remote computer must enable the "Remote Event Log Management" Windows Firewall exception; otherwise, when you try to use the session handle, the call will error with RPC\_S\_SERVER\_UNAVAILABLE. The computer to which you are connecting must be running Windows Vista or later.
 
 The following example shows how to connect to a remote computer.
 
@@ -70,7 +70,7 @@ EVT_HANDLE ConnectToRemote(LPWSTR lpwszRemote)
     Credentials.Password = NULL; 
     Credentials.Flags = EvtRpcLoginAuthNegotiate; 
 
-    // This call creates a remote seesion context; it does not actually
+    // This call creates a remote session context; it does not actually
     // create a connection to the remote computer. The connection to
     // the remote computer happens when you use the context.
     hRemote = EvtOpenSession(EvtRpcLogin, &Credentials, 0, 0);
@@ -121,13 +121,3 @@ cleanup:
         EvtClose(hPublishers);
 }
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-channels.md
+++ b/desktop-src/WES/defining-channels.md
@@ -23,7 +23,7 @@ The following example shows how to import a channel. You must set the **chid** a
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
@@ -43,6 +43,7 @@ The following example shows how to import a channel. You must set the **chid** a
                 </channels>
 
                 . . .
+
             </provider>
         </events>
     </instrumentation>
@@ -58,35 +59,33 @@ The following example shows how to import a channel. You must set the **chid** a
 </instrumentationManifest>
 ```
 
-
-
 Although Winmeta.xml defines legacy channels that you can import, you should not use them unless you are supporting legacy consumers that consume events out of the legacy channels (for example, Application or System). The Winmeta.xml file is included in the Windows SDK.
 
 The following example shows how to define a channel. You must set the **chid**, **name**, and **type** attributes. The **chid** attribute uniquely identifies the channel—each channel identifier in your list of channels must be unique. Set the **chid** attribute to a value that is unique for the channels that your provider lists; the channel identifier is referenced in one or more of your event definitions. The convention for naming the channel is to use the provider name and channel type in the form, *providername*/*channeltype*.
 
-
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
                 <channels>
-                    <importChannel chid="c1" 
+                    <importChannel chid="c1"
                                    name="Microsoft-Windows-BaseProvider/Admin"
                                    symbol="CHANNEL_BASEPROVIDER_ADMIN"
                                    />
-                    <channel chid="c2" 
+
+                    <channel chid="c2"
                              name="Microsoft-Windows-SampleProvider/Operational"
                              type="Operational"
                              enabled="true"
@@ -109,13 +108,3 @@ The following example shows how to define a channel. You must set the **chid**, 
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-channels.md
+++ b/desktop-src/WES/defining-channels.md
@@ -22,8 +22,8 @@ The following example shows how to import a channel. You must set the **chid** a
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
@@ -36,10 +36,10 @@ The following example shows how to import a channel. You must set the **chid** a
                 message="$(string.Provider.Name)">
 
                 <channels>
-                    <importChannel chid="c1" 
-                                   name="Microsoft-Windows-BaseProvider/Admin"
-                                   symbol="CHANNEL_BASEPROVIDER_ADMIN"
-                                   />
+                    <channel chid="c1"
+                             name="Microsoft-Windows-BaseProvider/Admin"
+                             symbol="CHANNEL_BASEPROVIDER_ADMIN"
+                             type="Admin"/>
                 </channels>
 
                 . . .

--- a/desktop-src/WES/defining-event-data-templates.md
+++ b/desktop-src/WES/defining-event-data-templates.md
@@ -68,11 +68,16 @@ The following example shows how to define a template. You must specify the templ
 
                 <templates>
                     <template tid="t2">
+                        <data name="TransferName" inType="win:UnicodeString"/>
                         <data name="Day" inType="win:UInt32" map="DaysOfTheWeek"/>
                         <data name="Transfer" inType="win:UInt32" map="TransferType"/>
                     </template>
 
                     <template tid="t3">
+                        <data name="TransferName" inType="win:UnicodeString"/>
+                        <data name="ErrorCode" inType="win:Int32" outType="win:HResult"/>
+                        <data name="FilesCount" inType="win:UInt16" />
+                        <data name="Files" inType="win:UnicodeString" count="FilesCount"/>
                         <data name="BufferSize" inType="win:UInt32" />
                         <data name="Buffer" inType="win:Binary" length="BufferSize"/>
                         <data name="Certificate" inType="win:Binary" length="11" />

--- a/desktop-src/WES/defining-event-data-templates.md
+++ b/desktop-src/WES/defining-event-data-templates.md
@@ -34,16 +34,16 @@ The following example shows how to define a template. You must specify the templ
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -117,13 +117,3 @@ The following example shows how to define a template. You must specify the templ
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-events.md
+++ b/desktop-src/WES/defining-events.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Providers must define all the events that they write. To define an event, use the **event** element.
 
-The **value** attribute is the event identifier and it must be unique for the events that you define. Whether you set the other attributes depends on who will be consuming the events and from where. If administrators will be consuming your events using a tool like Windows Event Viewer, then you must set the **channel** attribute. If the channel type is Admin, then you must also specify the **level** attribute and set it to one of the levels defined in Winmeta.xml (win:Critical through win:Informational).
+The **value** attribute is the event identifier and it must be unique for the events that you define. Whether you set the other attributes depends on who will be consuming the events and from where. If administrators will be consuming your events using a tool like Windows Event Viewer, then you must set the **channel** attribute. If the channel type is Admin, then you must also specify the **level** attribute and set it to one of the levels defined in Winmeta.xml (win:Critical through win:Verbose).
 
 If the event contains event-specific data, you must set the **template** attribute to the identifier of the template that defines the event-specific data. The **level**, **keywords**, **task**, and **opcode** attributes are used to group or bucket events. Although these attributes are optional, you should consider specifying level, task, opcode, and keywords, so that consumers can easily access only those events of interest. The **level** and **keywords** attributes can also be used by an ETW tracing session to limit the events that are written to the event tracing log file. The **keywords** attribute contains a space-delimited list of keyword names defined in the manifest. If multiple keywords are specified their mask values are OR'ed together to create the keyword value that the event will use.
 
@@ -24,7 +24,7 @@ The following example shows a complete manifest that defines events.
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events"
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
     <instrumentation>
         <events>
@@ -36,10 +36,16 @@ The following example shows a complete manifest that defines events.
                 message="$(string.Provider.Name)">
 
                 <channels>
-                    <channel chid="c1"
-                             name="Microsoft-Windows-BaseProvider/Admin"
-                             symbol="CHANNEL_BASEPROVIDER_ADMIN"
-                             type="Admin"/>
+                    <importChannel chid="c1"
+                                   name="Microsoft-Windows-BaseProvider/Admin"
+                                   symbol="CHANNEL_BASEPROVIDER_ADMIN"
+                                   />
+
+                    <channel chid="c2"
+                             name="Microsoft-Windows-SampleProvider/Operational"
+                             type="Operational"
+                             enabled="true"
+                             />
                 </channels>
 
                 <levels>
@@ -140,16 +146,16 @@ The following example shows a complete manifest that defines events.
                 </templates>
 
                 <events>
-                    <event value="1" 
-                        level="win:Informational" 
+                    <event value="1"
+                        level="win:Informational"
                         keywords="Remote Read"
                         task="Connect"
-                        template="t2" 
+                        template="t2"
                         channel="c1"
                         symbol="TRANSFER_SCHEDULE_EVENT"
                         message ="$(string.Event.XferSchedule)"/>
 
-                    <event value="2" 
+                    <event value="2"
                         level="win:Error"
                         keywords="Remote Write"
                         task="Disconnect"
@@ -165,6 +171,7 @@ The following example shows a complete manifest that defines events.
                         task="Validate"
                         opcode="Cleanup"
                         template="t4"
+                        channel="c2"
                         symbol="TEMPFILE_CLEANUP_EVENT"
                         message ="$(string.Event.TempFilesNotDeleted)"/>
                 </events>

--- a/desktop-src/WES/defining-events.md
+++ b/desktop-src/WES/defining-events.md
@@ -12,92 +12,83 @@ Providers must define all the events that they write. To define an event, use th
 
 The **value** attribute is the event identifier and it must be unique for the events that you define. Whether you set the other attributes depends on who will be consuming the events and from where. If administrators will be consuming your events using a tool like Windows Event Viewer, then you must set the **channel** attribute. If the channel type is Admin, then you must also specify the **level** attribute and set it to one of the levels defined in Winmeta.xml (win:Critical through win:Informational).
 
-If the event contains event-specific data, you must set the **template** attribute to the identifier of the template that defines the event-specific data. The **level**, **keywords**, **task**, and **opcode** attributes are used to group or bucket events. Although these attributes are optional, you should consider specifying level, task, and opcode, so that consumers can easily access only those events of interest. The **level** and **keywords** attributes can also be used by an ETW tracing session to limit the events that are written to the event tracing log file. The **keywords** attribute contains a space-delimited list of keyword names defined in the manifest.
+If the event contains event-specific data, you must set the **template** attribute to the identifier of the template that defines the event-specific data. The **level**, **keywords**, **task**, and **opcode** attributes are used to group or bucket events. Although these attributes are optional, you should consider specifying level, task, opcode, and keywords, so that consumers can easily access only those events of interest. The **level** and **keywords** attributes can also be used by an ETW tracing session to limit the events that are written to the event tracing log file. The **keywords** attribute contains a space-delimited list of keyword names defined in the manifest. If multiple keywords are specified their mask values are OR'ed together to create the keyword value that the event will use.
 
 You should set the **symbol** attribute to specify the symbolic constant that the compiler generates to identify the event's event descriptor—you use the event descriptor when writing the event. If you do not specify the symbol, the compiler will generate a name for you.
 
 The **message** attribute contains the localized message string that is displayed with the event. To include event-specific data in the string, add insertion strings to the message text. For example, to include the third data item in the template, include %3.
 
-The following example shows how to define events.
-
+The following example shows a complete manifest that defines events.
 
 ```XML
 <instrumentationManifest
-    xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns="http://schemas.microsoft.com/win/2004/08/events"
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
-
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
                 <channels>
-                    <channel chid="c1" 
-                             name="Microsoft-Windows-SampleProvider/Admin"
-                             type="Admin"
-                             enabled="true">
-
-                    <channel chid="c2" 
-                             name="Microsoft-Windows-SampleProvider/Operational"
-                             type="Operational"
-                             enabled="true">
+                    <channel chid="c1"
+                             name="Microsoft-Windows-BaseProvider/Admin"
+                             symbol="CHANNEL_BASEPROVIDER_ADMIN"
+                             type="Admin"/>
                 </channels>
 
+                <levels>
+                    <level name="NotValid"
+                           value="16"
+                           symbol="LEVEL_SAMPLEPROVIDER_NOTVALID"
+                           message="$(string.Level.NotValid)"/>
+
+                    <level name="Valid"
+                           value="17"
+                           symbol="LEVEL_SAMPLEPROVIDER_VALID"
+                           message="$(string.Level.Valid)"/>
+                </levels>
+
                 <tasks>
-                    <task />
- 
-                    <task name="Transfer" 
-                          symbol="TASK_TRANSFER"
-                          value="0" 
-                          message="$(string.Task.Transfer)">
+                    <task name="Disconnect"
+                          symbol="TASK_DISCONNECT"
+                          value="1"
+                          message="$(string.Task.Disconnect)"/>
 
-                        <opcodes>
-                            <opcode name="Download" 
-                                    symbol="OPCODE_DOWNLOAD_XFER" 
-                                    value="11"
-                                    message="$(string.Task.Transfer.Download)"/>
-                            <opcode name="Upload" 
-                                    symbol="OPCODE_UPLOAD_XFER" 
-                                    value="12"
-                                    message="$(string.Task.Transfer.Upload)"/>
-                            <opcode name="UploadReply" 
-                                    symbol="OPCODE_UPLOADREPLY_XFER" 
-                                    value="13"
-                                    message="$(string.Task.Transfer.UploadReply)"/>
-                        </opcodes>
-                    </task>
+                    <task name="Connect"
+                          symbol="TASK_CONNECT"
+                          value="2"
+                          message="$(string.Task.Connect)"/>
 
-                    <task name="Validate" 
+                    <task name="Validate"
                           symbol="TASK_VALIDATE"
-                          value="2" 
-                          message="$(string.Validate)">
-
-                        <opcodes>
-                            <opcode name="GetRules" 
-                                    symbol="OPCODE_GET_RULES" 
-                                    value="11"
-                                    message="$(string.Validate.GetRules)"/>
-                        </opcodes>
-                    </task>
+                          value="3"
+                          message="$(string.Task.Validate)"/>
                 </tasks>
 
                 <opcodes>
-                    <opcode name="Initialize" 
-                            symbol="OPCODE_INITIALIZE" 
+                    <opcode name="Initialize"
+                            symbol="OPCODE_INITIALIZE"
                             value="12"
-                            message="$(string.Initialize)"/>
+                            message="$(string.Opcode.Initialize)"/>
 
-                    <opcode name="Cleanup" 
-                            symbol="OPCODE_CLEANUP" 
+                    <opcode name="Cleanup"
+                            symbol="OPCODE_CLEANUP"
                             value="13"
-                            message="$(string.Cleanup)"/>
+                            message="$(string.Opcode.Cleanup)"/>
                  </opcodes>
+
+                <keywords>
+                    <keyword name="Read" mask="0x1" symbol="READ_KEYWORD"/>
+                    <keyword name="Write" mask="0x2" symbol="WRITE_KEYWORD"/>
+                    <keyword name="Local" mask="0x4" symbol="LOCAL_KEYWORD"/>
+                    <keyword name="Remote" mask="0x8" symbol="REMOTE_KEYWORD"/>
+                </keywords>
 
                 <maps>
                     <valueMap name="TransferType">
@@ -105,6 +96,7 @@ The following example shows how to define events.
                         <map value="2" message="$(string.TransferType.Upload)"/>
                         <map value="3" message="$(string.TransferType.UploadReply)"/>
                     </valueMap>
+
                     <bitMap name="DaysOfTheWeek">
                         <map value="0x1" message="$(string.DaysOfTheWeek.Sunday)"/>
                         <map value="0x2" message="$(string.DaysOfTheWeek.Monday)"/>
@@ -119,8 +111,8 @@ The following example shows how to define events.
                 <templates>
                     <template tid="t2">
                         <data name="TransferName" inType="win:UnicodeString"/>
-                        <data name="TransferType" inType="win:UInt32" map="TransferType"/>
                         <data name="Day" inType="win:UInt32" map="DaysOfTheWeek"/>
+                        <data name="Transfer" inType="win:UInt32" map="TransferType"/>
                     </template>
 
                     <template tid="t3">
@@ -128,7 +120,17 @@ The following example shows how to define events.
                         <data name="ErrorCode" inType="win:Int32" outType="win:HResult"/>
                         <data name="FilesCount" inType="win:UInt16" />
                         <data name="Files" inType="win:UnicodeString" count="FilesCount"/>
-                   </template>
+                        <data name="BufferSize" inType="win:UInt32" />
+                        <data name="Buffer" inType="win:Binary" length="BufferSize"/>
+                        <data name="Certificate" inType="win:Binary" length="11" />
+                        <data name="IsLocal" inType="win:Boolean" />
+                        <data name="Path" inType="win:UnicodeString" />
+                        <data name="ValuesCount" inType="win:UInt16" />
+                        <struct name="Values" count="ValuesCount" >
+                            <data name="Value" inType="win:UInt16" />
+                            <data name="Name" inType="win:UnicodeString" />
+                        </struct>
+                    </template>
 
                     <template tid="t4">
                         <data name="FilesCount" inType="win:UInt16" />
@@ -140,31 +142,32 @@ The following example shows how to define events.
                 <events>
                     <event value="1" 
                         level="win:Informational" 
-                        task="Transfer"
+                        keywords="Remote Read"
+                        task="Connect"
                         template="t2" 
-                        channel="c2" 
+                        channel="c1"
                         symbol="TRANSFER_SCHEDULE_EVENT"
                         message ="$(string.Event.XferSchedule)"/>
 
                     <event value="2" 
-                        level="win:Error" 
-                        task="Transfer"
-                        opcode="Download"
-                        template="t3" 
-                        channel="c1" 
+                        level="win:Error"
+                        keywords="Remote Write"
+                        task="Disconnect"
+                        opcode="Initialize"
+                        template="t3"
+                        channel="c1"
                         symbol="DOWNLOAD_XFER_FAILED_EVENT"
                         message ="$(string.Event.DownloadFailed)"/>
 
-                    <event value="3" 
-                        level="win:Warning" 
-                        task="Transfer"
+                    <event value="3"
+                        level="NotValid"
+                        keywords="Local Write"
+                        task="Validate"
                         opcode="Cleanup"
-                        template="t4" 
-                        channel="c1" 
+                        template="t4"
                         symbol="TEMPFILE_CLEANUP_EVENT"
                         message ="$(string.Event.TempFilesNotDeleted)"/>
                 </events>
-
             </provider>
         </events>
     </instrumentation>
@@ -173,16 +176,18 @@ The following example shows how to define events.
         <resources culture="en-US">
             <stringTable>
                 <string id="Provider.Name" value="Sample Provider"/>
-
-                <string id="Task.Transfer" value="Transfer"/>
-                <string id="Task.Transfer.Download" value="Download transfer operation"/>
-                <string id="Task.Transfer.Upload" value="Upload transfer operation"/>
-                <string id="Task.Transfer.UploadReply" value="Upload-reply transfer operation"/>
-
-                <string id="TransferType.Download" value="download"/>
-                <string id="TransferType.Upload" value="upload"/>
-                <string id="TransferType.UploadReply" value="upload-reply"/>
-
+                <string id="Level.Valid" value="Valid"/>
+                <string id="Level.NotValid" value="Not Valid"/>
+                <string id="Task.Disconnect" value="Disconnect"/>
+                <string id="Task.Connect" value="Connect"/>
+                <string id="Task.Connect.ReadRegistry" value="ReadRegistry"/>
+                <string id="Task.Validate" value="Connect"/>
+                <string id="Task.Validate.GetRules" value="GetRules"/>
+                <string id="Opcode.Initialize" value="Initialize"/>
+                <string id="Opcode.Cleanup" value="Cleanup"/>
+                <string id="TransferType.Download" value="Download"/>
+                <string id="TransferType.Upload" value="Upload"/>
+                <string id="TransferType.UploadReply" value="Upload-reply"/>
                 <string id="DaysOfTheWeek.Sunday" value="Sunday"/>
                 <string id="DaysOfTheWeek.Monday" value="Monday"/>
                 <string id="DaysOfTheWeek.Tuesday" value="Tuesday"/>
@@ -190,23 +195,11 @@ The following example shows how to define events.
                 <string id="DaysOfTheWeek.Thursday" value="Thursday"/>
                 <string id="DaysOfTheWeek.Friday" value="Friday"/>
                 <string id="DaysOfTheWeek.Saturday" value="Saturday"/>
-
                 <string id="Event.XferSchedule" value="The %1 %2 transfer will occur on %3."/>
                 <string id="Event.DownloadFailed" value="The %1 download job failed with %2. The job contains the following files:%n%n%4"/>
                 <string id="Event.TempFilesNotDeleted" value="The following temp files were not removed from %3:%n%n%2"/>
             </stringTable>
         </resources>
     </localization>
-
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-filters.md
+++ b/desktop-src/WES/defining-filters.md
@@ -18,16 +18,16 @@ The following example shows how to use the **filter** element to define a filter
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -62,13 +62,3 @@ The following example shows how to use the **filter** element to define a filter
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-filters.md
+++ b/desktop-src/WES/defining-filters.md
@@ -19,7 +19,7 @@ The following example shows how to use the **filter** element to define a filter
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/defining-keywords-used-to-classify-types-of-events.md
+++ b/desktop-src/WES/defining-keywords-used-to-classify-types-of-events.md
@@ -14,22 +14,25 @@ An ETW tracing session can use the keywords (in the same way that it uses level)
 
 For example, if the provider defines an event that specifies a read keyword (bit 0) and a local access keyword (bit 1), and a second event that specifies a read keyword (bit 0) and a remote access keyword (bit 2), you could set the "Any" bitmask to 1 to receive all read events, or you could set the "Any" bitmask to 1 and "All" bitmask to 3 to receive only local reads.
 
-The following example shows how to define a keyword. You must specify the keyword's **name** and **mask** attributes. The mask must have only one set—the keyword identifies the bit. The event definition's **keyword** attribute contains a space-separated list of keyword names. The **symbol** and **message** attributes are optional.
+You must specify the keyword's **name** and **mask** attributes. The mask must set only one bit, between bit 0 and bit 47. Bits 48 through 64 are reserved by the system. If an event's **keyword** attribute contains a space-separated list of keyword names then the event's keyword mask will be each of specified keywords' masks OR'ed together.
 
+The **symbol** and **message** attributes are optional.
+
+The following example shows how to define a keyword.
 
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -58,13 +61,3 @@ The following example shows how to define a keyword. You must specify the keywor
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-keywords-used-to-classify-types-of-events.md
+++ b/desktop-src/WES/defining-keywords-used-to-classify-types-of-events.md
@@ -14,7 +14,7 @@ An ETW tracing session can use the keywords (in the same way that it uses level)
 
 For example, if the provider defines an event that specifies a read keyword (bit 0) and a local access keyword (bit 1), and a second event that specifies a read keyword (bit 0) and a remote access keyword (bit 2), you could set the "Any" bitmask to 1 to receive all read events, or you could set the "Any" bitmask to 1 and "All" bitmask to 3 to receive only local reads.
 
-You must specify the keyword's **name** and **mask** attributes. The mask must set only one bit, between bit 0 and bit 47. Bits 48 through 64 are reserved by the system. If an event's **keyword** attribute contains a space-separated list of keyword names then the event's keyword mask will be each of specified keywords' masks OR'ed together.
+You must specify the keyword's **name** and **mask** attributes. The mask must set only one bit, between bit 0 and bit 47. Bits 48 through 64 are reserved.
 
 The **symbol** and **message** attributes are optional.
 
@@ -24,7 +24,7 @@ The following example shows how to define a keyword.
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/defining-name-value-mappings.md
+++ b/desktop-src/WES/defining-name-value-mappings.md
@@ -19,7 +19,7 @@ The following example shows how to define a value map and a bitmap. You must spe
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/defining-name-value-mappings.md
+++ b/desktop-src/WES/defining-name-value-mappings.md
@@ -18,16 +18,16 @@ The following example shows how to define a value map and a bitmap. You must spe
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -76,13 +76,3 @@ The following example shows how to define a value map and a bitmap. You must spe
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-severity-levels.md
+++ b/desktop-src/WES/defining-severity-levels.md
@@ -25,7 +25,7 @@ The following example shows how to define a level. You must specify the level's 
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/defining-severity-levels.md
+++ b/desktop-src/WES/defining-severity-levels.md
@@ -24,16 +24,16 @@ The following example shows how to define a level. You must specify the level's 
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -68,13 +68,3 @@ The following example shows how to define a level. You must specify the level's 
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-tasks-and-opcodes.md
+++ b/desktop-src/WES/defining-tasks-and-opcodes.md
@@ -10,24 +10,23 @@ ms.date: 05/31/2018
 
 Providers use tasks and opcodes to logically group events. Grouping events helps consumers query for only those events that contain specific task and opcode combinations. Typically, you use tasks to identify a major component of the provider such as the networking or database component. You could then use opcodes to identify the operations that the component performs, such as the send and receive operations for a networking component. If you had only one component, you could use task to reflect a major operation in the component, such as connect or disconnect, and use opcode to reflect an activity within the operation such as reading the registry. You could also use opcode without specifying a task. How you use task and opcodes to group events for the consumer is completely up to you.
 
-To define a task, use the **task** element. To define an opcode, use the **opcode** element. You can define the opcodes at the provider level (known as global opcodes) or locally at the task level (known as task-specific opcodes). If your provider will define more than 228 operations, you must define task-specific opcodes or a combination of task-specific and global opcodes. You can specify up to 228 global opcodes and up to 228 task-specific opcodes for each task that you define. The opcodes must be in the range from 11 through 239. The Winmeta.xml file defines common operations that you can use instead of defining your own.
+To define a task, use the **task** element. To define an opcode, use the **opcode** element. You can specify up to 228 opcodes. The task **value** must be greater than 0. The opcodes must be in the range from 11 through 239. The Winmeta.xml file defines common operations that you can use instead of defining your own.
 
-The following example shows how to define a task, a task with task-specific opcodes, and several global opcodes.
-
+The following example shows how to define several tasks and opcodes.
 
 ```XML
 <instrumentationManifest
-    xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns="http://schemas.microsoft.com/win/2004/08/events"
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="https://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>
         <events>
-            <provider name="Microsoft-Windows-SampleProvider" 
-                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}" 
-                symbol="PROVIDER_GUID" 
-                resourceFileName="<path to the exe or dll that contains the metadata resources>" 
+            <provider name="Microsoft-Windows-SampleProvider"
+                guid="{1db28f2e-8f80-4027-8c5a-a11f7f10f62d}"
+                symbol="PROVIDER_GUID"
+                resourceFileName="<path to the exe or dll that contains the metadata resources>"
                 messageFileName="<path to the exe or dll that contains the string resources>"
                 message="$(string.Provider.Name)">
 
@@ -36,33 +35,19 @@ The following example shows how to define a task, a task with task-specific opco
                 <tasks>
                     <task name="Disconnect" 
                           symbol="TASK_DISCONNECT"
-                          value="0" 
+                          value="1"
                           message="$(string.Task.Disconnect)"/>
  
                     <task name="Connect" 
                           symbol="TASK_CONNECT"
-                          value="1" 
+                          value="2"
                           message="$(string.Task.Connect)">
-
-                        <opcodes>
-                            <opcode name="ReadRegistry" 
-                                    symbol="OPCODE_READ_REGISTRY" 
-                                    value="11"
-                                    message="$(string.Task.Connect.ReadRegistry)"/>
-                        </opcodes>
                     </task>
 
                     <task name="Validate" 
                           symbol="TASK_VALIDATE"
-                          value="2" 
+                          value="3"
                           message="$(string.Task.Validate)">
-
-                        <opcodes>
-                            <opcode name="GetRules" 
-                                    symbol="OPCODE_GET_RULES" 
-                                    value="11"
-                                    message="$(string.Task.Validate.GetRules)"/>
-                        </opcodes>
                     </task>
                 </tasks>
 
@@ -101,13 +86,3 @@ The following example shows how to define a task, a task with task-specific opco
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/defining-tasks-and-opcodes.md
+++ b/desktop-src/WES/defining-tasks-and-opcodes.md
@@ -18,7 +18,7 @@ The following example shows how to define several tasks and opcodes.
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events"
     xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/developing-a-provider.md
+++ b/desktop-src/WES/developing-a-provider.md
@@ -18,13 +18,3 @@ wevtutil im provider.man
 
 wevtutil um provider.man
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/eventmanifestschema-eventstype-complextype.md
+++ b/desktop-src/WES/eventmanifestschema-eventstype-complextype.md
@@ -74,57 +74,20 @@ Contains a list of providers that are defined in the manifest.
 
 ## Child elements
 
-
-
-<table>
-<colgroup>
-<col style="width: 33%" />
-<col style="width: 33%" />
-<col style="width: 33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Element</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><strong>message</strong></td>
-
-<td>Defines a message string. <br/></td>
-</tr>
-<tr class="even">
-<td><strong>messageTable</strong></td>
-
-<td>Defines a list of message strings. You should not have to use a message table except in the following cases where you must define a message table to explicitly assign resource numbers to message strings. <br/>
-<ul>
-<li>You are migrating from a message text (.mc) file to a manifest but are still writing events to the application and system channels, so that legacy consumers to continue consuming the events. To make this work, the resource identifiers for the message strings defined in the manifest must be the same as the event identifiers. However, the message compiler automatically assigns resource identifiers to the message strings. To override the compiler, use the message table and set the value attribute to the event identifier and the message attribute to refer to a string in the string table in the localization section of the manifest.</li>
-<li>If you want to identify more than 16 providers, you must include the message table that the seventeenth and on providers must use to assign resource values for the message strings that they define. If the provider references message strings that providers 1 through 16 defined, you do not include those message strings in the message table.</li>
-</ul></td>
-</tr>
-<tr class="odd">
-<td><a href="eventmanifestschema-provider-eventstype-element.md"><strong>provider</strong></a></td>
-<td><a href="eventmanifestschema-providertype-complextype.md"><strong>ProviderType</strong></a></td>
-<td>A list of providers that you want to define.<br/></td>
-</tr>
-</tbody>
-</table>
-
-
+| Element | Type | Description |
+|---------|------|-------------|
+| message |      | Defines a message string. |
+| messageTable | | Defines a list of message strings. You should not have to use a message table except in the following cases where you must define a message table to explicitly assign resource numbers to message strings. <ul><li>You are migrating from a message text (.mc) file to a manifest but are still writing events to the application and system channels, so that legacy consumers to continue consuming the events. To make this work, the resource identifiers for the message strings defined in the manifest must be the same as the event identifiers. However, the message compiler automatically assigns resource identifiers to the message strings. To override the compiler, use the message table and set the value attribute to the event identifier and the message attribute to refer to a string in the string table in the localization section of the manifest.</li><li>If you want to identify more than 16 providers, you must include the message table that the seventeenth and on providers must use to assign resource values for the message strings that they define. If the provider references message strings that providers 1 through 16 defined, you do not include those message strings in the message table.</li></ul>|
+| [**provider**](eventmanifestschema-provider-eventstype-element.md) | [**ProviderType**](eventmanifestschema-providertype-complextype.md) | A list of providers that you want to define. |
 
 ## Attributes
 
-
-
-| Name    | Type                                                              | Description                                                                                        |
-|---------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| message | [**strTableRef**](eventmanifestschema-strtableref-simpletype.md) | A reference to the localized string in the string table.<br/>                                |
-| mid     | xs:string                                                         | Not used.<br/>                                                                               |
-| symbol  | [**CSymbolType**](eventmanifestschema-csymboltype-simpletype.md) | The symbolic name that you want the message compiler to create for this message string.<br/> |
-| value   | [**UInt32Type**](eventmanifestschema-hexint32type-simpletype.md) | The number to use as the message identifier for this message.<br/>                           |
-
+| Name    | Type                                                             | Description                                                                            |
+|---------|------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| message | [**strTableRef**](eventmanifestschema-strtableref-simpletype.md) | A reference to the localized string in the string table.                               |
+| mid     | xs:string                                                        | Not used.                                                                              |
+| symbol  | [**CSymbolType**](eventmanifestschema-csymboltype-simpletype.md) | The symbolic name that you want the message compiler to create for this message string.|
+| value   | [**UInt32Type**](eventmanifestschema-hexint32type-simpletype.md) | The number to use as the message identifier for this message.                          |
 
 
 ## Remarks
@@ -133,20 +96,7 @@ The practical limit of the number of providers that you can define in a manifest
 
 ## Requirements
 
-
-
-|                                     |                                                      |
-|-------------------------------------|------------------------------------------------------|
-| Minimum supported client<br/> | Windows Vista \[desktop apps only\]<br/>       |
-| Minimum supported server<br/> | Windows Server 2008 \[desktop apps only\]<br/> |
-
-
-
- 
-
- 
-
-
-
-
-
+|                          |                                           |
+|--------------------------|-------------------------------------------|
+| Minimum supported client | Windows Vista \[desktop apps only\]       |
+| Minimum supported server | Windows Server 2008 \[desktop apps only\] |

--- a/desktop-src/WES/identifying-the-provider.md
+++ b/desktop-src/WES/identifying-the-provider.md
@@ -47,13 +47,3 @@ The following example shows how to use the **provider** element to identify a pr
 
 </instrumentationManifest>
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/localizing-message-strings.md
+++ b/desktop-src/WES/localizing-message-strings.md
@@ -48,7 +48,6 @@ The following example shows how to define a string table. You must specify the s
 ```
 
 
-
 Instead of adding localized strings to the manifest, you should create a multilingual user interface (MUI) file for each language that you support. Use a message text file to specify your localized strings.
 
 The following procedure describes how to create a MUI file for English and French.
@@ -76,7 +75,6 @@ The following procedure describes how to create a MUI file for English and Frenc
     
     ```
 
-    
 
 2.  Run the following commands to create the resource DLL that contains your localized strings. The messages.mc file is the message text file that you created in step 1.
     ```cmd
@@ -104,8 +102,7 @@ The following procedure describes how to create a MUI file for English and Frenc
           </resources>
     </localization>
     ```
-
-    
+  
 
 5.  Run the following Muirct.exe commands to split the English strings from the provider executable file.
     ```cmd
@@ -113,8 +110,7 @@ The following procedure describes how to create a MUI file for English and Frenc
 
     muirct -c provider.exe.ln -e en-US\provider.exe.mui
     ```
-
-    
+ 
 
 6.  Run the following Muirct.exe commands to split the French strings from the resource DLL. Remove the language neutral file (fr-FR\\messages.dll) after the MUI file is created.
     ```cmd
@@ -122,15 +118,6 @@ The following procedure describes how to create a MUI file for English and Frenc
 
     muirct -c provider.exe.ln -e fr-FR\provider.exe.mui
     ```
-
-    
+  
 
 7.  Rename provider.exe.ln to provider.exe.
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/message-compiler--mc-exe-.md
+++ b/desktop-src/WES/message-compiler--mc-exe-.md
@@ -19,10 +19,11 @@ ms.date: 05/31/2018
 Used to compile instrumentation manifests and message text files. The compiler generates the message resource files to which your application links.
 
 ``` syntax
-MC [-?aAbcdnouUv] [-co] [-cs namespace] [-css namespace] [-e extension] 
-   [-h path] [-km] [-m length] [-mof] [-p prefix] [-P prefix] [-r path] 
-   [-s path] [-t path] [-w path] [-W path] [-x path] [-z name]
-   filename [filename]
+MC [-?aAbcdnouUv] [-m <length>] [-h <path>] [-e <extension>] [-r <path>]
+   [-x <path>] [-w <file>] [-W <file>] [-z <basename> ] [-cp <encoding>]
+   [-km | -um | -generateProjections | -cs <namespace>]
+   [-mof] [-p <prefix>] [-P <prefix>]
+   [<filename.man>] [<filename.mc>]
 ```
 
 -   [Arguments common to both message text files and manifest files](#arguments-common-to-both-message-text-files-and-manifest-files)
@@ -45,6 +46,13 @@ Displays the usage information for the Message Compiler.
 </dt> <dd>
 
 Use this argument to have the compiler set the customer bit (bit 28) in all message IDs. For information on the customer bit, see winerror.h.
+
+</dd> <dt>
+
+<span id="-cp"></span><span id="-CP"></span>**-cp** *encoding*
+</dt> <dd>
+
+Use this argument to specify the character encoding used for all generated text files. Valid names include "ansi" (default), "utf-8", and "utf-16". The Unicode encodings will add a byte order mark.
 
 </dd> <dt>
 
@@ -167,14 +175,14 @@ You can use this argument with the **-km** or **-um** argument.
 <span id="-cs_namespace"></span><span id="-CS_NAMESPACE"></span>**-cs** *namespace*
 </dt> <dd>
 
-Use this argument to have the compiler generate a C# class that includes the methods that you would call to log the events defined in your manifest.
+Use this argument to have the compiler generate a C# class based on the .NET 3.5 [EventProvider](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.eventprovider?view=netframework-3.5) class.
 
 </dd> <dt>
 
 <span id="-css_namespace"></span><span id="-CSS_NAMESPACE"></span>**-css** *namespace*
 </dt> <dd>
 
-Use this argument to have the compiler generate a static C# class that includes the methods that you would call to log the events defined in your manifest.
+Use this argument to have the compiler generate a static C# class based on the .NET 3.5 [EventProvider](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.eventing.eventprovider?view=netframework-3.5) class.
 
 </dd> <dt>
 
@@ -188,7 +196,7 @@ Use this argument to have the compiler generate the kernel-mode code that you wo
 <span id="-mof"></span><span id="-MOF"></span>**-mof**
 </dt> <dd>
 
-Use this argument to have the compiler generate code that you can use to log events on computers prior to Windows Vista. This option also creates a MOF file that contains the MOF classes for each event defined in the manifest. To register the classes in the MOF file so that consumers can decode the events, use the MOF compiler (Mofcomp.exe). For details on using the MOF compiler, see [Managed Object Format](https://docs.microsoft.com/windows/desktop/WmiSdk/managed-object-format--mof-).
+DEPRECATED. Use this argument to have the compiler generate code that you can use to log events on computers prior to Windows Vista. This option also creates a MOF file that contains the MOF classes for each event defined in the manifest. To register the classes in the MOF file so that consumers can decode the events, use the MOF compiler (Mofcomp.exe). For details on using the MOF compiler, see [Managed Object Format](https://docs.microsoft.com/windows/desktop/WmiSdk/managed-object-format--mof-).
 
 To use this switch, you must adhere to the following restrictions:
 
@@ -246,14 +254,14 @@ The compiler uses the base name of the input file as the base name of the files 
 <span id="-a"></span><span id="-A"></span>**-a**
 </dt> <dd>
 
-Use this argument to specify that the *filename* input file contains ANSI content (this is the default).
+Use this argument to specify that the *filename* input file contains content in the system-default Windows ANSI code page (CP_ACP). This is the default. Use **-u** for Unicode.
 
 </dd> <dt>
 
 <span id="-A"></span><span id="-a"></span>**-A**
 </dt> <dd>
 
-Use this argument to specify that the messages in the output .bin file should be ANSI.
+DEPRECATED. Use this argument to specify that the messages in the output .bin file should be ANSI.
 
 </dd> <dt>
 
@@ -288,14 +296,14 @@ Use this argument to have the compiler generate an OLE2 header file using **HRES
 <span id="-u"></span><span id="-U"></span>**-u**
 </dt> <dd>
 
-Use this argument to specify that the *filename* input file contains Unicode content. The default is ANSI content.
+Use this argument to specify that the *filename* input file contains UTF-16LE content. The default is ANSI content.
 
 </dd> <dt>
 
 <span id="-U"></span><span id="-u"></span>**-U**
 </dt> <dd>
 
-Use this argument to specify that the messages in the output .bin file should be Unicode (this is the default).
+Use this argument to specify that the messages in the output .bin file should be Unicode. This is the default.
 
 </dd> <dt>
 
@@ -314,6 +322,8 @@ Use this argument to specify the folder into which you want the compiler to plac
 </dd> </dl>
 
 ## Remarks
+
+The **-A** and **-mof** arguments are deprecated and will be removed in the future.
 
 The compiler accepts as input a manifest (.man) file or a message text (.mc) file and generates the following files:
 
@@ -353,28 +363,10 @@ The following example compiles the manifest and places the header and resource f
 mc -h <pathgoeshere> -r <pathgoeshere> spooler.man
 ```
 
-The following example compiles the manifest and generates user-mode code to log events on all supported operating system releases.
-
-``` syntax
-mc -um -mof spooler.man
-```
-
 ## Requirements
-
 
 
 |                                     |                                                            |
 |-------------------------------------|------------------------------------------------------------|
 | Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/> |
 | Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>       |
-
-
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/WES/message-compiler--mc-exe-.md
+++ b/desktop-src/WES/message-compiler--mc-exe-.md
@@ -254,7 +254,7 @@ The compiler uses the base name of the input file as the base name of the files 
 <span id="-a"></span><span id="-A"></span>**-a**
 </dt> <dd>
 
-Use this argument to specify that the *filename* input file contains content in the system-default Windows ANSI code page (CP_ACP). This is the default. Use **-u** for Unicode.
+Use this argument to specify that the *filename* input file contains content in the system-default Windows ANSI code page (CP_ACP). This is the default. Use **-u** for Unicode. If the input file contains a BOM this argument will be ignored.
 
 </dd> <dt>
 
@@ -296,7 +296,7 @@ Use this argument to have the compiler generate an OLE2 header file using **HRES
 <span id="-u"></span><span id="-U"></span>**-u**
 </dt> <dd>
 
-Use this argument to specify that the *filename* input file contains UTF-16LE content. The default is ANSI content.
+Use this argument to specify that the *filename* input file contains UTF-16LE content. The default is ANSI content. If the input file contains a BOM this argument will be ignored.
 
 </dd> <dt>
 
@@ -365,8 +365,7 @@ mc -h <pathgoeshere> -r <pathgoeshere> spooler.man
 
 ## Requirements
 
-
-|                                     |                                                            |
-|-------------------------------------|------------------------------------------------------------|
-| Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/> |
-| Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>       |
+|                          |                                                 |
+|--------------------------|-------------------------------------------------|
+| Minimum supported client | Windows 2000 Professional \[desktop apps only\] |
+| Minimum supported server | Windows 2000 Server \[desktop apps only\]       |

--- a/desktop-src/WES/rendering-events.md
+++ b/desktop-src/WES/rendering-events.md
@@ -151,7 +151,7 @@ DWORD PrintEventSystemData(EVT_HANDLE hEvent)
     ullTimeStamp = pRenderedValues[EvtSystemTimeCreated].FileTimeVal;
     ft.dwHighDateTime = (DWORD)((ullTimeStamp >> 32) & 0xFFFFFFFF);
     ft.dwLowDateTime = (DWORD)(ullTimeStamp & 0xFFFFFFFF);
-    
+
     FileTimeToSystemTime(&ft, &st);
     ullNanoseconds = (ullTimeStamp % 10000000) * 100; // Display nanoseconds instead of milliseconds for higher resolution
     wprintf(L"TimeCreated SystemTime: %02d/%02d/%02d %02d:%02d:%02d.%I64u)\n", 
@@ -196,7 +196,6 @@ cleanup:
     return status;
 }
 ```
-
 
 
 The following example shows how to render the specific values from the event. Use an XPath expression to specify the specific node or attribute to retrieve. You can specify one or more expressions to retrieve one or more values.
@@ -268,13 +267,3 @@ cleanup:
     return status;
 }
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/toc.yml
+++ b/desktop-src/WES/toc.yml
@@ -1,7 +1,7 @@
 - name: "Windows Event Log"
   href: windows-event-log.md
   items: 
-  - name: "What&apos;s New"
+  - name: "What's New"
     href: what-s-new.md
   - name: "Using Windows Event Log"
     href: using-windows-event-log.md

--- a/desktop-src/WES/using-windows-event-log.md
+++ b/desktop-src/WES/using-windows-event-log.md
@@ -23,18 +23,6 @@ For details, see the following topics:
 
 ## Related topics
 
-<dl> <dt>
-
-[How Do I Enable WPP Tracing Through the Windows Event Log Service?](https://msdn.microsoft.com/library/ff684506(VS.85).aspx)
-</dt> <dt>
+[How Do I Enable WPP Tracing Through the Windows Event Log Service?](https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/enabling-wpp-tracing-through-windows-event-log)
 
 [Windows Event Log Reference](windows-event-log-reference.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/what-s-new.md
+++ b/desktop-src/WES/what-s-new.md
@@ -27,11 +27,3 @@ The following changes were made to the version of the [**Message Compiler**](mes
 
 -   Added arguments to have the compiler generate logging code based on your manifest. You can also request that the compiler generate code to log events on operating systems prior to Windows Vista. For a list of the arguments, see the "Arguments specific to generating code used to log events" section of the [**Message Compiler**](message-compiler--mc-exe-.md) topic.
 -   The compiler now enforces stricter syntactic and semantic validation on the manifest. This may cause some manifests that successfully compiled on previous versions of the message compiler to require changes in order to successfully compile using the latest version.
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/windows-event-log-reference.md
+++ b/desktop-src/WES/windows-event-log-reference.md
@@ -26,11 +26,3 @@ For applications written using a .NET language, such as C# or Visual Basic, see 
 -   To consume events from a Windows Event Log channel or log, use the classes and methods defined in the [System.Diagnostics.Eventing.Reader](https://msdn.microsoft.com/library/system.diagnostics.eventing.reader(VS.90).aspx) namespace.
 
 As an alternative to using the [System.Diagnostics.Eventing](https://msdn.microsoft.com/library/system.diagnostics.eventing(VS.90).aspx) namespace to write events, you can use the **-cs** or **-css** argument to have the message compiler generate the code to write the events. For details, see [**Message Compiler**](message-compiler--mc-exe-.md).
-
- 
-
- 
-
-
-
-

--- a/desktop-src/WES/windows-event-log-tools.md
+++ b/desktop-src/WES/windows-event-log-tools.md
@@ -12,21 +12,7 @@ Windows Event Log provides the following tools that you use to build your provid
 
 
 
-| Tool                                                           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-|----------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**Message Compiler (MC.exe)**](message-compiler--mc-exe-.md) | A command line utility used to compile instrumentation manifests and message text files.<br/>                                                                                                                                                                                                                                                                                                                                                                                                                |
-| WevtUtil.exe                                                   | A command line utility used primarily to register your provider on the computer. You can also use it to get metadata information about the provider, its events, and the channels to which it logs events, and to query events from a channel or log file. The WevtUtil.exe tool is included in %windir%\\System32. For usage information, enter "wevtutil /?" at a command prompt.<br/> This command is limited to members of the Administrators group and must be run with elevated privileges.<br/> |
-| ECManGen.exe                                                   | A GUI that guides you through creating a manifest from scratch without ever having to use XML tags. Having knowledge of the information in the [Writing an Instrumentation Manifest](writing-an-instrumentation-manifest.md) and [EventManifest Schema](eventmanifestschema-schema.md) sections will help when using the tool. The tool is included in the \\Bin folder of the Windows SDK.<br/>                                                                                                           |
-
-
-
- 
-
- 
-
- 
-
-
-
-
-
+| Tool                                                           | Description                                                                                   |
+|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| [**Message Compiler (MC.exe)**](message-compiler--mc-exe-.md)  | A command line utility used to compile instrumentation manifests and message text files. |
+| WevtUtil.exe                                                   | A command line utility used primarily to register your provider on the computer. You can also use it to get metadata information about the provider, its events, and the channels to which it logs events, and to query events from a channel or log file. The WevtUtil.exe tool is included in %windir%\\System32. For usage information, enter "wevtutil /?" at a command prompt.<br/> This command is limited to members of the Administrators group and must be run with elevated privileges.|

--- a/desktop-src/WES/windows-event-log.md
+++ b/desktop-src/WES/windows-event-log.md
@@ -29,25 +29,7 @@ For complete version history, see [What's New](what-s-new.md).
 ## In this section
 
 
-
-| Topic                                                                     | Description                                                                                                   |
-|---------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
-| [Using Windows Event Log](using-windows-event-log.md)<br/>         | Procedural guide that shows how to use the Windows Event Log API.<br/>                                  |
-| [Windows Event Log Reference](windows-event-log-reference.md)<br/> | The data types, functions, enumerations, structures, constants, and schemas that the API includes.<br/> |
-
-
-
- 
-
-## Additional resources
-
-To get answers to your questions and to find out how other people are using Windows Event Log, visit the [Windows Events](https://social.msdn.microsoft.com/Forums/en-US/etw/threads) forum on MSDN.
-
- 
-
- 
-
-
-
-
-
+| Topic                                                        | Description                                                                                       |
+|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| [Using Windows Event Log](using-windows-event-log.md)        | Procedural guide that shows how to use the Windows Event Log API.                                 |
+| [Windows Event Log Reference](windows-event-log-reference.md)| The data types, functions, enumerations, structures, constants, and schemas that the API includes.|


### PR DESCRIPTION
- Fix broken Markdown syntax (Note vs NOTE)
- Fix broken tables
- Fix typos and confusing grammar
- Fix xmlns:win namespace for events manifests. The manifest will not compile if the namespace is specified with https.
- Make sure the example events manifest actually compiles.
- Make the complete manifest build off the partial example manifests described earlier in the guide.
- Add additional notes that bits 48-64 of an ETW keyword are off-limits.
- Update mc.exe help to match the updated help printed by mc.exe -?
- Remove references to SDK tools that have been removed from the SDK (ecmangen.exe)