### PR TITLE
Add link from 'Raytracing HLSL Reference' page to State Objects page

### DIFF
--- a/desktop-src/direct3d12/direct3d-12-raytracing-hlsl-reference.md
+++ b/desktop-src/direct3d12/direct3d-12-raytracing-hlsl-reference.md
@@ -24,7 +24,7 @@ This section provides information on the HLSL constructs that support the Direct
 | [Direct3D 12 Raytracing HLSL Structures](direct3d-12-raytracing-hlsl-structures.md)<br/>     | Describes the HLSL structures that support the Direct3D 12 raytracing pipeline. <br/>                          |
 
 
-
+Additionally, see the page [State Objects](https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-state-object) for information about the syntax used for defining Direct3D 12 raytracing state objects in HLSL.
  
 
 ## Related topics

--- a/desktop-src/direct3d12/direct3d-12-raytracing-hlsl-reference.md
+++ b/desktop-src/direct3d12/direct3d-12-raytracing-hlsl-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Direct3D 12 Raytracing HLSL Reference
+title: Direct3D 12 raytracing HLSL reference
 description: This section provides information on the HLSL constructs that support the Direct3D 12 raytracing pipeline.
 ms.assetid: 
 ms.localizationpriority: low
@@ -7,38 +7,22 @@ ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# Raytracing HLSL Reference
+# Raytracing HLSL reference
 
 This section provides information on the HLSL constructs that support the Direct3D 12 raytracing pipeline.
 
 ## In this section
 
+| Topic | Description |
+|-|-|
+| [Direct3D 12 raytracing HLSL enumerations](direct3d-12-raytracing-hlsl-enumerations.md) | Describes the HLSL enumerations that support the Direct3D 12 raytracing pipeline.  |
+| [Direct3D 12 raytracing HLSL intrinsics](direct3d-12-raytracing-hlsl-intrinsics.md) | Describes the HLSL instrinsics that support the Direct3D 12 raytracing pipeline. |
+| [Direct3D 12 raytracing HLSL resource types](direct3d-12-raytracing-hlsl-resource-types.md) | Describes the HLSL resource types that support the Direct3D 12 raytracing pipeline. |
+| [Direct3D 12 raytracing HLSL shaders](direct3d-12-raytracing-hlsl-shaders.md) | Describes the HLSL shaders that support the Direct3D 12 raytracing pipeline. |
+| [Direct3D 12 raytracing HLSL structures](direct3d-12-raytracing-hlsl-structures.md) | Describes the HLSL structures that support the Direct3D 12 raytracing pipeline. |
 
-
-| Topic                                                        | Description                                                                            |
-|--------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| [Direct3D 12 Raytracing HLSL Enumerations](direct3d-12-raytracing-hlsl-enumerations.md)<br/>     | Describes the HLSL enumerations that support the Direct3D 12 raytracing pipeline. <br/>                          |
-| [Direct3D 12 Raytracing HLSL Intrinsics](direct3d-12-raytracing-hlsl-intrinsics.md)<br/>     | Describes the HLSL instrinsics that support the Direct3D 12 raytracing pipeline. <br/>                          |
-| [Direct3D 12 Raytracing HLSL Resource Types](direct3d-12-raytracing-hlsl-resource-types.md)<br/>     | Describes the HLSL resource types that support the Direct3D 12 raytracing pipeline. <br/>                          |
-| [Direct3D 12 Raytracing HLSL Shaders](direct3d-12-raytracing-hlsl-shaders.md)<br/>     | Describes the HLSL shaders that support the Direct3D 12 raytracing pipeline. <br/>                          |
-| [Direct3D 12 Raytracing HLSL Structures](direct3d-12-raytracing-hlsl-structures.md)<br/>     | Describes the HLSL structures that support the Direct3D 12 raytracing pipeline. <br/>                          |
-
-
-Additionally, see the page [State Objects](https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-state-object) for information about the syntax used for defining Direct3D 12 raytracing state objects in HLSL.
- 
+Additionally, see the topic [State objects](/windows/win32/direct3dhlsl/dx-graphics-hlsl-state-object) for information about the syntax used for defining Direct3D 12 raytracing state objects in HLSL.
 
 ## Related topics
 
-<dl> <dt>
-
-[Direct3D 12 Reference](direct3d-12-reference.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
-
+* [Direct3D 12 reference](direct3d-12-reference.md)


### PR DESCRIPTION
There's this hub page linking to all the places you can find DXR HLSL syntax. 
In the interest of completeness, hub page should also link to 'State objects', since you can also specify DXR stuff through those.
It's formatted as a link rather than a row in the table because the linked page is not technically part of this section.