### PR TITLE
Updated ChassisTypes with new SMBIOS 3.0 Values

### DIFF
--- a/desktop-src/CIMWin32Prov/win32-systemenclosure.md
+++ b/desktop-src/CIMWin32Prov/win32-systemenclosure.md
@@ -384,6 +384,24 @@ This property is inherited from [**CIM\_Chassis**](cim-chassis.md).
 
 **Sealed-Case PC** (24)
 
+</dt> <dd></dd> <dt>
+
+<span id="Tablet"></span><span id="tablet"></span><span id="TABLET"></span>
+
+**Tablet** (30)
+
+</dt> <dd></dd> <dt>
+
+<span id="Convertible"></span><span id="Convertible"></span><span id="Convertible"></span>
+
+**Convertible** (31)
+
+</dt> <dd></dd> <dt>
+
+<span id="Detachable"></span><span id="Detachable "></span><span id="Detachable "></span>
+
+**Detachable** (32)
+
 
 </dt> <dd></dd> </dl>
 


### PR DESCRIPTION
Added the following:

30 - Tablet
31 - Convertible
32 - Detachable 

As documented by Lenovo:

https://thinkdeploy.blogspot.com/2017/04/new-enclosure-types-for-convertible.html