### PR TITLE
Document using assets in .themepacks

### DIFF
--- a/desktop-src/Controls/themesfileformat-overview.md
+++ b/desktop-src/Controls/themesfileformat-overview.md
@@ -718,21 +718,20 @@ Supported file types include the following:
 | Desktop icon | .ico                                |
 | Brand logo   | .png                                |
 
-If you place these asset files in the root of the .cab, you can reference most of them in your .theme file directly. For example, if you have a file called `Alert.wav` in the root of your .cab, you can use it in your sound scheme:
+Assets like sounds should be placed at the root of the .cab and referenced in .theme files directly. For example, if you have a file called `Alert.wav` in the root of your .cab, you can use it in your sound scheme:
 
 ```ini
 [AppEvents\Schemes\Apps\.Default\SystemAsterisk]
 DefaultValue=Alert.wav
 ```
 
-Wallpaper images behave differently. When a user activates a theme, these files are extracted to a `DesktopBackground\` folder relative to the .theme file. You should include this directory in your paths in .theme, but you should still place these files at the root of the .cab. For example, if you have a wallpaper called `BestDesktop.jpg` at the root of your .cab file, you should reference it in your .cab like this:
+Wallpaper images should be handled differently. They should extract to a `DesktopBackground\` folder and be referenced in .theme files by that subdirectory. For example, if you have a wallpaper called `BestDesktop.jpg`, ensure it extracts to `DesktopBackground\`, and reference it in your .cab like this:
 
 ```
 [Control Panel\Desktop]
-; Note the extra `DesktopBackground\` directory, even though the file is at the root of the .cab
+; Note the extra `DesktopBackground\` directory.
 Wallpaper=DesktopBackground\BestDesktop.jpg
 ```
-
 
 ## Related topics
 

--- a/desktop-src/Controls/themesfileformat-overview.md
+++ b/desktop-src/Controls/themesfileformat-overview.md
@@ -709,8 +709,6 @@ A .theme file has file associations; therefore, theme installer applications can
 
 Supported file types include the following:
 
-
-
 | File type    | Extension                           |
 |--------------|-------------------------------------|
 | Theme        | .theme                              |
@@ -720,9 +718,21 @@ Supported file types include the following:
 | Desktop icon | .ico                                |
 | Brand logo   | .png                                |
 
+If you place these asset files in the root of the .cab, you can reference most of them in your .theme file directly. For example, if you have a file called `Alert.wav` in the root of your .cab, you can use it in your sound scheme:
 
+```ini
+[AppEvents\Schemes\Apps\.Default\SystemAsterisk]
+DefaultValue=Alert.wav
+```
 
- 
+Wallpaper images behave differently. When a user activates a theme, these files are extracted to a `DesktopBackground\` folder relative to the .theme file. You should include this directory in your paths in .theme, but you should still place these files at the root of the .cab. For example, if you have a wallpaper called `BestDesktop.jpg` at the root of your .cab file, you should reference it in your .cab like this:
+
+```
+[Control Panel\Desktop]
+; Note the extra `DesktopBackground\` directory, even though the file is at the root of the .cab
+Wallpaper=DesktopBackground\BestDesktop.jpg
+```
+
 
 ## Related topics
 


### PR DESCRIPTION
Today, we do not document how to use assets you deploy in a `.themepack` file. This change includes barebones documentation explaining how to use asset files (like sounds and images) in a `.themepack`.

## PLEASE HOLD ##

The .cab/.themepack file must be specially generated to place any wallpapers into the DesktopBackground directory. I'd like to know if there are any area experts here.

## How tested?

* Created several themes from Settings, then extracted them as `.cab`s and inspected the folder structure and `.theme` files.
* Downloaded several themes with sound from our [Featured Desktop Themes](https://support.microsoft.com/en-us/help/13768/desktop-themes-featured) page, then extracted them as `.cab`s and inspected the folder structure and `.theme` files. *(The Age of Empires made me smile.)*

I have not been able to verify nested directories (can I include subdirectories in my themes?) or why the `DesktopBackground/` special case exists (can't we deploy wherever we want?).

Suggestions welcome.

Thanks!