### PR TITLE
Fix ORSetValue prototype

### DIFF
--- a/desktop-src/DevNotes/orsetvalue.md
+++ b/desktop-src/DevNotes/orsetvalue.md
@@ -27,7 +27,7 @@ DWORD ORSetValue(
   _In_     ORHKEY Handle,
   _In_opt_ PCWSTR lpValueName,
   _In_     DWORD  dwType,
-  _In_opt_ BYTE   *lpData,
+  _In_opt_ const BYTE *lpData,
   _In_     DWORD  cbData
 );
 ```

--- a/desktop-src/DevNotes/orsetvalue.md
+++ b/desktop-src/DevNotes/orsetvalue.md
@@ -27,7 +27,7 @@ DWORD ORSetValue(
   _In_     ORHKEY Handle,
   _In_opt_ PCWSTR lpValueName,
   _In_     DWORD  dwType,
-  _In_opt_ BYTE   lpData,
+  _In_opt_ BYTE   *lpData,
   _In_     DWORD  cbData
 );
 ```


### PR DESCRIPTION
Like RegSetValueExW, `lpData` must be a BYTE pointer, not just a single BYTE.