### PR TITLE
Fix IPv6 format typo in isInNetEx example

### DIFF
--- a/desktop-src/WinHttp/isinnetex.md
+++ b/desktop-src/WinHttp/isinnetex.md
@@ -55,7 +55,7 @@ isInNetEx(host, "198.95.0.0/16");
 ```
 
 ``` syntax
-isInNetEx(host, "3ffe:8311:ffff/48");
+isInNetEx(host, "3ffe:8311:ffff::/48");
     true if the IP address of the host matches 3ffe:8311:fff:*:*:*:*:*
 ```
 


### PR DESCRIPTION
IPv6 subnets are formatted with `::` in the prefix, as used in the description at the top - add the missing colons to an example.