### PR TITLE
Update predication-queries.md

### DIFF
--- a/desktop-src/direct3d12/predication-queries.md
+++ b/desktop-src/direct3d12/predication-queries.md
@@ -154,10 +154,12 @@ In the **LoadAssets** method a buffer needs to be created to store the results o
 
 ``` syntax
  // Create the query result buffer.
+              CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+              auto queryBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(8);
               ThrowIfFailed(m_device->CreateCommittedResource(
-                     &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+                     &heapProps,
                      D3D12_HEAP_FLAG_NONE,
-                     &CD3DX12_RESOURCE_DESC::Buffer(8),
+                     &queryBufferDesc,
                      D3D12_RESOURCE_STATE_GENERIC_READ,
                      nullptr,
                      IID_PPV_ARGS(&m_queryResult)


### PR DESCRIPTION
The pattern of ``&CD3DX*`` is non-conforming C++. With Warning Level 4 in Visual C++, it emits warning C4238. clang/LLVM emits ``-Waddress-of-temporary``. With VS 2019 (16.8) or later, building with ``/permissive-`` results in an ERROR of C2102.

This is being fixed in the official samples.