### PR TITLE
Fix casing policy for AppUserModelID

### DIFF
--- a/desktop-src/shell/appids.md
+++ b/desktop-src/shell/appids.md
@@ -46,7 +46,7 @@ The following items describe common scenarios that require an explicit AppUserMo
 
 ## How to Form an Application-Defined AppUserModelID
 
-An application must provide its AppUserModelID in the following form. It can have no more than 128 characters and cannot contain spaces. Each section should be camel-cased.
+An application must provide its AppUserModelID in the following form. It can have no more than 128 characters and cannot contain spaces. Each section should be pascal-cased.
 
 `CompanyName.ProductName.SubProduct.VersionInformation`
 


### PR DESCRIPTION
Looking at the AppUserModelID Microsoft uses for its applications I assume the author meant to write pascal-case. This error lead to confusion within my team.