### PR TITLE
Fixed error in variable naming

### DIFF
--- a/desktop-src/direct3d11/d3d10-graphics-programming-guide-depth-stencil.md
+++ b/desktop-src/direct3d11/d3d10-graphics-programming-guide-depth-stencil.md
@@ -72,7 +72,7 @@ dsDesc.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
 
 // Create depth stencil state
 ID3D11DepthStencilState * pDSState;
-pd3dDeviceContext->CreateDepthStencilState(&dsDesc, &pDSState);
+pd3dDevice->CreateDepthStencilState(&dsDesc, &pDSState);
 ```
 
 


### PR DESCRIPTION
Depth stencil state (ID3D11DepthStencilState) is created using ID3D11Device, not ID3D11DeviceContext