### PR TITLE
Very minor update to add TLS to the SSL nomenclature

### DIFF
--- a/desktop-src/Http/ssl-certificates.md
+++ b/desktop-src/Http/ssl-certificates.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # SSL Certificates
 
-Secure Sockets Layer (SSL) has become a standard for securing Internet connections and is used to prevent eavesdropping on the network. The SSL protocol allows a client and server to authenticate each other and negotiate encryption algorithms.
+Secure Sockets Layer (SSL), also known as Transport Layer Security (TLS), has become a standard for securing Internet connections and is used to prevent eavesdropping on the network. The SSL/TLS protocol allows a client and server to authenticate each other and negotiate encryption algorithms.
 
 SSL uses an encryption key and an encryption algorithm to secure the HTTP connection. The encryption keys are contained in SSL certificates used by both the client and the server. The certificate is typically an X.509 ([RFC 2459](https://www.ietf.org/rfc/rfc2459.txt)) document. The server provides the SSL certificate for the session and sends the certificate to the client in the handshake phase. The client sends its certificate to the server only if the server sends a request to the client for a certificate. Thus the client always authenticates the server but the server has the option whether or not to authenticate the client.
 


### PR DESCRIPTION
SSL is the old and familiar term; TLS is the newer and now more correct term. Both are commonly used (still), so we should include both of them on this page. I only updated the first paragraph because (a) it's the most important paragraph (b) we really should include TLS in order to match searches for TLS and (c) it's not actually my technology and I'm not the owner of the page, so I wanted to make as minimal of a change as possible.