### PR TITLE
Update symbolic-link-programming-considerations.md

### DIFF
--- a/desktop-src/FileIO/symbolic-link-programming-considerations.md
+++ b/desktop-src/FileIO/symbolic-link-programming-considerations.md
@@ -14,7 +14,9 @@ Keep the following programming considerations in mind when working with symbolic
 -   When creating a symbolic link, the operating system does not check to see if the target exists.
 -   If an application tries to open a non-existent target, **ERROR\_FILE\_NOT\_FOUND** is returned.
 -   Symbolic links are reparse points. For more information, see [Determining Whether a Directory Is a Mounted Folder](determining-whether-a-directory-is-a-volume-mount-point.md).
--   There is a maximum of 31 reparse points (and therefore symbolic links) allowed in a particular path.
+-   There is a maximum of 63 reparse points (and therefore symbolic links) allowed in a particular path.
+
+    **Windows Server 2003 and Windows XP:** There is a limit of 31 reparse points on any given path.
 
 ## Related topics
 


### PR DESCRIPTION
Corrected reparse point limitation from 31 to 63 and added Win2003/XP limit of 31.  ref: https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/FileIO/reparse-points.md