### PR TITLE
Update signtool.md for /verify option

### DIFF
--- a/desktop-src/SecCrypto/signtool.md
+++ b/desktop-src/SecCrypto/signtool.md
@@ -331,7 +331,9 @@ The following display options apply to all SignTool commands.
 
  
 
-The SignTool **verify** command determines whether the signing certificate was issued by a trusted authority, whether the signing certificate has been revoked, and, optionally, whether the signing certificate is valid for a specific policy.
+The SignTool **verify** command determines whether the signing certificate was issued by a trusted authority, whether the signing certificate has been revoked, and, optionally, whether the signing certificate is valid for a specific policy.  
+
+The SignTool **verify** command will output the **embedded** signature status unless an option is specified to search a catalog (/a, /ad, /as, /ag, /c).
 
 SignTool returns an exit code of zero for successful execution, one for failed execution, and two for execution that completed with warnings. If the SignTool encounters an unhandled exception, however, the return value is undefined.
 


### PR DESCRIPTION
Update to clarify signtool.exe verify option checks *only the EMBEDDED* signature if no catalog options are specified on the command line. Code review of the tool (/ds/security/cryptoapi/pkisign/tools/signtool/*) shows this is correct. However, this is not clear from any of our docs, nor does the tool output indicate that the signature is embedded if it is an embedded signature.