### PR TITLE
Correct error in Return value

### DIFF
--- a/desktop-src/Controls/ttm-enumtools.md
+++ b/desktop-src/Controls/ttm-enumtools.md
@@ -42,7 +42,7 @@ Pointer to a [**TOOLINFO**](/windows/win32/api/commctrl/ns-commctrl-tttoolinfoa)
 
 ## Return value
 
-Returns **TRUE** if any tools are enumerated, or **FALSE** otherwise.
+Returns **FALSE** whether or not a tool was enumerated.
 
 ## Remarks
 


### PR DESCRIPTION
The return value of TTM_ENUMTOOLS is always FALSE, whether or not a tool is enumerated. (At least, for TTM_ENUMTOOLSA)