### PR TITLE
Clarify the "2" value for ISO compatibility

### DIFF
--- a/desktop-src/Intl/locale-ifirstweekofyear.md
+++ b/desktop-src/Intl/locale-ifirstweekofyear.md
@@ -16,7 +16,9 @@ The first week of the year.
 |-------|----------------------------------------------------------------------------------------------------------------------------------|
 | 0     | Week containing 1/1 is the first week of the year. Note that this can be a single day, if 1/1 falls on the last day of the week. |
 | 1     | First full week following 1/1 is the first week of the year.                                                                     |
-| 2     | First week containing at least four days is the first week of the year.                                                          |
+| 2     | First week containing at least four days is the first week of the year. ISO 8601 compatible.                                     |
+
+When LOCALE_IFIRSTWEEKOFYEAR is 2, LOCALE_IFIRSTDAYOFWEEK is 0 (Monday), and LOCALE_ICALENDARTYPE is Gregorian, then the first week follows the ISO 8601 definition of the first week being the week with the first Thursday of the year.
 
 
 

--- a/desktop-src/Intl/locale-ifirstweekofyear.md
+++ b/desktop-src/Intl/locale-ifirstweekofyear.md
@@ -3,7 +3,7 @@ description: LOCALE\_IFIRSTWEEKOFYEAR
 ms.assetid: 866a28b7-e0b8-4b99-96df-345791a24833
 title: LOCALE_IFIRSTWEEKOFYEAR
 ms.topic: article
-ms.date: 05/31/2018
+ms.date: 03/04/2020
 ---
 
 # LOCALE\_IFIRSTWEEKOFYEAR
@@ -18,8 +18,7 @@ The first week of the year.
 | 1     | First full week following 1/1 is the first week of the year.                                                                     |
 | 2     | First week containing at least four days is the first week of the year. ISO 8601 compatible.                                     |
 
-When LOCALE_IFIRSTWEEKOFYEAR is 2, LOCALE_IFIRSTDAYOFWEEK is 0 (Monday), and LOCALE_ICALENDARTYPE is Gregorian, then the first week follows the ISO 8601 definition of the first week being the week with the first Thursday of the year.
-
+If LOCALE_IFIRSTWEEKOFYEAR is 2, LOCALE_IFIRSTDAYOFWEEK is 0 (Monday), and LOCALE_ICALENDARTYPE is Gregorian, then the first week follows the ISO 8601 definition where the first week is the week with the first Thursday of the Gregorian year in it.
 
 
  


### PR DESCRIPTION
Clarify that the "2" value for LOCALE_IFIRSTWEEKOFYEAR provides ISO 8601 compatibility (providing that the calendar is Gregorian and the first day of week is Monday).