### PR TITLE
Update about-object-identifier.md

### DIFF
--- a/desktop-src/SecCertEnroll/about-object-identifier.md
+++ b/desktop-src/SecCertEnroll/about-object-identifier.md
@@ -12,7 +12,7 @@ The **OBJECT IDENTIFIER** data type is encoded into a TLV triplet that begins wi
 
 -   The first two nodes of the OID are encoded onto a single byte. The first node is multiplied by the decimal 40 and the result is added to the value of the second node.
 -   Node values less than or equal to 127 are encoded on one byte.
--   Node values greater than or equal to 128 are encoded on multiple bytes. Bit 7 of the leftmost byte is set to one. Bits 0 through 6 of each byte contains the encoded value.
+-   Node values greater than or equal to 128 are encoded on multiple bytes. Bit 7 of all bytes but the last one is set to one. Bits 0 through 6 of each byte contain the encoded value.
 
 These points are shown by the following illustration.
 


### PR DESCRIPTION
Maybe I am misunderstanding something, but from the original text it is not clear how values exceeding 2^14 (i.e. not fitting in two OID value bytes) would be encoded.