### PR TITLE
Update direct3d-11-advanced-stages-tessellation.md

### DIFF
--- a/desktop-src/direct3d11/direct3d-11-advanced-stages-tessellation.md
+++ b/desktop-src/direct3d11/direct3d-11-advanced-stages-tessellation.md
@@ -104,10 +104,10 @@ Internally, the tessellator operates in two phases:
 
 | Type of Partitioning | Range                       |
 |----------------------|-----------------------------|
-| Fractional\_odd      | \[1...63\]                  |
-| Fractional\_even     | TessFactor range: \[2..64\] |
-| Integer              | TessFactor range: \[1..64\] |
-| Pow2                 | TessFactor range: \[1..64\] |
+| fractional\_odd      | \[1...63\]                  |
+| fractional\_even     | TessFactor range: \[2..64\] |
+| integer              | TessFactor range: \[1..64\] |
+| pow2                 | TessFactor range: \[1..64\] |
 
 
 


### PR DESCRIPTION
The names in "Types of Partitioning" should be all in lower case as the compiler expects it in that way.