### PR TITLE
Update context.md

### DIFF
--- a/desktop-src/shell/context.md
+++ b/desktop-src/shell/context.md
@@ -23,6 +23,8 @@ Additional information is available here:
 
 -   [How To Define Extended Verbs](how-to-define-extended-verbs.md)
 -   [How To Associate Verbs with DDE Commands](how-to-associate-verbs-with-dde-commands.md)
+-   [Verbs and File Associations](fa-verbs.md)
+-   [Old version of this article - The "Community Additions" contain information about possible `%...` replacement tokens](https://web.archive.org/web/20111002101214/http://msdn.microsoft.com/en-us/library/windows/desktop/cc144101(v=vs.85).aspx#contentFeedbackContainer)
 
 ## Shortcut Menus for File System Objects
 


### PR DESCRIPTION
More "Additional information" links!

The second link I added should possibly be changed to the official documentation, where `%L` `%w`, etc. are explained - but I couldn't find that information in any official microsoft documentation page...

"Allow edits by maintainers" is enabled, so you can change that link to an official documentation page about these <code>%<i>something</i></code> placeholders.