### PR TITLE
HLSL Sample*(): Fix more rendering errors.

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-gather.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-gather.md
@@ -19,7 +19,7 @@ Gets the four samples (red component only) that would be used for bilinear inter
 
 |                                                                                                    |
 |----------------------------------------------------------------------------------------------------|
-| <Template Type>4 Object.Gather( sampler\_state S, float2\|3\|4 Location \[, int2 Offset\] ); |
+| &lt;Template Type&gt;4 Object.Gather( sampler\_state S, float2\|3\|4 Location \[, int2 Offset\] ); |
 
 
 

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplebias.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplebias.md
@@ -19,7 +19,7 @@ Samples a texture, after applying the input bias to the mipmap level.
 
 |                                                                                                  |
 |--------------------------------------------------------------------------------------------------|
-| <Template Type> Object.SampleBias( sampler\_state S, float Location, float Bias \[, int Offset\] ); |
+| &lt;Template Type&gt; Object.SampleBias( sampler\_state S, float Location, float Bias \[, int Offset\] ); |
 
 
 

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplegrad.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplegrad.md
@@ -19,7 +19,7 @@ Samples a texture using a gradient to influence the way the sample location is c
 
 |                                                                                                            |
 |------------------------------------------------------------------------------------------------------------|
-| <Template Type> Object.SampleGrad( sampler\_state S, float Location, float DDX, float DDY \[, int Offset\] ); |
+| &lt;Template Type&gt; Object.SampleGrad( sampler\_state S, float Location, float DDX, float DDY \[, int Offset\] ); |
 
 
 

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplelevel.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplelevel.md
@@ -19,7 +19,7 @@ Samples a texture using a mipmap-level offset.
 
 |                                                                                                  |
 |--------------------------------------------------------------------------------------------------|
-| <Template Type> Object.SampleLevel( sampler\_state S, float Location, float LOD \[, int Offset\] ); |
+| &lt;Template Type&gt; Object.SampleLevel( sampler\_state S, float Location, float LOD \[, int Offset\] ); |
 
 
 


### PR DESCRIPTION
Just like f7e8f6623059b8f45aa4abc641889c25c46c14ba, except for
SampleLevel, SampleGrad, SampleBias, and Gather.