### PR TITLE
Update security-properties.md

### DIFF
--- a/desktop-src/AD/security-properties.md
+++ b/desktop-src/AD/security-properties.md
@@ -37,7 +37,7 @@ X509:<I>C=US,O=InternetCA,CN=APublicCertificateAuthority<S>C=US,O=Fabrikam,OU=Sa
 
 
 
-Be aware that "\<I\>" or "\<I>" and "\<S\>" are supported. Having only "\<S\>" is not supported. Applications should not modify the values within "\<I\>" or "\<S\>" because partial DN matching is not supported.
+Be aware that "\<S\>" or "\<I>" and "\<S\>" are supported. Having only "\<I\>" is not supported. Applications should not modify the values within "\<I\>" or "\<S\>" because partial DN matching is not supported.
 
 For external Kerberos accounts, the values should be the Kerberos account name. The Kerberos package uses the following syntax: "Kerberos:MITaccountname". For example, the following is the value for an account at Fabrikam.com:
 


### PR DESCRIPTION
The documentation incorrectly states that `I` is supported on it's own, while `S` is not. The reverse is actually true. 

The following documentation shows that `S` is supported on it's own, while `I` is not.

https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-certificate-requirements-and-enumeration#kdc-certificate