### PR TITLE
Create tls-cipher-suites-in-windows-10-v21H1.md

### DIFF
--- a/desktop-src/SecAuthN/cipher-suites-in-schannel.md
+++ b/desktop-src/SecAuthN/cipher-suites-in-schannel.md
@@ -28,6 +28,8 @@ In earlier versions of Windows, TLS cipher suites and elliptical curves were con
 
 Different Windows versions support different TLS cipher suites and priority order. See the corresponding Windows version for the default order in which they are chosen by the Microsoft Schannel Provider.
 
+**Windows 10, version 21H1:** For information about supported cipher suites, see [TLS Cipher Suites in Windows 10 v21H1](tls-cipher-suites-in-windows-10-v21H1.md)
+
 **Windows 10, version 1903:** For information about supported cipher suites, see [TLS Cipher Suites in Windows 10 v1903](tls-cipher-suites-in-windows-10-v1903.md)
 
 **Windows 10, version 1809:** For information about supported cipher suites, see [TLS Cipher Suites in Windows 10 v1809](tls-cipher-suites-in-windows-10-v1809.md)

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v21H1.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v21H1.md
@@ -1,5 +1,5 @@
 ---
-Description: Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
+description: Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
 title: TLS Cipher Suites in Windows 10 v21H1.
 ms.topic: article
 ms.date: 12/17/2020

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v21H1.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v21H1.md
@@ -1,0 +1,116 @@
+---
+Description: Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
+title: TLS Cipher Suites in Windows 10 v21H1.
+ms.topic: article
+ms.date: 12/17/2020
+---
+
+# TLS Cipher Suites in Windows 10 v21H1
+
+Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
+
+Availability of cipher suites should be controlled in one of two ways:
+
+-   Default priority order is overridden when a priority list is configured. Cipher suites not in the priority list will not be used.
+-   Allowed when the application passes SCH\_USE\_STRONG\_CRYPTO: The Microsoft Schannel provider will filter out known weak cipher suites when the application uses the SCH\_USE\_STRONG\_CRYPTO flag. RC4, DES, export and null cipher suites are filtered out.
+
+> [!IMPORTANT]
+> HTTP/2 web services fail with non-HTTP/2-compatible cipher suites. To ensure your web services function with HTTP/2 clients and browsers, see [How to deploy custom cipher suite ordering](https://support.microsoft.com/help/4032720/how-to-deploy-custom-cipher-suite-ordering-in-windows-server-2016).
+
+ 
+
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
+
+For Windows 10, version 21H1, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
+
+
+
+| Cipher suite string                                                                           | Allowed by SCH\_USE\_STRONG\_CRYPTO | TLS/SSL Protocol versions                     |
+|-----------------------------------------------------------------------------------------------|-------------------------------------|-----------------------------------------------|
+| TLS\_AES\_256\_GCM\_SHA384<br/>                                                               | Yes<br/>                      | TLS 1.3<br/>                            |
+| TLS\_AES\_128\_GCM\_SHA256<br/>                                                               | Yes<br/>                      | TLS 1.3<br/>                            |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_256\_GCM\_SHA384<br/>                                           | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_128\_GCM\_SHA256<br/>                                           | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_256\_GCM\_SHA384<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_128\_GCM\_SHA256<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_DHE\_RSA\_WITH\_AES\_256\_GCM\_SHA384<br/>                                               | No<br/>                       | TLS 1.2<br/>                            |
+| TLS\_DHE\_RSA\_WITH\_AES\_128\_GCM\_SHA256<br/>                                               | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_256\_CBC\_SHA384<br/>                                           | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_128\_CBC\_SHA256<br/>                                           | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_256\_CBC\_SHA384<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_256\_CBC\_SHA<br/>                                              | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_ECDHE\_ECDSA\_WITH\_AES\_128\_CBC\_SHA<br/>                                              | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_256\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_RSA\_WITH\_AES\_256\_GCM\_SHA384<br/>                                                    | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_RSA\_WITH\_AES\_128\_GCM\_SHA256<br/>                                                    | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_RSA\_WITH\_AES\_256\_CBC\_SHA256<br/>                                                    | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_RSA\_WITH\_AES\_128\_CBC\_SHA256<br/>                                                    | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_RSA\_WITH\_AES\_256\_CBC\_SHA<br/>                                                       | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_RSA\_WITH\_AES\_128\_CBC\_SHA<br/>                                                       | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_RSA\_WITH\_3DES\_EDE\_CBC\_SHA<br/>                                                      | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_RSA\_WITH\_NULL\_SHA256 <br/> Only used when application explicitly requests.<br/>       | No<br/>                       | TLS 1.2<br/>                            |
+| TLS\_RSA\_WITH\_NULL\_SHA <br/> Only used when application explicitly requests.<br/>          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+
+
+
+ 
+
+The following cipher suites are supported by the Microsoft Schannel Provider, but not enabled by default:
+
+
+
+| Cipher suite string                                                                               | Allowed by SCH\_USE\_STRONG\_CRYPTO | TLS/SSL Protocol versions                     |
+|---------------------------------------------------------------------------------------------------|-------------------------------------|-----------------------------------------------|
+| TLS\_CHACHA20\_POLY1305\_SHA256<br/>                                                        | Yes<br/>                      | TLS 1.3<br/>                            |
+| TLS\_DHE\_RSA\_WITH\_AES\_256\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_DHE\_RSA\_WITH\_AES\_128\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_DHE\_DSS\_WITH\_AES\_256\_CBC\_SHA256<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_DHE\_DSS\_WITH\_AES\_128\_CBC\_SHA256<br/>                                             | Yes<br/>                      | TLS 1.2<br/>                            |
+| TLS\_DHE\_DSS\_WITH\_AES\_256\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_DHE\_DSS\_WITH\_AES\_128\_CBC\_SHA<br/>                                                | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0<br/>          |
+| TLS\_DHE\_DSS\_WITH\_3DES\_EDE\_CBC\_SHA<br/>                                               | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_WITH\_RC4\_128\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_WITH\_RC4\_128\_MD5<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                              | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+
+
+
+ 
+
+The following PSK cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
+
+
+
+| Cipher suite string                              | Allowed by SCH\_USE\_STRONG\_CRYPTO | TLS/SSL Protocol versions |
+|--------------------------------------------------|-------------------------------------|---------------------------|
+| TLS\_PSK\_WITH\_AES\_256\_GCM\_SHA384<br/> | Yes<br/>                      | TLS 1.2<br/>        |
+| TLS\_PSK\_WITH\_AES\_128\_GCM\_SHA256<br/> | Yes<br/>                      | TLS 1.2<br/>        |
+| TLS\_PSK\_WITH\_AES\_256\_CBC\_SHA384<br/> | Yes<br/>                      | TLS 1.2<br/>        |
+| TLS\_PSK\_WITH\_AES\_128\_CBC\_SHA256<br/> | Yes<br/>                      | TLS 1.2<br/>        |
+| TLS\_PSK\_WITH\_NULL\_SHA384<br/>          | No<br/>                       | TLS 1.2<br/>        |
+| TLS\_PSK\_WITH\_NULL\_SHA256<br/>          | No<br/>                       | TLS 1.2<br/>        |
+
+
+
+ 
+
+> [!Note]  
+> No PSK cipher suites are enabled by default. Applications need to request PSK using SCH\_USE\_PRESHAREDKEY\_ONLY. For more information on Schannel flags, see [**SCHANNEL\_CRED**](/windows/desktop/api/Schannel/ns-schannel-schannel_cred).
+
+ 
+
+To add cipher suites, either deploy a group policy or use the TLS cmdlets:
+
+-   To use group policy, configure SSL Cipher Suite Order under Computer Configuration > Administrative Templates > Network > SSL Configuration Settings with the priority list for all cipher suites you want enabled.
+-   To use PowerShell, see [TLS cmdlets](/powershell/module/tls/?view=win10-ps).
+
+> [!Note]  
+> Prior to Windows 10, cipher suite strings were appended with the elliptic curve to determine the curve priority. Windows 10 supports an elliptic curve priority order setting so the elliptic curve suffix is not required and is overridden by the new elliptic curve priority order, when provided, to allow organizations to use group policy to configure different versions of Windows with the same cipher suites.

--- a/desktop-src/SecAuthN/toc.yml
+++ b/desktop-src/SecAuthN/toc.yml
@@ -242,6 +242,8 @@
           - name: "Cipher Suites in TLS/SSL (Schannel SSP)"
             href: cipher-suites-in-schannel.md
             items: 
+            - name: "TLS Cipher Suites in Windows 10 v21H1"
+              href: tls-cipher-suites-in-windows-10-v21H1.md
             - name: "TLS Cipher Suites in Windows 10 v1903"
               href: tls-cipher-suites-in-windows-10-v1903.md
             - name: "TLS Cipher Suites in Windows 10 v1809"


### PR DESCRIPTION
Creating documentation for TLS 1.3 cipher suites which will be supported in the Fe (21H1) release.