### PR TITLE
Update disabling-terminal-services-features.md

### DIFF
--- a/desktop-src/TermServ/disabling-terminal-services-features.md
+++ b/desktop-src/TermServ/disabling-terminal-services-features.md
@@ -16,6 +16,7 @@ For enhanced security, you might choose to disable Remote Desktop Services featu
 1.  Edit the registry of the client computer and add the following keys:
 
     -   **HKEY\_LOCAL\_MACHINE\\Software\\Microsoft\\Terminal Server\\DisableClipboardRedirection**
+    -   **HKEY\_LOCAL\_MACHINE\\Software\\Microsoft\\Terminal Server\\DisableDriveRedirection**
     -   **HKEY\_LOCAL\_MACHINE\\Software\\Microsoft\\Terminal Server\\DisablePrinterRedirection**
 
 2.  Set the value of both keys to **REG\_DWORD** 1.


### PR DESCRIPTION
Undocumented registry key that prevents the client from handing the local drives to the server for mapping. While the keys for Clipboard and Printer will grey-out the options in mstsc.exe the Drive key will not. Drives will not get mapped with DisableDriveRedirection set to 1 though.