### PR TITLE
Fix syntax summary table formatting

### DIFF
--- a/desktop-src/wic/-wic-codec-metadataquerylanguage.md
+++ b/desktop-src/wic/-wic-codec-metadataquerylanguage.md
@@ -201,22 +201,22 @@ The following table is a formal definition of the WIC metadata query language. E
 
 | Symbol                   | Expression                                                                                                                                                                  |
 |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <path>             | <name> \| '/' <property path>                                                                                                                                   |
-| <property path>    | <metadata item> \| <property path> '/' <property path>                                                                                                    |
-| <metadata item>    | <index name> \| <item name> \| <schema name> ':' <item name>                                                                                        |
-| <schema name>      | <item name>                                                                                                                                                           |
-| <item name>        | <metadata item> \| <indexed item><index>                                                                                                                  |
-| <indexed item>     | <item> \| <implied metadata><item>                                                                                                                        |
-| <implied metadata> | '<'<name>'>'                                                                                                                                                    |
-| <item>             | <name> \| <index> <data> \| <data>                                                                                                                  |
-| <data>             | '{' <data type> '=' <value> '}'                                                                                                                                 |
-| <index>            | '\[' <number> \| <star> '\]'                                                                                                                                    |
-| <data type>        | 'char' \| 'uchar' \| 'short' \| 'ushort' \| 'long' \| 'ulong' \| 'int' \| 'uint' \| 'longlong' \| 'ulonglong' \| 'float' \| 'double' \| 'str' \| 'wstr' \| 'guid' \| 'bool' |
-| <data value>       | <number> \| <name> \| <guid>                                                                                                                              |
-| <star>             | '\*'                                                                                                                                                                        |
-| <number>           | number                                                                                                                                                                      |
-| <name>             | string                                                                                                                                                                      |
-| <guid>             | guid                                                                                                                                                                        |
+| \<path>             | \<name> \| '/' \<property path>                                                                                                                                   |
+| \<property path>    | \<metadata item> \| \<property path> '/' \<property path>                                                                                                    |
+| \<metadata item>    | \<index name> \| \<item name> \| \<schema name> ':' \<item name>                                                                                        |
+| \<schema name>      | \<item name>                                                                                                                                                           |
+| \<item name>        | \<metadata item> \| <indexed item><index>                                                                                                                  |
+| \<indexed item>     | \<item> \| \<implied metadata>\<item>                                                                                                                        |
+| \<implied metadata> | '<'\<name>'>'                                                                                                                                                    |
+| \<item>             | \<name> \| \<index> \<data> \| \<data>                                                                                                                  |
+| \<data>             | '{' \<data type> '=' \<value> '}'                                                                                                                                 |
+| \<index>            | '\[' \<number> \| \<star> '\]'                                                                                                                                    |
+| \<data type>        | 'char' \| 'uchar' \| 'short' \| 'ushort' \| 'long' \| 'ulong' \| 'int' \| 'uint' \| 'longlong' \| 'ulonglong' \| 'float' \| 'double' \| 'str' \| 'wstr' \| 'guid' \| 'bool' |
+| \<data value>       | \<number> \| \<name> \| \<guid>                                                                                                                              |
+| \<star>             | '\*'                                                                                                                                                                        |
+| \<number>           | number                                                                                                                                                                      |
+| \<name>             | string                                                                                                                                                                      |
+| \<guid>             | guid                                                                                                                                                                        |
 
 
 


### PR DESCRIPTION
The symbol names were not escaped, making the table render improperly