### PR TITLE
Replace the flag from int zero to the right enum

### DIFF
--- a/desktop-src/direct3d12/creating-descriptor-heaps.md
+++ b/desktop-src/direct3d12/creating-descriptor-heaps.md
@@ -247,7 +247,7 @@ public:
         D3D12_DESCRIPTOR_HEAP_DESC Desc;
         Desc.Type = Type;
         Desc.NumDescriptors = NumDescriptors;
-        Desc.Flags = (bShaderVisible ? D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE : 0);
+        Desc.Flags = (bShaderVisible ? D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE : D3D12_DESCRIPTOR_HEAP_FLAG_NONE);
        
         HRESULT hr = pDevice->CreateDescriptorHeap(&Desc, 
                                __uuidof(ID3D12DescriptorHeap), 


### PR DESCRIPTION
The code that is selected when the variable 'bShaderVisible' is false doesn't compile with the error:
"cannot convert from 'int' to 'D3D12_DESCRIPTOR_HEAP_FLAGS', Conversion to enumeration type requires an explicit cast (static_cast, C-style cast or function-style cast)"
so by using the correct enum D3D12_DESCRIPTOR_HEAP_FLAG_NONE instead of the integer zero, it does not only compile but is also more consistent with usage.