### PR TITLE
Update win32-physicalmemory.md

### DIFF
--- a/desktop-src/CIMWin32Prov/win32-physicalmemory.md
+++ b/desktop-src/CIMWin32Prov/win32-physicalmemory.md
@@ -930,6 +930,12 @@ DDR3—May not be available; see note above.
 
 FBD2
 
+</dt> <dd></dd> <dt>
+
+<span id="DDR2"></span><span id="ddr2"></span>
+
+<span id="DDR2"></span><span id="ddr2"></span>**DDR4** (26)
+
 </dd> </dl>
 
 </dd> <dt>

--- a/desktop-src/CIMWin32Prov/win32-physicalmemory.md
+++ b/desktop-src/CIMWin32Prov/win32-physicalmemory.md
@@ -903,7 +903,7 @@ This property is inherited from [**CIM\_PhysicalMemory**](cim-physicalmemory.md)
 
 </dt> <dd>
 
-DDR2—May not be available; see note above.
+DDR2—May not be available.
 
 </dd> <dt>
 
@@ -914,14 +914,14 @@ DDR2—May not be available; see note above.
 
 </dt> <dd>
 
-DDR2—FB-DIMM,May not be available; see note above.
+DDR2—FB-DIMM,May not be available.
 
 </dd> <dt>
 
 24
 </dt> <dd>
 
-DDR3—May not be available; see note above.
+DDR3—May not be available.
 
 </dd> <dt>
 

--- a/desktop-src/CIMWin32Prov/win32-physicalmemory.md
+++ b/desktop-src/CIMWin32Prov/win32-physicalmemory.md
@@ -932,9 +932,7 @@ FBD2
 
 </dt> <dd></dd> <dt>
 
-<span id="DDR2"></span><span id="ddr2"></span>
-
-<span id="DDR2"></span><span id="ddr2"></span>**DDR4** (26)
+<span id="DDR4"></span><span id="DDR4"></span>**DDR4** (26)
 
 </dd> </dl>
 


### PR DESCRIPTION
I ran ``wmic MemoryChip get SMBIOSMemoryType``

and got ``26``, and the RAM I have on this laptop is DDR4 and 26 was no where to see, so I added it and guessed it must mean DDR4.

Also, what are these "May not be available; see note above." and where's the note? huh?

&nbsp;

I don't even know how **SMBIOSMemoryType** even worked, it doesn't even show up in ``/?`` or ``wmic MemoryChip list full``
well "full" apperantly is defined, that's why it didn't show up, according to ``list /?``, but for ``/?`` I don't really have an explanation. But I believe that even "/?" is somewhere else defined.

There was a command that did show it, which was ``get /all``. But that's not like "/?", but the function is already there. But, I wouldn't say that with "get /all" it is clear to see, because it isn't clear to see that much.

&nbsp;

Regarding to the "list" command maybe there can be a "list all" or "list /all"? Even though "wmic" is said to be "deprecated"... not sure about, what replaced it. I'm not even sure why it was tagged as "deprecated", I believe it supports all values fine. The only thing that is "deprecated" is the defined value stuff like "brief" and "full", as example.

It rather should be made that when using ``wmic MemoryChip get /?`` it should act like "get /all" and maybe just show a list of all properties that can be accessed.