### PR TITLE
Update d3dxsaveprtbuffertofile.md

### DIFF
--- a/desktop-src/direct3d9/d3dxsaveprtbuffertofile.md
+++ b/desktop-src/direct3d9/d3dxsaveprtbuffertofile.md
@@ -1,5 +1,5 @@
 ---
-Description: Saves a precomputed radiance transfer (PRT) buffer to disk.
+description: Saves a precomputed radiance transfer (PRT) buffer to disk.
 ms.assetid: 1fca69bd-6729-45af-981f-b7480c741bc2
 title: D3DXSavePRTBufferToFile function (D3DX9Mesh.h)
 ms.topic: reference
@@ -22,51 +22,40 @@ Saves a precomputed radiance transfer (PRT) buffer to disk.
 
 ## Syntax
 
-
-```C++
+```cpp
 HRESULT D3DXSavePRTBufferToFile(
   _In_ LPCSTR          pFileName,
   _In_ LPD3DXPRTBUFFER pBuffer
 );
 ```
 
-
-
 ## Parameters
 
-<dl> <dt>
-
 *pFileName* \[in\]
-</dt> <dd>
 
-Type: **[**LPCSTR**](../winprog/windows-data-types.md)**
+Type: **[LPCSTR](../winprog/windows-data-types.md)**
 
 Name of the file to which the buffer is to be saved.
 
-</dd> <dt>
-
 *pBuffer* \[in\]
-</dt> <dd>
 
-Type: **[**LPD3DXPRTBUFFER**](id3dxprtbuffer.md)**
+Type: **[LPD3DXPRTBUFFER](id3dxprtbuffer.md)**
 
 Address of a pointer to the input [**ID3DXPRTBuffer**](id3dxprtbuffer.md) object.
 
-</dd> </dl>
-
 ## Return value
 
-Type: **[**HRESULT**](https://msdn.microsoft.com/library/Bb401631(v=MSDN.10).aspx)**
+Type: **[HRESULT](/windows/win32/com/structure-of-com-error-codes)**
 
-If the method succeeds, the return value is D3D\_OK. If the method fails, the return value can be D3DERR\_INVALIDCALL.
+If the method succeeds, the return value is **D3D\_OK**. If the method fails, the return value can be **D3DERR\_INVALIDCALL**.
 
 ## Remarks
 
-The compiler setting also determines the function version. If Unicode is defined, the function call resolves to D3DXSavePRTBufferToFileW. Otherwise, the function call resolves to D3DXSavePRTBufferToFileA.
+The compiler setting also determines the function version. If Unicode is defined, then the function call resolves to [D3DXSavePRTBufferToFileW](/windows/win32/direct3d9/d3dxsaveprtbuffertofile). Otherwise, the function call resolves to **D3DXSavePRTBufferToFileA**.
 
-The ``PRT`` file format is a binary file in the form of a header and then a data block:
+The PRT file format is a binary file in the form of a header and then a data block.
 
-```C++
+```cpp
 struct PRTHeader
 {
     UINT NumSamples;
@@ -78,28 +67,17 @@ struct PRTHeader
 };
 ```
 
-For the case of ``bIsTex`` being non-zero, then ``NumSamples`` should equal ``TexWidth * TexHeight``.
+For the case of *bIsTex* being non-zero, *NumSamples* should equal `TexWidth * TexHeight`.
 
-The data block that follows the header is ``NumSamples * NumCoeffs * NumChannels * sizeof(float)`` bytes.
+The data block that follows the header is `NumSamples * NumCoeffs * NumChannels * sizeof(float)` bytes.
 
 ## Requirements
-
-
 
 |                    |                                                                                        |
 |--------------------|----------------------------------------------------------------------------------------|
 | Header<br/>  | <dl> <dt>D3DX9Mesh.h</dt> </dl> |
 | Library<br/> | <dl> <dt>D3dx9.lib</dt> </dl>   |
 
-
-
 ## See also
 
-<dl> <dt>
-
 [Precomputed Radiance Transfer Functions](dx9-graphics-reference-d3dx-functions-prt.md)
-</dt> </dl>
-
- 
-
- 

--- a/desktop-src/direct3d9/d3dxsaveprtbuffertofile.md
+++ b/desktop-src/direct3d9/d3dxsaveprtbuffertofile.md
@@ -64,6 +64,24 @@ If the method succeeds, the return value is D3D\_OK. If the method fails, the re
 
 The compiler setting also determines the function version. If Unicode is defined, the function call resolves to D3DXSavePRTBufferToFileW. Otherwise, the function call resolves to D3DXSavePRTBufferToFileA.
 
+The ``PRT`` file format is a binary file in the form of a header and then a data block:
+
+```C++
+struct PRTHeader
+{
+    UINT NumSamples;
+    UINT NumCoeffs;
+    UINT NumChannels;
+    UINT TexWidth;
+    UINT TexHeight;
+    UINT bIsTex;
+};
+```
+
+For the case of ``bIsTex`` being non-zero, then ``NumSamples`` should equal ``TexWidth * TexHeight``.
+
+The data block that follows the header is ``NumSamples * NumCoeffs * NumChannels * sizeof(float)`` bytes.
+
 ## Requirements
 
 


### PR DESCRIPTION
The ``PRT`` file format is opaque, but it's trivial and should be documented.