### PR TITLE
Make appx package formatting fixes

### DIFF
--- a/desktop-src/appxpkg/make-appx-package--makeappx-exe-.md
+++ b/desktop-src/appxpkg/make-appx-package--makeappx-exe-.md
@@ -54,7 +54,7 @@ Place the AppxManifest.xml in the root of a directory containing all of the payl
 
 3.  Run this command:
 
-    **MakeAppx pack /d** *input\_directorypath* **/p** *filepath***.appx**
+    **MakeAppx pack /d** *input\_directorypath* **/p** _filepath_**.appx**
 
 ### To create a package using a mapping file
 
@@ -72,7 +72,7 @@ Place the AppxManifest.xml in the root of a directory containing all of the payl
 
 3.  Run this command:
 
-    **MakeAppx pack /f** *mapping\_filepath* **/p** *filepath***.appx**
+    **MakeAppx pack /f** *mapping\_filepath* **/p** _filepath_**.appx**
 
 ### To sign the package using SignTool
 
@@ -80,11 +80,11 @@ Place the AppxManifest.xml in the root of a directory containing all of the payl
 
 2.  Run SignTool.exe to sign the package:
 
-    **SignTool sign /a /v /fd** *hashAlgorithm* **/f** *certFileName* *filepath***.appx**
+    **SignTool sign /a /v /fd** *hashAlgorithm* **/f** *certFileName* _filepath_**.appx**
 
     The *hashAlgorithm* must match the hash algorithm used to create the blockmap when the app was packaged. With the MakeAppx packaging utility, the default Appx blockmap hash algorithm is **SHA256**. Run SignTool.exe specifying **SHA256** as the file digest (/fd) algorithm:
 
-    **SignTool sign /a /v /fd SHA256 /f** *certFileName* *filepath***.appx**
+    **SignTool sign /a /v /fd SHA256 /f** *certFileName* _filepath_**.appx**
 
     For more info about how to sign packages, see [How to sign an app package using SignTool](how-to-sign-a-package-using-signtool.md).
 
@@ -92,7 +92,7 @@ Place the AppxManifest.xml in the root of a directory containing all of the payl
 
 1.  Run this command:
 
-    **MakeAppx unpack /p** *file***.appx /d** *output\_directory*
+    **MakeAppx unpack /p** _file_**.appx /d** *output\_directory*
 
 2.  The unpacked package has the same structure as the installed package.
 
@@ -104,7 +104,7 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 2.  Run this command:
 
-    **MakeAppx bundle /d** *input\_directorypath* **/p** *filepath***.appxbundle**
+    **MakeAppx bundle /d** *input\_directorypath* **/p** _filepath_**.appxbundle**
 
 ### To create a package bundle using a mapping file
 
@@ -122,13 +122,13 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 2.  Run this command:
 
-    **MakeAppx bundle /f** *mapping\_filepath* **/p** *filepath***.appxbundle**
+    **MakeAppx bundle /f** *mapping\_filepath* **/p** _filepath_**.appxbundle**
 
 ### To extract packages from a bundle
 
 1.  Run this command:
 
-    **MakeAppx unbundle /p** *bundle\_name***.appxbundle /d** *output\_directory*
+    **MakeAppx unbundle /p** _bundle\_name_**.appxbundle /d** *output\_directory*
 
 2.  The unpacked bundle has the same structure as the installed package bundle.
 
@@ -143,7 +143,7 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 2.  Run this command:
 
-    **MakeAppx.exe encrypt /p** *package\_name***.appx /ep** *encrypted\_package\_name***.eappx /kf** *keyfile\_name***.txt**
+    **MakeAppx.exe encrypt /p** _package\_name_**.appx /ep** _encrypted\_package\_name_**.eappx /kf** _keyfile\_name_**.txt**
 
 3.  The input package will be encrypted into the specified encrypted package using the provided key file.
 
@@ -151,7 +151,7 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 1.  Run this command:
 
-    **MakeAppx.exe encrypt /p** *package\_name***.appx /ep** *encrypted\_package\_name***.eappx /kt**
+    **MakeAppx.exe encrypt /p** _package\_name_**.appx /ep** _encrypted\_package\_name_**.eappx /kt**
 
 2.  The input package will be encrypted into the specified encrypted package using the global test key.
 
@@ -166,7 +166,7 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 2.  Run this command:
 
-    **MakeAppx.exe decrypt /p** *package\_name***.appx /ep** *unencrypted\_package\_name***.eappx /kf** *keyfile\_name***.txt**
+    **MakeAppx.exe decrypt /p** _package\_name_**.appx /ep** _unencrypted\_package\_name_**.eappx /kf** _keyfile\_name_**.txt**
 
 3.  The input package will be decrypted into the specified unencrypted package using the provided key file.
 
@@ -174,7 +174,7 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 1.  Run this command:
 
-    **MakeAppx.exe decrypt /p** *package\_name***.appx /ep** *unencrypted\_package\_name***.eappx /kt**
+    **MakeAppx.exe decrypt /p** _package\_name_**.appx /ep** _unencrypted\_package\_name_**.eappx /kt**
 
 2.  The input package will be decrypted into the specified unencrypted package using the global test key.
 
@@ -182,21 +182,21 @@ We use the **bundle** command to create an app bundle at <output bundle name> by
 
 The command line argument **/p** is always required, with either **/d**, **/f**, or **/ep**. Note that **/d**, **/f**, and **/ep** are mutually exclusive.
 
-**MakeAppx pack \[options\]** **/p** *<output package name>***/d** *<content directory>*
+**MakeAppx pack \[options\]** **/p** *\<output package name\>* **/d** *\<content directory\>*
 
-**MakeAppx pack \[options\]** **/p** *<output package name>***/f** *<mapping file>*
+**MakeAppx pack \[options\]** **/p** *\<output package name\>* **/f** *\<mapping file\>*
 
-**MakeAppx unpack \[options\]** **/p** *<input package name>***/d** *<output directory>*
+**MakeAppx unpack \[options\]** **/p** *\<input package name\>* **/d** *\<output directory\>*
 
-**MakeAppx bundle \[options\]** **/p** *<output bundle name>***/d** *<content directory>*
+**MakeAppx bundle \[options\]** **/p** *\<output bundle name\>* **/d** *\<content directory\>*
 
-**MakeAppx bundle \[options\]** **/p** *<output bundle name>***/f** *<mapping file>*
+**MakeAppx bundle \[options\]** **/p** *\<output bundle name\>* **/f** *\<mapping file\>*
 
-**MakeAppx unbundle \[options\]** **/p** *<input bundle name>***/d** *<output directory>*
+**MakeAppx unbundle \[options\]** **/p** *\<input bundle name\>* **/d** *\<output directory\>*
 
-**MakeAppx encrypt \[options\]** **/p** *<input package name>***/ep** *<output package name>*
+**MakeAppx encrypt \[options\]** **/p** *\<input package name\>* **/ep** *\<output package name\>*
 
-**MakeAppx decrypt \[options\]** **/p** *<input package name>***/ep** *<output package name>*
+**MakeAppx decrypt \[options\]** **/p** *\<input package name\>* **/ep** *\<output package name\>*
 
 ## Command-line Syntax
 


### PR DESCRIPTION
Fixes formatting errors in the Make appx package page.
Addresses adjacent bold and italic in commands and missing escaping for command parameters. 