### PR TITLE
Update localization independent SID｡

### DIFF
--- a/desktop-src/TaskSchd/logon-trigger-example--c---.md
+++ b/desktop-src/TaskSchd/logon-trigger-example--c---.md
@@ -329,7 +329,7 @@ int __cdecl wmain()
             _bstr_t( wszTaskName ),
             pTask,
             TASK_CREATE_OR_UPDATE, 
-            _variant_t(L"Builtin\\Administrators"), 
+            _variant_t(L"S-1-5-32-544"),
             _variant_t(), 
             TASK_LOGON_GROUP,
             _variant_t(L""),


### PR DESCRIPTION
The `userId` parameter of the [ITaskFolder::RegisterTaskDefinition()](https://docs.microsoft.com/en-us/windows/win32/api/taskschd/nf-taskschd-itaskfolder-registertaskdefinition) method has been replaced on language independent SID of the "S-1-5-32-544" administrator group. The "Builtin\\Administrators" value will work only on English-language versions of Windows and will not work on versions with other localizations.
Links:
[Well-known security identifiers in Windows operating systems](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/security-identifiers-in-windows)