### PR TITLE
Update code example to not use undefined variable.

### DIFF
--- a/desktop-src/winmsg/using-windows.md
+++ b/desktop-src/winmsg/using-windows.md
@@ -43,7 +43,7 @@ hwndMain = CreateWindowEx(
     CW_USEDEFAULT,          // default height               
     (HWND) NULL,            // no parent or owner window    
     (HMENU) NULL,           // class menu used              
-    hinstance,              // instance handle              
+    hinst,                  // instance handle              
     NULL);                  // no window creation data      
  
 if (!hwndMain) 


### PR DESCRIPTION
The example code declares a variable `HINST hinst` but later uses an undefined variable `hinstance`. Presumably this should have been the previously defined `hinst` variable.