### PR TITLE
Update improving-direct2d-performance.md

### DIFF
--- a/desktop-src/Direct2D/improving-direct2d-performance.md
+++ b/desktop-src/Direct2D/improving-direct2d-performance.md
@@ -209,7 +209,8 @@ m_d2dContext->BeginDraw();
 …
 m_d2dContext->EndDraw();
 
-// Call the FillOpacityMask method. 
+// Call the FillOpacityMask method
+// Note: for this call to work correctly the anti alias mode must be D2D1_ANTIALIAS_MODE_ALIASED. 
 m_d2dContext->SetTarget(oldTarget.Get());
 m_d2dContext->FillOpacityMask(
     opacityBitmap.Get(),


### PR DESCRIPTION
Add crucial hint that, for caching with A8 bitmap & the FillopacityMask method, the anti-aliasing mode must have been set correctly