### PR TITLE
Fix IPv4 address example format error

### DIFF
--- a/desktop-src/WmiSdk/swbemlocator-connectserver.md
+++ b/desktop-src/WmiSdk/swbemlocator-connectserver.md
@@ -55,7 +55,7 @@ Computer name to which you are connecting. If the remote computer is in a differ
 
 Example: `server1.network.fabrikam`
 
-You also can use an IP address in this parameter. If the IP address is in IPv6 format, the target computer must be running IPv6. An address in IPv4 looks like `111.222.333.444`
+You also can use an IP address in this parameter. If the IP address is in IPv6 format, the target computer must be running IPv6. An address in IPv4 looks like `123.123.123.123`
 
 An IP address in IPv6 format looks like `2010:836B:4179::836B:4179`
 


### PR DESCRIPTION
IPv4 address should be arranged between 0-255, 333 and 444 are invalid.