### PR TITLE
Fix D3D12 return code page

### DIFF
--- a/desktop-src/direct3d12/d3d12-graphics-reference-returnvalues.md
+++ b/desktop-src/direct3d12/d3d12-graphics-reference-returnvalues.md
@@ -15,15 +15,14 @@ The following are return codes from API functions. For more return codes, see [D
 
 | HRESULT                                                                  | Description                                                                                                           |
 |--------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| D3D12\_ERROR\_FILE\_NOT\_FOUND                                           | The file was not found.                                                                                               |
-| D3D12\_ERROR\_TOO\_MANY\_UNIQUE\_STATE\_OBJECTS                          | There are too many unique instances of a particular type of state object.                                             |
-| D3D12\_ERROR\_TOO\_MANY\_UNIQUE\_VIEW\_OBJECTS                           | There are too many unique instances of a particular type of view object.                                              |
+| D3D12\_ERROR\_ADAPTER\_NOT\_FOUND                                        | The specified cached PSO was created on a different adapter and cannot be reused on the current adapter.          |
+| D3D12\_ERROR\_DRIVER\_VERSION\_MISMATCH                                  | The specified cached PSO was created on a different driver version and cannot be reused on the current adapter.  |
 | D3DERR\_INVALIDCALL (replaced with DXGI\_ERROR\_INVALID\_CALL)           | The method call is invalid. For example, a method's parameter may not be a valid pointer.                             |
 | D3DERR\_WASSTILLDRAWING (replaced with DXGI\_ERROR\_WAS\_STILL\_DRAWING) | The previous blit operation that is transferring information to or from this surface is incomplete.                   |
 | E\_FAIL                                                                  | Attempted to create a device with the debug layer enabled and the layer is not installed.                             |
-| E\_INVALIDARG                                                            | An invalid parameter was passed to the returning function.                                                            |
+| E\_INVALIDARG                                                            | An invalid parameter was passed to the returning function.                                                             |
 | E\_OUTOFMEMORY                                                           | Direct3D could not allocate sufficient memory to complete the call.                                                   |
-| E\_NOTIMPL                                                               | The method call isn't implemented with the passed parameter combination.                                              |
+| E\_NOTIMPL                                                               | The method call isn't implemented with the passed parameter combination.                                               |
 | S\_FALSE                                                                 | Alternate success value, indicating a successful but nonstandard completion (the precise meaning depends on context). |
 | S\_OK                                                                    | No error occurred.                                                                                                    |
 


### PR DESCRIPTION
The 3 return codes specify don't actually seem to exist (can't find in winerror, magicnumdb, or anywhere), and seem to have just been taken from the equivalent D3D11 errors. I replaced them with the actual `D3D12_ERROR_*` codes i found in winerror/d3d12.h