### PR TITLE
Powershell example should have -ne instead

### DIFF
--- a/desktop-src/WmiCoreProv/wmimonitorid.md
+++ b/desktop-src/WmiCoreProv/wmimonitorid.md
@@ -202,7 +202,7 @@ The following PowerShell example retrieves the serial number of multiple monitor
 
 
 ```PowerShell
-gwmi WmiMonitorID -Namespace root\wmi | ForEach-Object {($_.UserFriendlyName -notmatch 0 | foreach {[char]$_}) -join ""; ($_.SerialNumberID -notmatch 0 | foreach {[char]$_}) -join ""}
+gwmi WmiMonitorID -Namespace root\wmi | ForEach-Object {($_.UserFriendlyName -ne 0 | foreach {[char]$_}) -join ""; ($_.SerialNumberID -ne 0 | foreach {[char]$_}) -join ""}
 ```
 
 


### PR DESCRIPTION
Powershell example should have -ne instead of -notmatch.  UserFriendlyName is a Unit16 array and the idea i believe is to ignore items in the array with a value of 0. NotMatch is a regex lookup at the string that will exclude important non-zero values that contain a zero like 105  which is the Ascii code for uppercase "E"

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_comparison_operators?view=powershell-7.1#-notmatch