### PR TITLE
Remove uniform lane index requirement for Wave

### DIFF
--- a/desktop-src/direct3dhlsl/wavereadlaneat.md
+++ b/desktop-src/direct3dhlsl/wavereadlaneat.md
@@ -42,13 +42,13 @@ The expression to evaluate.
 *laneIndex* 
 </dt> <dd>
 
-The input lane index must be uniform across the wave.
+The index of the lane for which the *expr* result will be returned.
 
 </dd> </dl>
 
 ## Return value
 
-The resulting value is uniform across the wave.
+The resulting value is the result of *expr*. It will be uniform if *laneIndex* is uniform.
 
 ## Remarks
 


### PR DESCRIPTION
The HLSL compiler team has agreed to this change, which is more consistent with the later specifications, but failed to update this document. This is consistent with conformant implementations.