### PR TITLE
Revert "Update creating-a-child-process-with-redirected-input-and-output.md"

### DIFF
--- a/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
+++ b/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
@@ -56,8 +56,7 @@ int _tmain(int argc, TCHAR *argv[])
 
 // Ensure the read handle to the pipe for STDOUT is not inherited.
 
-   if ( ! SetHandleInformation(g_hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT,
-                               HANDLE_FLAG_INHERIT) )
+   if ( ! SetHandleInformation(g_hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0) )
       ErrorExit(TEXT("Stdout SetHandleInformation")); 
 
 // Create a pipe for the child process's STDIN. 
@@ -67,8 +66,7 @@ int _tmain(int argc, TCHAR *argv[])
 
 // Ensure the write handle to the pipe for STDIN is not inherited. 
  
-   if ( ! SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT,
-                               HANDLE_FLAG_INHERIT) )
+   if ( ! SetHandleInformation(g_hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0) )
       ErrorExit(TEXT("Stdin SetHandleInformation")); 
  
 // Create the child process. 


### PR DESCRIPTION
Reverts MicrosoftDocs/win32#694

I was wrong about this, I'm sorry.  It seemed to fix my problem, but I got the In/Out Rd/Wr messed up.  This is disabling inheritance on the local side of the pipe, which is exactly what you want to do.  So this should be reverted.