### PR TITLE
Fix potential typo in for R8G8_SINT.

### DIFF
--- a/desktop-src/direct3d12/typed-unordered-access-view-loads.md
+++ b/desktop-src/direct3d12/typed-unordered-access-view-loads.md
@@ -68,7 +68,7 @@ The following formats are optionally and individually supported on D3D12 and D3D
 -   R8G8\_UNORM
 -   R8G8\_UINT
 -   R8G8\_SNORM
--   8G8\_SINT
+-   R8G8\_SINT
 -   R16\_UNORM
 -   R16\_SNORM
 -   R8\_SNORM


### PR DESCRIPTION
Line 71 reads as 8G8_SINT, I believe this should be R8G8_SINT to match DXGI_FORMAT_R8G8_SINT.