### PR TITLE
Fix incomplete `syntax`es in SecAuthN

### DIFF
--- a/desktop-src/SecAuthN/acquirecredentialshandle--general.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--general.md
@@ -36,6 +36,16 @@ For information about using this function with a specific [*security support pro
 
 
 ```C++
+SECURITY_STATUS SEC_Entry AcquireCredentialsHandle(
+  _In_  SEC_CHAR       *pszPrincipal,
+  _In_  SEC_CHAR       *pszPackage,
+  _In_  ULONG          fCredentialUse,
+  _In_  PLUID          pvLogonID,
+  _In_  PVOID          pAuthData,
+  _In_  SEC_GET_KEY_FN pGetKeyFn,
+  _In_  PVOID          pvGetKeyArgument,
+  _Out_ PCredHandle    phCredential,
+  _Out_ PTimeStamp     ptsExpiry
 );
 ```
 

--- a/desktop-src/SecAuthN/decryptmessage--general.md
+++ b/desktop-src/SecAuthN/decryptmessage--general.md
@@ -39,6 +39,11 @@ For information about using this function with a specific SSP, see the following
 
 
 ```C++
+SECURITY_STATUS SEC_Entry DecryptMessage(
+  _In_    PCtxtHandle    phContext,
+  _Inout_ PSecBufferDesc pMessage,
+  _In_    ULONG          MessageSeqNo,
+  _Out_   PULONG         pfQOP
 );
 ```
 

--- a/desktop-src/SecAuthN/encryptmessage--general.md
+++ b/desktop-src/SecAuthN/encryptmessage--general.md
@@ -30,6 +30,11 @@ For information about using this function with a specific SSP, see the following
 ## Syntax
 
 ```C++
+SECURITY_STATUS SEC_Entry EncryptMessage(
+  _In_    PCtxtHandle    phContext,
+  _In_    ULONG          fQOP,
+  _Inout_ PSecBufferDesc pMessage,
+  _In_    ULONG          MessageSeqNo
 );
 ```
 ## Parameters

--- a/desktop-src/SecAuthN/initializesecuritycontext--general.md
+++ b/desktop-src/SecAuthN/initializesecuritycontext--general.md
@@ -33,6 +33,19 @@ For information about using this function with a specific [*security support pro
 
 
 ```C++
+SECURITY_STATUS SEC_Entry InitializeSecurityContext(
+  _In_opt_    PCredHandle    phCredential,
+  _In_opt_    PCtxtHandle    phContext,
+  _In_opt_    SEC_CHAR       *pszTargetName,
+  _In_        ULONG          fContextReq,
+  _In_        ULONG          Reserved1,
+  _In_        ULONG          TargetDataRep,
+  _In_opt_    PSecBufferDesc pInput,
+  _In_        ULONG          Reserved2,
+  _Inout_opt_ PCtxtHandle    phNewContext,
+  _Inout_opt_ PSecBufferDesc pOutput,
+  _Out_       PULONG         pfContextAttr,
+  _Out_opt_   PTimeStamp     ptsExpiry
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--credssp.md
+++ b/desktop-src/SecAuthN/querycontextattributes--credssp.md
@@ -15,6 +15,10 @@ The **QueryContextAttributes (CredSSP)** function lets a transport application q
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--digest.md
+++ b/desktop-src/SecAuthN/querycontextattributes--digest.md
@@ -14,6 +14,10 @@ The **QueryContextAttributes (Digest)** function enables a transport application
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--general.md
+++ b/desktop-src/SecAuthN/querycontextattributes--general.md
@@ -32,9 +32,9 @@ For information about using this function with a specific [*security support pro
 
 ```C++
 SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
-    _In_  PCtxtHandle phContext,              // Context to query
-    _In_  unsigned long ulAttribute,          // Attribute to query
-    _Out_ void * pBuffer              // Buffer for attributes
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--general.md
+++ b/desktop-src/SecAuthN/querycontextattributes--general.md
@@ -31,6 +31,10 @@ For information about using this function with a specific [*security support pro
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+    _In_  PCtxtHandle phContext,              // Context to query
+    _In_  unsigned long ulAttribute,          // Attribute to query
+    _Out_ void * pBuffer              // Buffer for attributes
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--kerberos.md
+++ b/desktop-src/SecAuthN/querycontextattributes--kerberos.md
@@ -14,6 +14,10 @@ The **QueryContextAttributes (Kerberos)** function enables a transport applicati
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--negotiate.md
+++ b/desktop-src/SecAuthN/querycontextattributes--negotiate.md
@@ -14,6 +14,10 @@ The **QueryContextAttributes (Negotiate)** function enables a transport applicat
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--ntlm.md
+++ b/desktop-src/SecAuthN/querycontextattributes--ntlm.md
@@ -14,6 +14,10 @@ The **QueryContextAttributes (NTLM)** function enables a transport application t
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 

--- a/desktop-src/SecAuthN/querycontextattributes--schannel.md
+++ b/desktop-src/SecAuthN/querycontextattributes--schannel.md
@@ -14,6 +14,10 @@ The **QueryContextAttributes (Schannel)** function enables a transport applicati
 
 
 ```C++
+SECURITY_STATUS SEC_ENTRY QueryContextAttributes(
+  _In_  PCtxtHandle phContext,
+  _In_  ULONG       ulAttribute,
+  _Out_ PVOID       pBuffer
 );
 ```
 


### PR DESCRIPTION
The `Syntax` section in some API references contains only a `);`. This PR trys to complete them using some knowledge from similar API references and Windows header files.