### PR TITLE
Fix broken Note rendering in -gdiplus-types-of-coordinate-systems-about.md

### DIFF
--- a/desktop-src/gdiplus/-gdiplus-types-of-coordinate-systems-about.md
+++ b/desktop-src/gdiplus/-gdiplus-types-of-coordinate-systems-about.md
@@ -59,7 +59,7 @@ myGraphics.DrawLine(&myPen, 0, 0, 2, 1);
 
 
 > [!Note] If you don't specify a pen width when you construct your pen, the previous example will draw a line that is one inch wide. You can specify the pen width in the second argument to the [**Pen**](/windows/desktop/api/gdipluspen/nl-gdipluspen-pen) constructor:
->
+> <br/><br/>
 > `Pen myPen(Color(255, 0, 0, 0), 1/myGraphics.GetDpiX())`.
 
  


### PR DESCRIPTION
The note section with the words `If you don't specify a pen width ...` doesn't seem to render correctly when converted to HTML (see live page here https://docs.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-types-of-coordinate-systems-about)

I suspect this may have to do with the blank line just before the code example that calls the Pen constructor. I have tried using two "break" tags to keep the blank line in a way that will cause the resulting HTML to properly render the Note (i.e with highlights to call attention to it). **This may not be the correct fix so I welcome further edits to this PR.**

The broken note renders as follows:

![gh_note_bad_render](https://user-images.githubusercontent.com/20465797/90699223-65888a00-e28b-11ea-94ef-b99c48114f70.png)

...whereas it should render similar to this note (from here https://docs.microsoft.com/en-us/windows/win32/gdiplus/-gdiplus-types-of-bitmaps-about):

![gh_note_good_render](https://user-images.githubusercontent.com/20465797/90699273-85b84900-e28b-11ea-82b8-f8a2e327c227.png)
