### PR TITLE
Fix TIFF codec option docs

### DIFF
--- a/desktop-src/wic/tiff-format-overview.md
+++ b/desktop-src/wic/tiff-format-overview.md
@@ -56,45 +56,20 @@ WIC-enabled codecs differ at the encoding option level. Encoder options reflect 
 
 The TIFF codec uses basic WIC options. The following table lists the WIC encoder options supported by the native TIFF codec.
 
-
-
-Basic WIC Encoder Options
-
-Property Name
-
-VARTYPE
-
-Value Range
-
-Default Value
-
-CompressionQuality
-
-VT\_R4
-
-0 - 1.0
-
-TIFFCompressionMethod
-
-VT\_UI1
-
-[**WICTiffCompressionOption**](/windows/desktop/api/Wincodec/ne-wincodec-wictiffcompressionoption)
-
-[**WICTiffCompressionDontCare**](/windows/desktop/api/Wincodec/ne-wincodec-wictiffcompressionoption)
-
-
-
- 
+| Property Name         | VARTYPE | Value Range | Default Value    |
+|-----------------------|---------|-------------|------------------|
+| CompressionQuality    | VT\_R4  | 0 - 1.0     | 0                |
+| TiffCompressionMethod | VT\_UI1 | [**WICTiffCompressionOption**](/windows/desktop/api/Wincodec/ne-wincodec-wictiffcompressionoption) | [**WICTiffCompressionDontCare**](/windows/desktop/api/Wincodec/ne-wincodec-wictiffcompressionoption) |
 
 If an encoder option is present in the [**IPropertyBag2**](/previous-versions/windows/internet-explorer/ie-developer/platform-apis/aa768192(v=vs.85)) option list that the codec does not support, it is ignored.
 
 ### CompressionQuality Option
 
-Specifies the desired compression quality. 0.0 indicates the efficient compression schema available. Typically, this schema results in a faster encode but larger output. A value of 1.0 specifies the most efficient compression schema available. Typically, this schema results in a longer encode but producing smaller output.
+Specifies the desired compression quality. 0.0 indicates the least efficient compression scheme available. Typically, this scheme results in a faster encode but larger output. A value of 1.0 specifies the most efficient compression scheme available. Typically, this scheme results in a longer encode but produces smaller output.
 
-The default value is .
+The default value is 0.
 
-### TIFFCompressionMethod Option
+### TiffCompressionMethod Option
 
 Specifies the TIFF compression method.
 
@@ -102,7 +77,7 @@ The default value is [**WICTiffCompressionDontCare**](/windows/desktop/api/Winco
 
 ## Decoding
 
-The WIC decoding API are designed to be codec-independent and image decoding for WIC-enabled codecs is essentially the same. For more information about image decoding, see the [Decoding Overview](-wic-creating-decoder.md). For more information about using decoded image data, see the [Bitmap Sources Overview](-wic-bitmapsources.md).
+The WIC decoding APIs are designed to be codec-independent and image decoding for WIC-enabled codecs is essentially the same. For more information about image decoding, see the [Decoding Overview](-wic-creating-decoder.md). For more information about using decoded image data, see the [Bitmap Sources Overview](-wic-bitmapsources.md).
 
  
 


### PR DESCRIPTION
Formatted the TIFF codec options as a table.

I've also improved the wording of the `CompressionQuality` option description.  The default value for this option is currently missing from the docs.  I attempted to determine the actual default value through experimentation with the Windows 10 version of the codec, but no value made any difference in file size, so I've given a default of `0` to reflect the default value returned by `IPropertyBag2::Read`.

And I have changed the casing of the `TiffCompressionMethod` name to match what's returned by `IPropertyBag2::GetPropertyInfo` from the Windows 10 version of the codec.