### PR TITLE
fix(ETW): retrieve inherited MOF properties for parsing.

### DIFF
--- a/desktop-src/ETW/retrieving-event-data-using-mof.md
+++ b/desktop-src/ETW/retrieving-event-data-using-mof.md
@@ -595,7 +595,7 @@ BOOL GetPropertyList(IWbemClassObject* pClass, PROPERTY_LIST** ppProperties, DWO
 
     // Retrieve the property names.
 
-    hr = pClass->GetNames(NULL, WBEM_FLAG_LOCAL_ONLY, NULL, &pNames);
+    hr = pClass->GetNames(NULL, WBEM_FLAG_NONSYSTEM_ONLY, NULL, &pNames);
     if (pNames)
     {
         *pPropertyCount = pNames->rgsabound->cElements;
@@ -649,6 +649,10 @@ BOOL GetPropertyList(IWbemClassObject* pClass, PROPERTY_LIST** ppProperties, DWO
                 j = var.intVal - 1;
                 VariantClear(&var);
                 *(*ppPropertyIndex+j) = i;
+            }
+            else if (WBEM_E_NOT_FOUND == hr)
+            {
+                continue; // Ignore property without WmiDataId
             }
             else
             {


### PR DESCRIPTION
The example provided in topic "Retrieving Event Data Using MOF" cannot parse some kernel trace event like `Process_V4_TypeGroup1` on Windows Server 2012 R2 correctly.

Trace event `Process_V4_TypeGroup1` contains a property `Flags` inherited from `MSNT_SystemTrace` with `WmiDataId("7")`. I deduce that retrieving properties using `WBEM_FLAG_LOCAL_ONLY` will fail to capture such properties, rendering the data in the MOF buffer corrupted.

So I recommend using `WBEM_FLAG_NONSYSTEM_ONLY` instead.