### PR TITLE
Update convertsystemtimetocaldatetime.md

### DIFF
--- a/desktop-src/Intl/convertsystemtimetocaldatetime.md
+++ b/desktop-src/Intl/convertsystemtimetocaldatetime.md
@@ -26,7 +26,7 @@ Deprecated. Converts a specified [**SYSTEMTIME**](https://msdn.microsoft.com/lib
 
 ```C++
 BOOL ConvertSystemTimeToCalDateTime(
-  _In_  const SYSTEMTIME    lpSysTime,
+  _In_  const SYSTEMTIME   *lpSysTime,
   _In_        CALID         calId,
   _Out_       LPCALDATETIME lpCalDateTime
 


### PR DESCRIPTION
lpSysTime is a pointer to the struct, not the struct itself