### PR TITLE
Wrong path to new "Maximum Path Length Limitation" page in "Naming Files, Paths, and Namespaces"

### DIFF
--- a/desktop-src/FileIO/naming-a-file.md
+++ b/desktop-src/FileIO/naming-a-file.md
@@ -29,7 +29,7 @@ For additional information, see the following subsections:
     -   [NT Namespaces](#nt-namespaces)
 -   [Related topics](#related-topics)
 
-To learn about configuring Windows 10 to support long file paths, see [Maximum Path Length Limitation](/windows/desktop/api/FileAPI/maximum-file-path-limitation).
+To learn about configuring Windows 10 to support long file paths, see [Maximum Path Length Limitation](maximum-file-path-limitation.md).
 
 ## File and Directory Names
 
@@ -126,7 +126,7 @@ Relative paths can combine both example types, for example "C:..\\tmp.txt". This
 
 ### Maximum Path Length Limitation
 
-In editions of Windows before Windows 10 version 1607, the maximum length for a path is **MAX\_PATH**, which is defined as 260 characters. In later versions of Windows, changing a registry key or using the Group Policy tool is required to remove the limit. See [Maximum Path Length Limitation](/windows/desktop/api/FileAPI/maximum-file-path-limitation) for full details.
+In editions of Windows before Windows 10 version 1607, the maximum length for a path is **MAX\_PATH**, which is defined as 260 characters. In later versions of Windows, changing a registry key or using the Group Policy tool is required to remove the limit. See [Maximum Path Length Limitation](maximum-file-path-limitation.md) for full details.
 
 ## Namespaces
 


### PR DESCRIPTION
Page in question: [Naming Files, Paths, and Namespaces](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#maximum-path-length-limitation)

Splitting out the Maximum Path Length info was a great idea, but the path to the relocated content (in the new "[Maximum Path Length Limitation](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)" page) is incorrect. It points to another directory when the new file is in the same directory as this one. The result is that the user is taken to a non-existent URL and get a 404 error.

I simply removed the path and added **.md** to the filename (in both places) to be consistent with how the link to the "File Streams" page is being handled.

This error was introduced in the following two commits:

* [855d8d3](https://github.com/MicrosoftDocs/win32/commit/855d8d3527f0179e802fd0395f7f50dd8e361524#diff-81fad2a8f974c7b1b74b6c862688e8d7)
* [e19c3f9](https://github.com/MicrosoftDocs/win32/commit/e19c3f9eabe9103c1e5aca7f97ccd9d41320c2d7)


Take care,
Solomon...
https://SqlQuantumLift.com/
https://SqlQuantumLeap.com/
https://SQLsharp.com/
