### PR TITLE
WindowsRibbon docs corrected:

### DIFF
--- a/desktop-src/windowsribbon/ribbon-controls-galleries.md
+++ b/desktop-src/windowsribbon/ribbon-controls-galleries.md
@@ -254,69 +254,46 @@ A *CommandId* attribute used to bind a Command to a Command handler when the mar
 ```XML
 
 <!-- DropDownGallery -->
-<Command Name=&quot;cmdDropDownGalleryGroup&quot;
-         Symbol=&quot;cmdDropDownGalleryGroup&quot;
-         Comment=&quot;DropDownGallery Group&quot;
-         LabelTitle=&quot;DropDownGallery&quot;/>
-<Command Name=&quot;cmdDropDownGallery&quot;
-         Symbol=&quot;cmdDropDownGallery&quot;
-         Comment=&quot;DropDownGallery&quot;
-         LabelTitle=&quot;DropDownGallery&quot;/>
+<Command Name="cmdDropDownGalleryGroup"
+         Symbol="cmdDropDownGalleryGroup"
+         Comment="DropDownGallery Group"
+         LabelTitle="DropDownGallery"/>
+<Command Name="cmdDropDownGallery"
+         Symbol="cmdDropDownGallery"
+         Comment="DropDownGallery"
+         LabelTitle="DropDownGallery"/>
 ```
 
 
 
-<span codelanguage="XML"></span>
 
-<table>
-<colgroup>
-<col style="width: 100%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>XML</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><pre><code><!-- InRibbonGallery -->
-<Command Name=&quot;cmdInRibbonGalleryGroup&quot;
-         Symbol=&quot;cmdInRibbonGalleryGroup&quot;
-         Comment=&quot;InRibbonGallery Group&quot;
-         LabelTitle=&quot;InRibbonGallery&quot;/>
-<Command Name=&quot;cmdInRibbonGallery&quot;
-         Symbol=&quot;cmdInRibbonGallery&quot;
-         Comment=&quot;InRibbonGallery&quot;
-         LabelTitle=&quot;InRibbonGallery&quot;/></code></pre></td>
-</tr>
-</tbody>
-</table>
+```XML
 
-<span codelanguage="XML"></span>
+<!-- InRibbonGallery -->
+<Command Name="cmdInRibbonGalleryGroup"
+         Symbol="cmdInRibbonGalleryGroup"
+         Comment="InRibbonGallery Group"
+         LabelTitle="InRibbonGallery"/>
+<Command Name="cmdInRibbonGallery"
+         Symbol="cmdInRibbonGallery"
+         Comment="InRibbonGallery"
+         LabelTitle="InRibbonGallery"
+```
 
-<table>
-<colgroup>
-<col style="width: 100%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>XML</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><pre><code><!-- SplitButtonGallery -->
-<Command Name=&quot;cmdSplitButtonGalleryGroup&quot;
-         Symbol=&quot;cmdSplitButtonGalleryGroup&quot;
-         Comment=&quot;SplitButtonGallery Group&quot;
-         LabelTitle=&quot;SplitButtonGallery&quot;/>
-<Command Name=&quot;cmdSplitButtonGallery&quot;
-         Symbol=&quot;cmdSplitButtonGallery&quot;
-         Comment=&quot;SplitButtonGallery&quot;
-         LabelTitle=&quot;SplitButtonGallery&quot;/></code></pre></td>
-</tr>
-</tbody>
-</table>
+
+
+```XML
+
+<!-- SplitButtonGallery -->
+<Command Name="cmdSplitButtonGalleryGroup"
+         Symbol="cmdSplitButtonGalleryGroup"
+         Comment="SplitButtonGallery Group"
+         LabelTitle="SplitButtonGallery"/>
+<Command Name="cmdSplitButtonGallery"
+         Symbol="cmdSplitButtonGallery"
+         Comment="SplitButtonGallery"
+         LabelTitle="SplitButtonGallery"
+```
 
 
 

--- a/desktop-src/windowsribbon/windowsribbon-element-fontcontrol.md
+++ b/desktop-src/windowsribbon/windowsribbon-element-fontcontrol.md
@@ -25,7 +25,7 @@ Represents a [Font Control](windowsribbon-controls-fontcontrol.md), which is a s
 <FontControl
   CommandName = "xs:positiveInteger or xs:string"
   FontType = "xs:string"
-  IsGrowShrinkButtonGroupVisible = "xs:string"
+  IsGrowShrinkButtonGroupVisible = "Boolean"
   IsStrikethroughButtonVisible = "Boolean"
   IsUnderlineButtonVisible = "Boolean"
   IsHighlightButtonVisible = "Boolean"
@@ -121,7 +121,7 @@ This control is displayed by default and cannot be hidden by setting the <em>IsH
 </tr>
 <tr class="odd">
 <td><strong>IsGrowShrinkButtonGroupVisible</strong><br/></td>
-<td>xs:string<br/></td>
+<td>Boolean<br/></td>
 <td>No<br/></td>
 <td><strong>Windows 8 and newer</strong><br/> Restricted to one of the following values: <br/>
 <blockquote>

--- a/desktop-src/windowsribbon/windowsribbon-element-inribbongallery.md
+++ b/desktop-src/windowsribbon/windowsribbon-element-inribbongallery.md
@@ -164,7 +164,7 @@ Applies only to galleries where the value of the <em>Type</em> attribute is equa
 | [**CheckBox**](windowsribbon-element-checkbox.md)<br/>                                     | May occur one or more times<br/> <br/> |
 | [**InRibbonGallery.MenuGroups**](windowsribbon-element-inribbongallery-menugroups.md)<br/> | Must occur exactly once<br/> <br/>     |
 | [**InRibbonGallery.MenuLayout**](windowsribbon-element-inribbongallery-menulayout.md)<br/> | May occur at most once<br/> <br/>      |
-| [**Spinner**](windowsribbon-element-spinner.md)<br/>                                       | May occur one or more times<br/> <br/> |
+| [**Button**](windowsribbon-element-button.md)<br/>                                       | May occur one or more times<br/> <br/> |
 | [**SplitButton**](windowsribbon-element-splitbutton.md)<br/>                               | May occur one or more times<br/> <br/> |
 | [**ToggleButton**](windowsribbon-element-togglebutton.md)<br/>                             | May occur one or more times<br/> <br/> |
 

--- a/desktop-src/windowsribbon/windowsribbon-element-verticalmenulayout.md
+++ b/desktop-src/windowsribbon/windowsribbon-element-verticalmenulayout.md
@@ -59,7 +59,7 @@ Represents a vertical layout for items in a gallery.
 <td><strong>IsMultipleHighlightingEnabled</strong><br/></td>
 <td>xs:boolean<br/></td>
 <td>No<br/></td>
-<td><strong>Windows 8 and newer</strong><br/> Highlights all items in the list up to, and including, the current mouseover item (instead of the mouseover item only). Typically used for mutliple <strong>Undo</strong> and <strong>Redo</strong> functionality.<br/> <br/>
+<td><strong>Windows 8 and newer</strong><br/> Highlights all items in the list up to, and including, the current mouseover item (instead of the mouseover item only). Typically used for multiple <strong>Undo</strong> and <strong>Redo</strong> functionality.<br/> <br/>
 <dt><span></span><span></span><strong></strong> (true)<br/> </dt> <dd></dd> <dt><span></span><span></span><strong></strong> (false)<br/> </dt> <dd> Default. <br/> </dd> </dl></td>
 </tr>
 <tr class="odd">

--- a/desktop-src/windowsribbon/windowsribbon-templates.md
+++ b/desktop-src/windowsribbon/windowsribbon-templates.md
@@ -185,32 +185,25 @@ Eight button-family controls (alternate presentation).<br/>
 > [!Note]  
 > All control elements declared with this template must be contained in two [**ControlGroup**](windowsribbon-element-controlgroup.md) elements: one for the first five elements and one for the last three elements.
 
-<br/> The following example demonstrates the markup required for this template.<br/> <span codelanguage=""></span>
+<br/> The following example demonstrates the markup required for this template.<br/>
 
-<table>
-<colgroup>
-<col style="width: 100%" />
-</colgroup>
-<tbody>
-<tr class="odd">
-<td><pre><code><Group CommandName=&quot;cmdSizeDefinitionsGroup&quot; 
-       SizeDefinition=&quot;EightButtons-LastThreeSmall&quot;>
+```
+<Group CommandName="cmdSizeDefinitionsGroup" 
+       SizeDefinition="EightButtons-LastThreeSmall">
   <ControlGroup>
-    <Button CommandName=&quot;cmdSDButton1&quot; />
-    <Button CommandName=&quot;cmdSDButton2&quot; />
-    <Button CommandName=&quot;cmdSDButton3&quot; />
-    <Button CommandName=&quot;cmdSDButton4&quot; />
-    <Button CommandName=&quot;cmdSDButton5&quot; />
+    <Button CommandName="cmdSDButton1" />
+    <Button CommandName="cmdSDButton2" />
+    <Button CommandName="cmdSDButton3" />
+    <Button CommandName="cmdSDButton4" />
+    <Button CommandName="cmdSDButton5" />
   </ControlGroup>
   <ControlGroup>
-    <Button CommandName=&quot;cmdSDButton6&quot; />
-    <Button CommandName=&quot;cmdSDButton7&quot; />
-    <Button CommandName=&quot;cmdSDButton8&quot; />
+    <Button CommandName="cmdSDButton6" />
+    <Button CommandName="cmdSDButton7" />
+    <Button CommandName="cmdSDButton8" />
   </ControlGroup>
-</Group></code></pre></td>
-</tr>
-</tbody>
-</table>
+</Group>
+```
 
 
 


### PR DESCRIPTION
some copy elements, typos, inRibbonGallery controls: Spinner => Button