### PR TITLE
Adding a TF 1.15 callout

### DIFF
--- a/desktop-src/direct3d12/gpu-tensorflow-wsl.md
+++ b/desktop-src/direct3d12/gpu-tensorflow-wsl.md
@@ -82,6 +82,9 @@ conda activate directml
 
 Install the package of TensorFlow with a DirectML backend through pip by running the following command (replace `cp36` with `cp35` for Python 3.5, or `cp37` for Python 3.7).
 
+> [!NOTE]
+> The tensorflow-directml package only supports TensorFlow 1.15. 
+
 ```
 pip install https://github.com/microsoft/DirectML/releases/download/tensorflow-directml-1.15.3.dev200615/tensorflow_directml-1.15.3.dev200615-cp36-cp36m-linux_x86_64.whl
 ```


### PR DESCRIPTION
Adding a note to call out that currently only TensorFlow 1.15 is supported.