### PR TITLE
Update notes-on-example-code.md

### DIFF
--- a/desktop-src/direct3d12/notes-on-example-code.md
+++ b/desktop-src/direct3d12/notes-on-example-code.md
@@ -58,7 +58,8 @@ m_commandList->RSSetViewports(1, &m_viewport);
 m_commandList->RSSetScissorRects(1, &m_scissorRect);
 
 // Indicate that the back buffer will be used as a render target.
-m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET));
+auto barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+m_commandList->ResourceBarrier(1, &barrier);
 
 CD3DX12_CPU_DESCRIPTOR_HANDLE rtvHandle(m_rtvHeap->GetCPUDescriptorHandleForHeapStart(), m_frameIndex, m_rtvDescriptorSize);
 m_commandList->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
@@ -71,8 +72,8 @@ m_commandList->IASetVertexBuffers(0, 1, &m_vertexBufferView);
 m_commandList->DrawInstanced(3, 1, 0, 0);
 
 // Indicate that the back buffer will now be used to present.
-m_commandList->ResourceBarrier(1, &CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT));
-
+m_commandList->ResourceBarrier(1, &barrier);
+barrier = CD3DX12_RESOURCE_BARRIER::Transition(m_renderTargets[m_frameIndex].Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
 ThrowIfFailed(m_commandList->Close());
 ```
 


### PR DESCRIPTION
The pattern of ``&CD3DX*`` is non-conforming C++. With Warning Level 4 in Visual C++, it emits warning C4238. clang/LLVM emits ``-Waddress-of-temporary``. With VS 2019 (16.8) or later, building with ``/permissive-`` results in an ERROR of C2102.

This is being fixed in the official samples.