### PR TITLE
Fixed typos at WLAN_REASON_CODE description

### DIFF
--- a/desktop-src/NativeWiFi/wlan-reason-code.md
+++ b/desktop-src/NativeWiFi/wlan-reason-code.md
@@ -199,7 +199,7 @@ The following table lists MSM security error codes.
 | WLAN\_REASON\_CODE\_MSMSEC\_PROFILE\_UNSUPPORTED\_AUTH                  | Profile specifies an unsupported authentication ,mechanism.                                                                                                                               |
 | WLAN\_REASON\_CODE\_MSMSEC\_PROFILE\_UNSUPPORTED\_CIPHER                | Profile specifies an unsupported cipher.                                                                                                                                                  |
 | WLAN\_REASON\_CODE\_MSMSEC\_UI\_REQUEST\_FAILURE                        | Failed to queue the user interface request.                                                                                                                                               |
-| WLAN\_REASON\_CODE\_MSMSEC\_CAPABILITY\_MFP\_NW\_NIC                    | The wireless LAN requires Management Frame Protection (MFP) and the network interface does not suppport MFP. For more informarion, see the IEEE 802.11w amendment to the 802.11 standard. |
+| WLAN\_REASON\_CODE\_MSMSEC\_CAPABILITY\_MFP\_NW\_NIC                    | The wireless LAN requires Management Frame Protection (MFP) and the network interface does not support MFP. For more information, see the IEEE 802.11w amendment to the 802.11 standard. |
 
 
 


### PR DESCRIPTION
suppport => support, informarion => information