### PR TITLE
Update code-page-identifiers.md

### DIFF
--- a/desktop-src/Intl/code-page-identifiers.md
+++ b/desktop-src/Intl/code-page-identifiers.md
@@ -42,7 +42,7 @@ The following table defines the available code page identifiers.
 | 866        | cp866                   | OEM Russian; Cyrillic (DOS)                                                                         |
 | 869        | ibm869                  | OEM Modern Greek; Greek, Modern (DOS)                                                               |
 | 870        | IBM870                  | IBM EBCDIC Multilingual/ROECE (Latin 2); IBM EBCDIC Multilingual Latin 2                            |
-| 874        | windows-874             | ANSI/OEM Thai (ISO 8859-11); Thai (Windows)                                                         |
+| 874        | windows-874             | Thai (Windows)                                                         |
 | 875        | cp875                   | IBM EBCDIC Greek Modern                                                                             |
 | 932        | shift\_jis              | ANSI/OEM Japanese; Japanese (Shift-JIS)                                                             |
 | 936        | gb2312                  | ANSI/OEM Simplified Chinese (PRC, Singapore); Chinese Simplified (GB2312)                           |


### PR DESCRIPTION
Here I updated the code page 874 as it's clearly not identical to ISO 8859-11. You can refer to the following Unicode mappings:
https://unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP874.TXT
https://unicode.org/Public/MAPPINGS/ISO8859/8859-11.TXT
(Different on 0x91-0x97 and also other places)