### PR TITLE
Make _tmain() return int instead of void.

### DIFF
--- a/desktop-src/FileIO/moving-directories.md
+++ b/desktop-src/FileIO/moving-directories.md
@@ -18,7 +18,7 @@ The following example demonstrates the use of the [**MoveFileEx**](/windows/desk
 #include <tchar.h>
 #include <stdio.h>
 
-void __cdecl _tmain(int argc, TCHAR *argv[])
+int __cdecl _tmain(int argc, TCHAR *argv[])
 {
     printf("\n");
     if( argc != 3 )

--- a/desktop-src/FileIO/opening-a-file-for-reading-or-writing.md
+++ b/desktop-src/FileIO/opening-a-file-for-reading-or-writing.md
@@ -25,7 +25,7 @@ A subsequent call to open this file with [**CreateFile**](/windows/desktop/api/F
 
 void DisplayError(LPTSTR lpszFunction);
 
-void __cdecl _tmain(int argc, TCHAR *argv[])
+int __cdecl _tmain(int argc, TCHAR *argv[])
 {
     HANDLE hFile; 
     char DataBuffer[] = "This is some test data to write to the file.";
@@ -175,7 +175,7 @@ VOID CALLBACK FileIOCompletionRoutine(
 // do not use parameters to differentiate between text and binary file types.
 //
 
-void __cdecl _tmain(int argc, TCHAR *argv[])
+int __cdecl _tmain(int argc, TCHAR *argv[])
 {
     HANDLE hFile; 
     DWORD  dwBytesRead = 0;

--- a/desktop-src/FileIO/testing-for-the-end-of-a-file.md
+++ b/desktop-src/FileIO/testing-for-the-end-of-a-file.md
@@ -236,7 +236,7 @@ DWORD AsyncTestForEnd( HANDLE hEvent, HANDLE hFile )
     return stOverlapped.Offset;
 }
 
-void __cdecl _tmain(int argc, TCHAR *argv[])
+int __cdecl _tmain(int argc, TCHAR *argv[])
 
 // To force an EOF condition, execute this application specifying a
 // zero-length file. This is because the offset (file pointer) must be

--- a/desktop-src/Services/svc-cpp.md
+++ b/desktop-src/Services/svc-cpp.md
@@ -44,9 +44,9 @@ VOID SvcReportEvent( LPTSTR );
 //   None
 // 
 // Return value:
-//   None
+//   None, defaults to 0 (zero)
 //
-void __cdecl _tmain(int argc, TCHAR *argv[]) 
+int __cdecl _tmain(int argc, TCHAR *argv[]) 
 { 
     // If command-line parameter is "install", install the service. 
     // Otherwise, the service is probably being started by the SCM.

--- a/desktop-src/Services/svcconfig-cpp.md
+++ b/desktop-src/Services/svcconfig-cpp.md
@@ -40,9 +40,9 @@ VOID __stdcall DoDeleteSvc(void);
 //   Command-line syntax is: svcconfig [command] [service_path]
 // 
 // Return value:
-//   None
+//   None, defaults to 0 (zero)
 //
-void __cdecl _tmain(int argc, TCHAR *argv[])
+int __cdecl _tmain(int argc, TCHAR *argv[])
 {
     printf("\n");
     if( argc != 3 )

--- a/desktop-src/Services/writing-a-service-program-s-main-function.md
+++ b/desktop-src/Services/writing-a-service-program-s-main-function.md
@@ -37,9 +37,9 @@ The \_tmain function is the entry point. The SvcReportEvent function writes info
 //   None
 // 
 // Return value:
-//   None
+//   None, defaults to 0 (zero)
 //
-void __cdecl _tmain(int argc, TCHAR *argv[]) 
+int __cdecl _tmain(int argc, TCHAR *argv[])
 { 
     // If command-line parameter is "install", install the service. 
     // Otherwise, the service is probably being started by the SCM.

--- a/desktop-src/SysInfo/enumerating-registry-subkeys.md
+++ b/desktop-src/SysInfo/enumerating-registry-subkeys.md
@@ -106,7 +106,7 @@ void QueryKey(HKEY hKey)
     }
 }
 
-void __cdecl _tmain(void)
+int __cdecl _tmain()
 {
    HKEY hTestKey;
 


### PR DESCRIPTION
Some samples won't compile since `_tmain()` is declared `void`.

Signed-off-by: Ted Lyngmo <ted@lyncon.se>