### PR TITLE
Update dx-graphics-hlsl-to-load.md

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-load.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-load.md
@@ -28,7 +28,7 @@ Reads texel data without any filtering or sampling.
 </tbody>
 </table>
 
-typeX denotes that there are four possible types: int, int2, int3 or int4.
+typeX denotes that there are four possible types: **int**, **int2**, **int3** or **int4**.
 
  
 

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-load.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-load.md
@@ -20,15 +20,15 @@ Reads texel data without any filtering or sampling.
 <table>
 <tbody>
 <tr class="odd">
-<td>ret Object.Load(<dl> int Location,<br />
-[int SampleIndex, ]<br />
-[int Offset ]<br />
+<td>ret Object.Load(<dl> typeX Location,<br />
+[typeX SampleIndex, ]<br />
+[typeX Offset ]<br />
 </dl>);</td>
 </tr>
 </tbody>
 </table>
 
-
+typeX denotes that there are four possible types: int, int2, int3 or int4.
 
  
 


### PR DESCRIPTION
Misleading description of input parameters.
For example in the description of the function "GetDimensions"
we have a template type of an input variable, that can be changed amid parameters.
https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-to-getdimensions
But in the current function ( I am speaking about "Load") is said, that **each** parameter has type int.
And when you scroll down the page, you can observe, that objects of different types also accept
different types of parameters