### PR TITLE
HLSL Sample(): Fix rendering error

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-sample.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-sample.md
@@ -17,7 +17,7 @@ Samples a texture.
 
 |                                                                                  |
 |----------------------------------------------------------------------------------|
-| <Template Type> Object.Sample( sampler\_state S, float Location \[, int Offset\] ); |
+| &lt;Template Type&gt; Object.Sample( sampler\_state S, float Location \[, int Offset\] ); |
 
 ## Parameters
 


### PR DESCRIPTION
A malformed tag was causing <template type> to be
interpreted as an HTML template, breaking the layout
on https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-sample