### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Our documentation is written in Markdown, a lightweight text style syntax. If yo
 
 ### Editing a file
 
-You can find guidance on using this repo in the [Windows Authoring Guide](https://review.docs.microsoft.com/windows-authoring-guide/?branch=master). Documentation on upcoming features must be contributed via the private repository only. You **must** make sure you are contributing to the correct branch. 
+You can find guidance on using this repo in the [Windows Authoring Guide](???). Documentation on upcoming features must be contributed via the private repository only. You **must** make sure you are contributing to the correct branch. 
 
 You may clone this repository locally and make edits on your own machine, or you can use the GitHub interface to make edits. Cloning is a better option for large changes. In-browser editing works well for small fixes. Make sure you do so in a new personal branch. When you are ready to submit your edits, create a PR here on the GitHub page.
 
@@ -16,6 +16,6 @@ You may clone this repository locally and make edits on your own machine, or you
 
 When creating a pull request in the internal repo, make sure you're merging your personal branch into the branch it was created from.
 
-After you submit your pull request, it is evaluated against a [content quality checklist](https://review.docs.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=master) to ensure it meets our basic standards. If it passes, it is assigned to a member of the UWP documentation team for further review. If it fails, you'll be told what changes to make.
+After you submit your pull request, it is evaluated against a [content quality checklist](???) to ensure it meets our basic standards. If it passes, it is assigned to a member of the UWP documentation team for further review. If it fails, you'll be told what changes to make.
 
 The assigned reviewer(s) may approve or reject the PR, or work with you to make further changes. Reviewers will not merge the PR until you have approved it yourself.


### PR DESCRIPTION
Hi,

My edit is not actually to remove these entries, however I could not find a way to create an issue against this repository. Apologies in advance if this is not an appropriate way to provide feedback.

As a non-microsoft person, I cannot access either of these links:

https://review.docs.microsoft.com/windows-authoring-guide/?branch=master
https://review.docs.microsoft.com/help/contribute/contribute-how-to-write-pull-request-quality-criteria?branch=master

I get a message saying:

> We are sorry, the page is forbidden.
> You do not have permission with this credential, please sign out to try with others and go back again.

Could the contents be made publicly available? Or at least the relevant parts added inline? If not, perhaps the links should be removed since contributors are likely to want to follow any rules/guidelines and them being unavailable might deter people from bothering.

Thanks.