### PR TITLE
Clarify what you need to do to get WM_SIZE and WM_MOVE messages

### DIFF
--- a/desktop-src/winmsg/wm-move.md
+++ b/desktop-src/winmsg/wm-move.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Sent after a window has been moved.
 
-A window receives this message through its [**WindowProc**](https://msdn.microsoft.com/library/ms633573(v=VS.85).aspx) function.
+A window receives this message through its [**WindowProc**](https://docs.microsoft.com/\windows/win32/api/winuser/nf-winuser-defwindowproca) function.
 
 
 ```C++

--- a/desktop-src/winmsg/wm-move.md
+++ b/desktop-src/winmsg/wm-move.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Sent after a window has been moved.
 
-A window receives this message through its [**WindowProc**](https://docs.microsoft.com/\windows/win32/api/winuser/nf-winuser-defwindowproca) function.
+A window receives this message through its [**WindowProc**](https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-defwindowproca) function.
 
 
 ```C++

--- a/desktop-src/winmsg/wm-move.md
+++ b/desktop-src/winmsg/wm-move.md
@@ -59,6 +59,12 @@ yPos = (int)(short) HIWORD(lParam);   // vertical position
 
 You can also use the [**MAKEPOINTS**](https://msdn.microsoft.com/library/Dd145043(v=VS.85).aspx) macro to convert the *lParam* parameter to a [**POINTS**](https://msdn.microsoft.com/library/Dd162808(v=VS.85).aspx) structure.
 
+The [**DefWindowProc**](https://msdn.microsoft.com/library/ms633572(v=VS.85).aspx) function
+sends the **WM\_SIZE** and **WM\_MOVE** messages when it processes
+the [**WM\_WINDOWPOSCHANGED**](wm-windowposchanged.md) message.
+The **WM\_SIZE** and **WM\_MOVE** messages are not sent if an application handles
+the **WM\_WINDOWPOSCHANGED** message without calling **DefWindowProc**.
+
 ## Requirements
 
 
@@ -82,6 +88,9 @@ You can also use the [**MAKEPOINTS**](https://msdn.microsoft.com/library/Dd14504
 </dt> <dt>
 
 [**LOWORD**](https://msdn.microsoft.com/library/ms632659(v=VS.85).aspx)
+</dt> <dt>
+
+[**WM\_WINDOWPOSCHANGED**](wm-windowposchanged.md)
 </dt> <dt>
 
 **Conceptual**

--- a/desktop-src/winmsg/wm-size.md
+++ b/desktop-src/winmsg/wm-size.md
@@ -65,6 +65,12 @@ If the [**SetScrollPos**](https://msdn.microsoft.com/library/Cc411085(v=MSDN.10)
 
 Although the width and height of a window are 32-bit values, the *lParam* parameter contains only the low-order 16 bits of each.
 
+The [**DefWindowProc**](https://msdn.microsoft.com/library/ms633572(v=VS.85).aspx) function
+sends the **WM\_SIZE** and **WM\_MOVE** messages when it processes
+the [**WM\_WINDOWPOSCHANGED**](wm-windowposchanged.md) message.
+The **WM\_SIZE** and **WM\_MOVE** messages are not sent if an application handles
+the **WM\_WINDOWPOSCHANGED** message without calling **DefWindowProc**.
+
 ## Requirements
 
 
@@ -91,6 +97,9 @@ Although the width and height of a window are 32-bit values, the *lParam* parame
 </dt> <dt>
 
 [**MoveWindow**](https://msdn.microsoft.com/library/ms633534(v=VS.85).aspx)
+</dt> <dt>
+
+[**WM\_WINDOWPOSCHANGED**](wm-windowposchanged.md)
 </dt> <dt>
 
 **Conceptual**

--- a/desktop-src/winmsg/wm-size.md
+++ b/desktop-src/winmsg/wm-size.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Sent to a window after its size has changed.
 
-A window receives this message through its [**WindowProc**](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-defwindowproca) function.
+A window receives this message through its [**WindowProc**](https://docs.microsoft.com/windows/win32/api/winuser/nf-winuser-defwindowproca) function.
 
 
 ```C++

--- a/desktop-src/winmsg/wm-size.md
+++ b/desktop-src/winmsg/wm-size.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Sent to a window after its size has changed.
 
-A window receives this message through its [**WindowProc**](https://msdn.microsoft.com/library/ms633573(v=VS.85).aspx) function.
+A window receives this message through its [**WindowProc**](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-defwindowproca) function.
 
 
 ```C++


### PR DESCRIPTION
This has historically been [a source of confusion](https://stackoverflow.com/questions/61065523/no-wm-size-received-when-windows-resized).
