### PR TITLE
Fix bogus D3DSTT_* values.

### DIFF
--- a/desktop-src/direct3d9/d3dsampler-texture-type.md
+++ b/desktop-src/direct3d9/d3dsampler-texture-type.md
@@ -41,28 +41,28 @@ typedef enum D3DSAMPLER_TEXTURE_TYPE {
 <span id="D3DSTT_UNKNOWN"></span><span id="d3dstt_unknown"></span>**D3DSTT\_UNKNOWN**
 </dt> <dd>
 
-Uninitialized value. The value of this element is D3DSP\_TEXTURETYPE\_SHIFT.
+Uninitialized value. The value of this element is 0 &lt;&lt; D3DSP\_TEXTURETYPE\_SHIFT.
 
 </dd> <dt>
 
 <span id="D3DSTT_2D"></span><span id="d3dstt_2d"></span>**D3DSTT\_2D**
 </dt> <dd>
 
-Declaring a 2D texture. The value of this element is D3DSP\_TEXTURETYPE\_SHIFT \* 4.
+Declaring a 2D texture. The value of this element is 2 &lt;&lt; D3DSP\_TEXTURETYPE\_SHIFT.
 
 </dd> <dt>
 
 <span id="D3DSTT_CUBE"></span><span id="d3dstt_cube"></span>**D3DSTT\_CUBE**
 </dt> <dd>
 
-Declaring a cube texture. The value of this element is D3DSP\_TEXTURETYPE\_SHIFT \* 8.
+Declaring a cube texture. The value of this element is 3 &lt;&lt; D3DSP\_TEXTURETYPE\_SHIFT.
 
 </dd> <dt>
 
 <span id="D3DSTT_VOLUME"></span><span id="d3dstt_volume"></span>**D3DSTT\_VOLUME**
 </dt> <dd>
 
-Declaring a volume texture. The value of this element is D3DSP\_TEXTURETYPE\_SHIFT \* 16.
+Declaring a volume texture. The value of this element is 4 &lt;&lt; D3DSP\_TEXTURETYPE\_SHIFT.
 
 </dd> <dt>
 


### PR DESCRIPTION
I believe someone tried to "simplify" the math by assuming `(x << y)` == `(y << x)`, which is incorrect.

### C:\Program Files (x86)\Windows Kits\10\Include\10.0.18362.0\shared\d3d9types.h

```cpp
#define D3DSP_TEXTURETYPE_SHIFT 27
#define D3DSP_TEXTURETYPE_MASK  0x78000000

typedef enum _D3DSAMPLER_TEXTURE_TYPE
{
    D3DSTT_UNKNOWN = 0<<D3DSP_TEXTURETYPE_SHIFT, // uninitialized value
    D3DSTT_2D      = 2<<D3DSP_TEXTURETYPE_SHIFT, // dcl_2d s# (for declaring a 2-D texture)
    D3DSTT_CUBE    = 3<<D3DSP_TEXTURETYPE_SHIFT, // dcl_cube s# (for declaring a cube texture)
    D3DSTT_VOLUME  = 4<<D3DSP_TEXTURETYPE_SHIFT, // dcl_volume s# (for declaring a volume texture)
    D3DSTT_FORCE_DWORD  = 0x7fffffff,      // force 32-bit size enum
} D3DSAMPLER_TEXTURE_TYPE;
```

### D3DSTT_UNKNOWN

* The actual value is 0: `0 << D3DSP_TEXTURETYPE_SHIFT` == `0 << 27`
* The bogus documented value is 27: `D3DSP_TEXTURETYPE_SHIFT` == `D3DSP_TEXTURETYPE_SHIFT << 0` == `27 << 0`

### D3DSTT_2D

* The actual value is 268435456: `2 << D3DSP_TEXTURETYPE_SHIFT` == `2 << 27`
* The bogus documented value is 108: `D3DSP_TEXTURETYPE_SHIFT * 4` == `D3DSP_TEXTURETYPE_SHIFT << 2` == `27 << 2`

### D3DSTT_CUBE

* The actual value is 402653184: `3 << D3DSP_TEXTURETYPE_SHIFT` == `3 << 27`
* The bogus documented value is 216: `D3DSP_TEXTURETYPE_SHIFT * 8` == `D3DSP_TEXTURETYPE_SHIFT << 3` == `27 << 3`

### D3DSTT_VOLUME

* The actual value is 536870912: `4 << D3DSP_TEXTURETYPE_SHIFT` == `4 << 27`
* The bogus documented value is 432: `D3DSP_TEXTURETYPE_SHIFT * 16` == `D3DSP_TEXTURETYPE_SHIFT << 4` == `27 << 4`