### PR TITLE
Note maximum number of tags that can be stored w/ System.Keywords

### DIFF
--- a/desktop-src/properties/props-system-keywords.md
+++ b/desktop-src/properties/props-system-keywords.md
@@ -27,7 +27,7 @@ propertyDescription
 
 ## Remarks
 
-PKEY values are defined in Propkey.h.
+PKEY values are defined in Propkey.h.  A maximum of 20 keywords can be stored.
 
 ## Related topics
 

--- a/desktop-src/properties/props-system-keywords.md
+++ b/desktop-src/properties/props-system-keywords.md
@@ -27,7 +27,7 @@ propertyDescription
 
 ## Remarks
 
-PKEY values are defined in Propkey.h.  A maximum of 20 keywords can be stored.
+PKEY values are defined in Propkey.h. A maximum of 20 keywords can be stored.
 
 ## Related topics
 


### PR DESCRIPTION
See [Maximum vector size for properties in Windows Search](https://stackoverflow.com/questions/52729984) for a hard limit on tags that can be stored.