### PR TITLE
Update synchronization-and-multiprocessor-issues.md

### DIFF
--- a/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
+++ b/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
@@ -24,7 +24,7 @@ CPU caches can be partitioned into banks that can be accessed in parallel. This 
 
 Processors can support instructions for memory barriers with acquire, release, and fence semantics. These semantics describe the order in which results of an operation become available. With acquire semantics, the results of the operation are available before the results of any operation that appears after it in code. With release semantics, the results of the operation are available after the results of any operation that appears before it in code. Fence semantics combine acquire and release semantics. The results of an operation with fence semantics are available before those of any operation that appears after it in code and after those of any operation that appears before it.
 
-On x86 and x64 processors that support SSE2, the instructions are **mfence** (memory fence), **lfence** (load fence), and **sfence** (store fence). On ARM processors, the instrutions are **dmb**, **dsb**, and **isb** For more information, see the documentation for the processor.
+On x86 and x64 processors that support SSE2, the instructions are **mfence** (memory fence), **lfence** (load fence), and **sfence** (store fence). On ARM processors, the instrutions are **dmb** and **dsb**. For more information, see the documentation for the processor.
 
 The following synchronization functions use the appropriate barriers to ensure memory ordering:
 

--- a/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
+++ b/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
@@ -33,7 +33,6 @@ The following synchronization functions use the appropriate barriers to ensure m
 -   One-time initialization begin and completion
 -   **EnterSynchronizationBarrier** function
 -   Functions that signal synchronization objects
--   Functions that wake from waiting on condition variables or from waiting on addresses
 -   Wait functions
 -   Interlocked functions (except functions with _NoFence_ suffix, or intrinsics with _\_nf_ suffix)
 

--- a/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
+++ b/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
@@ -69,7 +69,7 @@ BOOL FetchComputedValue(int *piResult)
 
 This race condition above can be repaired by using the **volatile** keyword or the [**InterlockedExchange**](/windows/desktop/api/WinBase/nf-winbase-interlockedexchange) function to ensure that the value of `iValue` is updated for all processors before the value of `fValueHasBeenComputed` is set to **TRUE**.
 
-Starting Visual Studio 2005, if compimed in **/volaitle:ms** mode, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
+Starting Visual Studio 2005, if compiled in **/volaitle:ms** mode, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
 
 ``` syntax
 volatile int iValue;

--- a/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
+++ b/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
@@ -69,7 +69,7 @@ BOOL FetchComputedValue(int *piResult)
 
 This race condition above can be repaired by using the **volatile** keyword or the [**InterlockedExchange**](/windows/desktop/api/WinBase/nf-winbase-interlockedexchange) function to ensure that the value of `iValue` is updated for all processors before the value of `fValueHasBeenComputed` is set to **TRUE**.
 
-Starting Visual Studio 2005, if compiled in **/volaitle:ms** mode, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
+Starting Visual Studio 2005, if compiled in **/volatile:ms** mode, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
 
 ``` syntax
 volatile int iValue;

--- a/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
+++ b/desktop-src/Sync/synchronization-and-multiprocessor-issues.md
@@ -24,14 +24,18 @@ CPU caches can be partitioned into banks that can be accessed in parallel. This 
 
 Processors can support instructions for memory barriers with acquire, release, and fence semantics. These semantics describe the order in which results of an operation become available. With acquire semantics, the results of the operation are available before the results of any operation that appears after it in code. With release semantics, the results of the operation are available after the results of any operation that appears before it in code. Fence semantics combine acquire and release semantics. The results of an operation with fence semantics are available before those of any operation that appears after it in code and after those of any operation that appears before it.
 
-On Intel Itanium-based systems, the instruction is mf (memory fence) with the following modifiers: acq (acquire) and rel (release). On processors that support SSE2, the instructions are mfence (memory fence), lfence (load fence), and sfence (store fence). For more information, see the documentation for the processor.
+On x86 and x64 processors that support SSE2, the instructions are **mfence** (memory fence), **lfence** (load fence), and **sfence** (store fence). On ARM processors, the instrutions are **dmb**, **dsb**, and **isb** For more information, see the documentation for the processor.
 
 The following synchronization functions use the appropriate barriers to ensure memory ordering:
 
 -   Functions that enter or leave critical sections
+-   Functions that acquire or release SRW locks
+-   One-time initialization begin and completion
+-   **EnterSynchronizationBarrier** function
 -   Functions that signal synchronization objects
+-   Functions that wake from waiting on condition variables or from waiting on addresses
 -   Wait functions
--   Interlocked functions
+-   Interlocked functions (except functions with _NoFence_ suffix, or intrinsics with _\_nf_ suffix)
 
 ## Fixing a Race Condition
 
@@ -65,7 +69,7 @@ BOOL FetchComputedValue(int *piResult)
 
 This race condition above can be repaired by using the **volatile** keyword or the [**InterlockedExchange**](/windows/desktop/api/WinBase/nf-winbase-interlockedexchange) function to ensure that the value of `iValue` is updated for all processors before the value of `fValueHasBeenComputed` is set to **TRUE**.
 
-With Visual Studio 2005, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
+Starting Visual Studio 2005, if compimed in **/volaitle:ms** mode, the compiler uses acquire semantics for read operations on **volatile** variables and release semantics for write operations on **volatile** variables (when supported by the CPU). Therefore, you can correct the example as follows:
 
 ``` syntax
 volatile int iValue;


### PR DESCRIPTION
Memory ordering section aged a decade ago.
Added Vista+ primitives, added ARM, removed Itanium.
Noted that /volaitle:ms is needed to use volatile with acquire-release semantics.