### PR TITLE
Fixed hyperlink in the themesfileformat-overview.md file

### DIFF
--- a/desktop-src/Controls/themesfileformat-overview.md
+++ b/desktop-src/Controls/themesfileformat-overview.md
@@ -16,7 +16,7 @@ The following topics are discussed in this article.
 
 -   [Creating a Theme File](#creating-a-theme-file)
 -   [Description of a Theme File](#description-of-a-theme-file)
-    -   [\[Theme\] Section](#theme-file-format)
+    -   [\[Theme\] Section](#theme-section)
     -   [\[Control Panel\\Colors\] Section](#control-panelcolors-section)
     -   [\[Control Panel\\Cursors\] Section](#control-panelcursors-section)
     -   [\[Control Panel\\Desktop\] Section](#control-paneldesktop-section)


### PR DESCRIPTION
The error was that the hyperlink with the text "[Theme] Section" was linking to the section header "Theme File Format" and not "[Theme] Section."