### PR TITLE
error in documented return value for TTM_ENUMTOOLS

### DIFF
--- a/desktop-src/Controls/ttm-enumtools.md
+++ b/desktop-src/Controls/ttm-enumtools.md
@@ -42,7 +42,7 @@ Pointer to a [**TOOLINFO**](/windows/win32/api/commctrl/ns-commctrl-tttoolinfoa)
 
 ## Return value
 
-Returns **TRUE** if any tools are enumerated, or **FALSE** otherwise.
+Returns **FALSE** whether or not a tool is enumerated.
 
 ## Remarks
 


### PR DESCRIPTION
The return value from TTM_ENUMTOOLS is always FALSE, whether or not a tool is enumerated, at least for the ASCII version TTM_ENUMTOOLSA