### PR TITLE
Wide string arguments passed into non wide string function.

### DIFF
--- a/desktop-src/LearnWin32/example--the-open-dialog-box.md
+++ b/desktop-src/LearnWin32/example--the-open-dialog-box.md
@@ -51,7 +51,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int nCmdShow
                     // Display the file name to the user.
                     if (SUCCEEDED(hr))
                     {
-                        MessageBox(NULL, pszFilePath, L"File Path", MB_OK);
+                        MessageBoxW(NULL, pszFilePath, L"File Path", MB_OK);
                         CoTaskMemFree(pszFilePath);
                     }
                     pItem->Release();


### PR DESCRIPTION
The arguments passed into MessageBox() are wide strings, and produce an error because MessageBox is not meant for wide strings. This PR fixes this by changing MessageBox() to MessageBoxW().

https://docs.microsoft.com/en-us/windows/win32/learnwin32/example--the-open-dialog-box