### PR TITLE
Note Id2D1Factory::GetDesktopDpi is deprecated.

### DIFF
--- a/desktop-src/LearnWin32/dpi-and-device-independent-pixels.md
+++ b/desktop-src/LearnWin32/dpi-and-device-independent-pixels.md
@@ -156,8 +156,8 @@ void InitializeDPIScale(HWND hwnd)
     ReleaseDC(hwnd, hdc);
 }
 ```
-
-
+> [!Note]  
+> On Windows 10, version 1903,  [**ID2D1Factory::GetDesktopDpi**](https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1factory-getdesktopdpi) is deprecated and the recommendation is [**DisplayInformation::LogicalDpi**](https://docs.microsoft.com/en-us/uwp/api/windows.graphics.display.displayinformation.logicaldpi?view=winrt-19041) for Windows Store Apps or [**GetDpiForWindow**](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdpiforwindow) for desktop apps. If you still want to use it, suppress the compiler error message by writing the line [**#pragma warning(suppress: 4996)**](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019#:~:text=To%20turn%20off%20the%20warning,warning(suppress%20%3A%204996)%20.) just before the [**ID2D1Factory::GetDesktopDpi**](https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1factory-getdesktopdpi) call. Although it is not recommended, it is possible to set the default DPI awareness programmatically using [**SetProcessDpiAwarenessContext**](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext?redirectedfrom=MSDN). Once a window (an HWND) has been created in your process, changing the DPI awareness mode is no longer supported. If you are setting the process-default DPI awareness mode programmatically, you must call the corresponding API before any HWNDs have been created. For information see [Setting the default DPI awareness for a process](https://docs.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process).
 
 ## Resizing the Render Target
 


### PR DESCRIPTION
I felt a 'note' on deprecation is relevant here, especially a brief exposition about the point in time when DPI awareness is meant to be taken care of by the programmer and the system.