### PR TITLE
Update readback-data-using-heaps.md

### DIFF
--- a/desktop-src/direct3d12/readback-data-using-heaps.md
+++ b/desktop-src/direct3d12/readback-data-using-heaps.md
@@ -11,8 +11,8 @@ ms.date: 12/17/2018
 
 To read back data from the GPU (for example, to capture a screen shot), you use a readback heap. This technique is related to [Uploading texture data via a buffer](upload-and-readback-of-texture-data.md), with a few differences.
 
-- To read back data, you create a heap with the **D3D12_HEAP_TYPE** set to [D3D12_HEAP_TYPE_READBACK](/windows/desktop/api/d3d12/ne-d3d12-d3d12_heap_type), instead of D3D12_HEAP_TYPE_UPLOAD.
-- The resource on the read-back heap must always be a ``D3D12_RESOURCE_DIMENSION_BUFFER``.
+- To read back data, you create a heap with the **D3D12_HEAP_TYPE** set to [D3D12_HEAP_TYPE_READBACK](/windows/desktop/api/d3d12/ne-d3d12-d3d12_heap_type), instead of **D3D12_HEAP_TYPE_UPLOAD**.
+- The resource on the read-back heap must always be a **D3D12_RESOURCE_DIMENSION_BUFFER**.
 - You use a fence to detect when the GPU completes processing a frame (when it is done writing data into your output buffer). This is important, because the [**ID3D12Resource::Map**](/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-map) method doesn't synchronize with the GPU (conversely, the Direct3D 11 equivalent *does* synchronize). Direct3D 12 **Map** calls behave as if you called the Direct3D 11 equivalent with the NO_OVERWRITE flag.
 - After the data is ready (including any necessary resource barrier), call [**ID3D12Resource::Map**](/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-map) to make the readback data visible to the CPU.
 
@@ -89,7 +89,7 @@ readbackBuffer->Unmap
 );
 ```
 
-For a full implementation of a 'screenshot' routine which reads the render target texture and writes it to disk as a file, see *DirectX Tool Kit for DX12*'s [ScreenGrab](https://github.com/microsoft/DirectXTK12/blob/master/Src/ScreenGrab.cpp).
+For a full implementation of a screenshot routine that reads the render target texture, and writes it to disk as a file, see *DirectX Tool Kit for DX12*'s [ScreenGrab](https://github.com/microsoft/DirectXTK12/blob/master/Src/ScreenGrab.cpp).
 
 ## Related topics
 

--- a/desktop-src/direct3d12/readback-data-using-heaps.md
+++ b/desktop-src/direct3d12/readback-data-using-heaps.md
@@ -12,6 +12,7 @@ ms.date: 12/17/2018
 To read back data from the GPU (for example, to capture a screen shot), you use a readback heap. This technique is related to [Uploading texture data via a buffer](upload-and-readback-of-texture-data.md), with a few differences.
 
 - To read back data, you create a heap with the **D3D12_HEAP_TYPE** set to [D3D12_HEAP_TYPE_READBACK](/windows/desktop/api/d3d12/ne-d3d12-d3d12_heap_type), instead of D3D12_HEAP_TYPE_UPLOAD.
+- The resource on the read-back heap must always be a ``D3D12_RESOURCE_DIMENSION_BUFFER``.
 - You use a fence to detect when the GPU completes processing a frame (when it is done writing data into your output buffer). This is important, because the [**ID3D12Resource::Map**](/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-map) method doesn't synchronize with the GPU (conversely, the Direct3D 11 equivalent *does* synchronize). Direct3D 12 **Map** calls behave as if you called the Direct3D 11 equivalent with the NO_OVERWRITE flag.
 - After the data is ready (including any necessary resource barrier), call [**ID3D12Resource::Map**](/windows/desktop/api/d3d12/nf-d3d12-id3d12resource-map) to make the readback data visible to the CPU.
 
@@ -87,6 +88,8 @@ readbackBuffer->Unmap
     &emptyRange
 );
 ```
+
+For a full implementation of a 'screenshot' routine which reads the render target texture and writes it to disk as a file, see *DirectX Tool Kit for DX12*'s [ScreenGrab](https://github.com/microsoft/DirectXTK12/blob/master/Src/ScreenGrab.cpp).
 
 ## Related topics
 


### PR DESCRIPTION
The example of buffer to buffer here is simple, but it hides an important detail that you still need a 1D buffer when reading back other resource types.