### PR TITLE
Update refreshing-a-dynamic-object.md

### DIFF
--- a/desktop-src/AD/refreshing-a-dynamic-object.md
+++ b/desktop-src/AD/refreshing-a-dynamic-object.md
@@ -15,6 +15,8 @@ A client can refresh the Time To Live (TTL) of a given directory entry to keep i
 -   Performing an LDAP extended operation with an OID of 1.3.6.1.4.1.1466.101.119.1 for TTL refresh, as stipulated in the RFC 2589. This OID is defined as **LDAP\_TTL\_EXTENDED\_OP\_OID** in WINLDAP.H.
 
  
+**Remark***:
+Dynamic objects are removed by Garbage Collector when they have expired, there is no phase of the object being a tombstone when it has expired. You need to be careful with the AD replication latency when you refresh objects. You have to ensure that the update to refresh the TTL arrives early enough so all replicas of the naming context (full and global catalog) see the refresh transaction before the object expires locally.
 
  
 


### PR DESCRIPTION
the update to entryTTL has be replicate before the object expires. e.g. for groups it will end up with an empty membershp list when you resurrect a group from expired state.

Filed as BUG 29608897 as end-status is a group with no members on one replica, and members on the other.