### PR TITLE
Fixing link in ICcgDomainAuthCredentials

### DIFF
--- a/desktop-src/SecAuthN/iccgdomainauthcredentials.md
+++ b/desktop-src/SecAuthN/iccgdomainauthcredentials.md
@@ -32,7 +32,7 @@ The **ICcgDomainAuthCredentials** interface has these methods.
 
 | Method                                           | Description                                                                                               |
 |:-------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
-| [**GetPasswordCredentials**](getpasswordcredentials.md)               | Returns credentials to authenticate a non-domain joined container with Active Directory.<br/>                                                              |
+| [**GetPasswordCredentials**](iccgdomainauthcredentials-getpasswordcredentials.md)               | Returns credentials to authenticate a non-domain joined container with Active Directory.<br/>                                                              |
 
 
 


### PR DESCRIPTION
GetPasswordCredentials link points to a page that does not exist. Fixing link to the correct page.