### PR TITLE
Update -wic-codec-wiccreateimagingfactory-proxy.md

### DIFF
--- a/desktop-src/wic/-wic-codec-wiccreateimagingfactory-proxy.md
+++ b/desktop-src/wic/-wic-codec-wiccreateimagingfactory-proxy.md
@@ -22,15 +22,12 @@ Proxy function for creating the [**IWICImagingFactory**](/windows/desktop/api/Wi
 
 ## Syntax
 
-
-```C++
+```cpp
 HRESULT WICCreateImagingFactory_Proxy(
   _In_  UINT               SDKVersion,
   _Out_ IWICImagingFactory **ppIImagingFactory
 );
 ```
-
-
 
 ## Parameters
 
@@ -58,7 +55,7 @@ If this function succeeds, it returns **S\_OK**. Otherwise, it returns an **HRES
 
 ## Remarks
 
-This function is a helper for creating a WIC factory for explicit DLL linking that was needed for Windows XP. In normal usage, you would just use **[**CoCreateInstance**](/windows/win32/wic/-wic-api#class-factories)** instead as it's always included in all newer versions of Windows.
+This function is a helper for creating a WIC factory for explicit DLL linking, which was needed for Windows XP. In normal usage, you would use [**CoCreateInstance**](/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance) instead (see [WIC API class factories](/windows/win32/wic/-wic-api#class-factories)), since that's always included in all newer versions of Windows.
 
 ## Requirements
 

--- a/desktop-src/wic/-wic-codec-wiccreateimagingfactory-proxy.md
+++ b/desktop-src/wic/-wic-codec-wiccreateimagingfactory-proxy.md
@@ -13,7 +13,7 @@ api_type:
 - DllExport
 api_location: 
 - Windowscodecs.dll
-- Wincodec.lib
+- Windowscodecs.lib
 ---
 
 # WICCreateImagingFactory\_Proxy function
@@ -58,6 +58,8 @@ If this function succeeds, it returns **S\_OK**. Otherwise, it returns an **HRES
 
 ## Remarks
 
+This function is a helper for creating a WIC factory for explicit DLL linking that was needed for Windows XP. In normal usage, you would just use **[**CoCreateInstance**](/windows/win32/wic/-wic-api#class-factories)** instead as it's always included in all newer versions of Windows.
+
 ## Requirements
 
 
@@ -66,7 +68,7 @@ If this function succeeds, it returns **S\_OK**. Otherwise, it returns an **HRES
 |-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Minimum supported client<br/> | Windows XP with SP2, Windows Vista \[desktop apps only\]<br/>                                                                                              |
 | Minimum supported server<br/> | Windows Server 2008 \[desktop apps only\]<br/>                                                                                                             |
-| DLL<br/>                      | <dl> <dt>Windowscodecs.dll; </dt> <dt>Wincodec.lib</dt> </dl> |
+| DLL<br/>                      | <dl> <dt>Windowscodecs.dll; </dt> <dt>windowscodecs.lib</dt> </dl> |
 
 
 


### PR DESCRIPTION
``wincodec.lib`` doesn't exist in any Windows SDK. It's called ``windowscodecs.lib``.

> You might want to do a search & replace for all the WIC topics for this as well.