### PR TITLE
Add link to NVIDIA's CUDA on WSL User Guide

### DIFF
--- a/desktop-src/direct3d12/gpu-cuda-in-wsl.md
+++ b/desktop-src/direct3d12/gpu-cuda-in-wsl.md
@@ -35,6 +35,6 @@ For this preview, you need a kernel version of 4.19.121 or higher. You can check
 wsl cat /proc/version
 ```
 
-Now you can start using your exisiting Linux workflows through [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker) or by installing [PyTorch](https://pytorch.org/get-started/locally/) or [TensorFlow](https://www.tensorflow.org/install/gpu) inside WSL 2.
+Now you can start using your exisiting Linux workflows through [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker) or by installing [PyTorch](https://pytorch.org/get-started/locally/) or [TensorFlow](https://www.tensorflow.org/install/gpu) inside WSL 2. More information on getting setup is captured in [NVIDIA's CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html).
 
 Share feedback on NVIDIA’s support via their [Community Forum for CUDA on WSL](https://forums.developer.nvidia.com/c/accelerated-computing/cuda/cuda-on-windows-subsystem-for-linux-wsl-2/303).

--- a/desktop-src/direct3d12/gpu-cuda-in-wsl.md
+++ b/desktop-src/direct3d12/gpu-cuda-in-wsl.md
@@ -14,7 +14,7 @@ The Windows Insider SDK supports running existing ML tools, libraries, and popul
 
 ## Install the latest Windows Insider Fast build 
 
-To use this preview, you'll need to [register for the Windows Insider Program](https://insider.windows.com/getting-started/#register). Once you do, follow [these instuctions](https://insider.windows.com/en-us/getting-started/#install) to install the latest insider build. When choosing your settings, ensure you're selecting the [Fast ring](https://docs.microsoft.com/windows-insider/flight-hub/#active-development-builds-of-windows-10). 
+To use this preview, you'll need to [register for the Windows Insider Program](https://insider.windows.com/getting-started/#register). Once you do, follow [these instuctions](https://insider.windows.com/getting-started/#install) to install the latest Insider build. When choosing your settings, ensure you're selecting the [Fast ring](/windows-insider/flight-hub/#active-development-builds-of-windows-10). 
 
 For this preview, you need Build 20150 or higher. You can check your build version number by running `winver` via the **Run** command (Windows logo key + R).
 
@@ -22,19 +22,19 @@ For this preview, you need Build 20150 or higher. You can check your build versi
 
 Download and install the [NVIDIA CUDA-enabled driver for WSL](https://developer.nvidia.com/cuda/wsl) to use with your existing CUDA ML workflows. 
 
-## Setup WSL 2 for the preview 
+## Set up WSL 2 for the preview 
 
-Once you've installed the above driver, ensure you [enable WSL 2](https://docs.microsoft.com/windows/wsl/install-win10) and [install a glibc-based distribution](https://docs.microsoft.com/windows/wsl/install-win10#install-your-linux-distribution-of-choice) (like Ubuntu or Debian). Ensure you have the latest kernel by selecting **Check for updates** in the **Windows Update** section of the Settings app. 
+Once you've installed the above driver, ensure you [enable WSL 2](/windows/wsl/install-win10) and [install a glibc-based distribution](/windows/wsl/install-win10#install-your-linux-distribution-of-choice) (such as Ubuntu or Debian). Ensure you have the latest kernel by selecting **Check for updates** in the **Windows Update** section of the Settings app. 
 
 > [!NOTE]
-> Ensure you have the **Receive updates for other Microsoft products when you update Windows** enabled. You can find it in **Advanced options** within the **Windows Update** section of the Settings app. 
+> Ensure you have **Receive updates for other Microsoft products when you update Windows** enabled. You can find it in **Advanced options** within the **Windows Update** section of the Settings app. 
 
 For this preview, you need a kernel version of 4.19.121 or higher. You can check the version number by running the following command in PowerShell. 
 
-```
+```powershell
 wsl cat /proc/version
 ```
 
-Now you can start using your exisiting Linux workflows through [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker) or by installing [PyTorch](https://pytorch.org/get-started/locally/) or [TensorFlow](https://www.tensorflow.org/install/gpu) inside WSL 2. More information on getting setup is captured in [NVIDIA's CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html).
+Now you can start using your exisiting Linux workflows through [NVIDIA Docker](https://github.com/NVIDIA/nvidia-docker), or by installing [PyTorch](https://pytorch.org/get-started/locally/) or [TensorFlow](https://www.tensorflow.org/install/gpu) inside WSL 2. More information on getting set up is captured in [NVIDIA's CUDA on WSL User Guide](https://docs.nvidia.com/cuda/wsl-user-guide/index.html).
 
-Share feedback on NVIDIA’s support via their [Community Forum for CUDA on WSL](https://forums.developer.nvidia.com/c/accelerated-computing/cuda/cuda-on-windows-subsystem-for-linux-wsl-2/303).
+Share feedback on NVIDIA's support via their [Community forum for CUDA on WSL](https://forums.developer.nvidia.com/c/accelerated-computing/cuda/cuda-on-windows-subsystem-for-linux-wsl-2/303).


### PR DESCRIPTION
Added a link near the end of the documentation that points to NVIDIA's CDUA on WSL User Guide providing additional guidance for users.