### PR TITLE
Update indirect-drawing-and-gpu-culling-.md

### DIFF
--- a/desktop-src/direct3d12/indirect-drawing-and-gpu-culling-.md
+++ b/desktop-src/direct3d12/indirect-drawing-and-gpu-culling-.md
@@ -305,8 +305,9 @@ for (UINT frame = 0; frame < FrameCount; frame++)
        // Allocate a buffer large enough to hold all of the indirect commands
        // for a single frame as well as a UAV counter.
        commandBufferDesc = CD3DX12_RESOURCE_DESC::Buffer(CommandBufferSizePerFrame + sizeof(UINT), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+       CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
        ThrowIfFailed(m_device->CreateCommittedResource(
-             &CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+             &heapProps,
              D3D12_HEAP_FLAG_NONE,
              &commandBufferDesc,
              D3D12_RESOURCE_STATE_COPY_DEST,


### PR DESCRIPTION
The pattern of ``&CD3DX*`` is non-conforming C++. With Warning Level 4 in Visual C++, it emits warning C4238. clang/LLVM emits ``-Waddress-of-temporary``. With VS 2019 (16.8) or later, building with ``/permissive-`` results in an ERROR of C2102.

This is being fixed in the official samples.