### PR TITLE
detail halfway cases in round documentation

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-round.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-round.md
@@ -18,7 +18,7 @@ ms.date: 05/31/2018
 
 # round
 
-Rounds the specified value to the nearest integer.
+Rounds the specified value to the nearest integer. Halfway cases are rounded to the nearest even.
 
 
 


### PR DESCRIPTION
This rounds halfway cases to the nearest even.  We should be explicit about this especially because it differs from C++'s std::round which rounds halfway cases away from zero.