### PR TITLE
Update d3dxboxboundprobe.md

### DIFF
--- a/desktop-src/direct3d9/d3dxboxboundprobe.md
+++ b/desktop-src/direct3d9/d3dxboxboundprobe.md
@@ -1,14 +1,14 @@
 ---
 Description: Determines whether a ray intersects the volume of a box's bounding box.
 ms.assetid: 45ff8540-ed5c-4f54-b3b7-3385087a6863
-title: D3DXboxBoundProbe function (D3DX9Mesh.h)
+title: D3DXBoxBoundProbe function (D3DX9Mesh.h)
 ms.topic: reference
 ms.date: 05/31/2018
 topic_type: 
 - APIRef
 - kbSyntax
 api_name: 
-- D3DXboxBoundProbe
+- D3DXBoxBoundProbe
 api_type: 
 - LibDef
 api_location: 
@@ -16,7 +16,7 @@ api_location:
 - d3dx9.dll
 ---
 
-# D3DXboxBoundProbe function
+# D3DXBoxBoundProbe function
 
 Determines whether a ray intersects the volume of a box's bounding box.
 
@@ -24,7 +24,7 @@ Determines whether a ray intersects the volume of a box's bounding box.
 
 
 ```C++
-BOOL D3DXboxBoundProbe(
+BOOL D3DXBoxBoundProbe(
   _In_ const D3DXVECTOR3 *pMin,
   _In_ const D3DXVECTOR3 *pMax,
   _In_ const D3DXVECTOR3 *pRayPosition,


### PR DESCRIPTION
Correct casing. This is a D3DX function that operates on "Box" not a "D3D" function for "Xbox"!