### PR TITLE
TermServ: Adds information about Windows version released after Server 2008

### DIFF
--- a/desktop-src/TermServ/installagreementlicensekeypack-win32-tslicensekeypack.md
+++ b/desktop-src/TermServ/installagreementlicensekeypack-win32-tslicensekeypack.md
@@ -123,7 +123,31 @@ Not supported.
 2
 </dt> <dd>
 
-Windows Server 2008
+Windows Server 2008 / 2008 R2
+
+</dd>
+<dt>
+
+4
+</dt> <dd>
+
+Windows Server 2012 / 2012 R2
+
+</dd>
+<dt>
+
+5
+</dt> <dd>
+
+Windows Server 2016
+
+</dd>
+<dt>
+
+6
+</dt> <dd>
+
+Windows Server 2019
 
 </dd> </dl> </dd> <dt>
 

--- a/desktop-src/TermServ/installopenlicensekeypack-win32-tslicensekeypack.md
+++ b/desktop-src/TermServ/installopenlicensekeypack-win32-tslicensekeypack.md
@@ -81,7 +81,31 @@ Not supported.
 2
 </dt> <dd>
 
-Windows Server 2008
+Windows Server 2008 / 2008 R2
+
+</dd>
+ <dt>
+
+4
+</dt> <dd>
+
+Windows Server 2012 / 2012 R2
+
+</dd>
+ <dt>
+
+5
+</dt> <dd>
+
+Windows Server 2016
+
+</dd>
+ <dt>
+
+6
+</dt> <dd>
+
+Windows Server 2019
 
 </dd> </dl> </dd> <dt>
 

--- a/desktop-src/TermServ/win32-tslicensekeypack.md
+++ b/desktop-src/TermServ/win32-tslicensekeypack.md
@@ -330,10 +330,24 @@ Product version identifier for the Remote Desktop Services license key pack.
 
 <dt>
 
+6
+</dt> <dd>
+
+Windows Server 2019
+
+</dd> <dt>
+
+5
+</dt> <dd>
+
+Windows Server 2016
+
+</dd> <dt>
+
 4
 </dt> <dd>
 
-Windows Server 2012
+Windows Server 2012 / 2012 R2
 
 </dd> <dt>
 


### PR DESCRIPTION
I used https://support.microsoft.com/en-us/topic/-cannot-bind-parameter-productversion-error-when-you-run-new-item-cmdlet-to-install-cal-in-windows-server-2016-5644c625-c47f-c73d-c3a2-847a0c7f326d and my own experience to fill missing values