### PR TITLE
Fix documentation for HLSL Gather*

### DIFF
--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gather.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gather.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::Gather(S,float,int) function
-description: Samples a texture and returns all four components.
+description: Returns the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 5d196c1c-8cc9-4add-9d33-654294314ee2
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::Gather(S,float,int) function
 
-Samples a texture and returns all four components.
+Returns the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gatheralpha.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherAlpha(S,float,int) function
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 4c980e06-d768-479e-bee3-1b2541c23038
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherAlpha(S,float,int) function
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gatherblue.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gatherblue.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherBlue(S,float,int) function
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 6d753ef2-2818-4990-81df-52dda044d21d
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherBlue(S,float,int) function
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmp.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmp.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmp(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 ms.assetid: 1084bcb3-2834-400a-98ff-4e3182f63f20
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmp(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpalpha.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpalpha.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpAlpha(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 ms.assetid: 6fa60604-1eac-405d-bffa-3055569b7a09
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpAlpha(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpblue.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpblue.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpBlue(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 ms.assetid: d8e03c55-18f1-4598-a700-9ba3a680d78a
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpBlue(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpgreen.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpgreen.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpGreen(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 ms.assetid: 5a11ce0c-56b2-460a-95d7-15688dd158ff
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpGreen(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpred.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathercmpred.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpRed(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 ms.assetid: bd5fdd3b-c1b0-4cb0-aec5-9fe020420e6c
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpRed(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gathergreen.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gathergreen.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherGreen(S,float,int) function
-description: Samples a texture and returns the green component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 ms.assetid: 97e1fb52-75f4-4e73-93f1-98b7a5925efc
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherGreen(S,float,int) function
 
-Samples a texture and returns the green component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d-gatherred.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d-gatherred.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherRed(S,float,int) function
-description: Samples a texture and returns the red component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 ms.assetid: 6d2d1556-d52f-4625-93ca-34da399f9a8b
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherRed(S,float,int) function
 
-Samples a texture and returns the red component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2d.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2d.md
@@ -21,28 +21,28 @@ Texture2D type ([as it exists in Shader Model 4](dx-graphics-hlsl-to-type.md)) p
 
 
 
-| Method                                                                  | Description                                                                                |
-|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| [**Gather**](texture2d-gather.md)                                      | Samples a texture and returns all components.                                              |
-| [**GatherRed**](texture2d-gatherred.md)                                | Samples a texture and returns the red component.                                           |
-| [**GatherGreen**](texture2d-gathergreen.md)                            | Samples a texture and returns the green component.                                         |
-| [**GatherBlue**](texture2d-gatherblue.md)                              | Samples a texture and returns the blue component.                                          |
-| [**GatherAlpha**](texture2d-gatheralpha.md)                            | Samples a texture and returns the alpha component.                                         |
-| [**GatherCmp**](texture2d-gathercmp.md)                                | Samples and compares a texture and returns all components.                                 |
-| [**GatherCmpRed**](texture2d-gathercmpred.md)                          | Samples and compares a texture and returns the red component.                              |
-| [**GatherCmpGreen**](texture2d-gathercmpgreen.md)                      | Samples and compares a texture and returns the green component.                            |
-| [**GatherCmpBlue**](texture2d-gathercmpblue.md)                        | Samples and compares a texture and returns the blue component.                             |
-| [**GatherCmpAlpha**](texture2d-gathercmpalpha.md)                      | Samples and compares a texture and returns the alpha component.                            |
-| [**GetDimensions**](sm5-object-texture2d-getdimensions.md)             | Gets the resource dimensions.                                                              |
-| [**Load**](texture2d-load.md)                                          | Reads texture data.                                                                        |
-| [**mips.Operator\[\]\[\]**](sm5-object-texture2d-mipsoperatorindex.md) | Gets a read-only resource variable.                                                        |
-| [**Operator\[\]**](sm5-object-texture2d-operatorindex.md)              | Gets a read-only resource variable.                                                        |
-| [**Sample**](texture-sample-overload.md)                               | Samples a texture.                                                                         |
-| [**SampleBias**](texture2d-samplebias.md)                              | Samples a texture, after applying the bias value to the mipmap level.                      |
-| [**SampleCmp**](texture2d-samplecmp.md)                                | Samples a texture, using a comparison value to reject samples.                             |
-| [**SampleCmpLevelZero**](texture2d-samplecmplevelzero.md)              | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.       |
-| [**SampleGrad**](texture2d-samplegrad.md)                              | Samples a texture using a gradient to influence the way the sample location is calculated. |
-| [**SampleLevel**](texture2d-samplelevel.md)                            | Samples a texture on the specified mipmap level.                                           |
+| Method                                                                 | Description                                                                                                                                        |
+|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**Gather**](texture2d-gather.md)                                      | Returns the four texel values that would be used in a bi-linear filtering operation.                                                                |
+| [**GatherRed**](texture2d-gatherred.md)                                | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.                                          |
+| [**GatherGreen**](texture2d-gathergreen.md)                            | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.                                        |
+| [**GatherBlue**](texture2d-gatherblue.md)                              | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.                                         |
+| [**GatherAlpha**](texture2d-gatheralpha.md)                            | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.                                        |
+| [**GatherCmp**](texture2d-gathercmp.md)                                | For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.                      |
+| [**GatherCmpRed**](texture2d-gathercmpred.md)                          | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.   |
+| [**GatherCmpGreen**](texture2d-gathercmpgreen.md)                      | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value. |
+| [**GatherCmpBlue**](texture2d-gathercmpblue.md)                        | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.  |
+| [**GatherCmpAlpha**](texture2d-gathercmpalpha.md)                      | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value. |
+| [**GetDimensions**](sm5-object-texture2d-getdimensions.md)             | Gets the resource dimensions.                                                                                                                       |
+| [**Load**](texture2d-load.md)                                          | Reads texture data.                                                                                                                                 |
+| [**mips.Operator\[\]\[\]**](sm5-object-texture2d-mipsoperatorindex.md) | Gets a read-only resource variable.                                                                                                                 |
+| [**Operator\[\]**](sm5-object-texture2d-operatorindex.md)              | Gets a read-only resource variable.                                                                                                                 |
+| [**Sample**](texture-sample-overload.md)                               | Samples a texture.                                                                                                                                  |
+| [**SampleBias**](texture2d-samplebias.md)                              | Samples a texture, after applying the bias value to the mipmap level.                                                                               |
+| [**SampleCmp**](texture2d-samplecmp.md)                                | Samples a texture, using a comparison value to reject samples.                                                                                      |
+| [**SampleCmpLevelZero**](texture2d-samplecmplevelzero.md)              | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.                                                                |
+| [**SampleGrad**](texture2d-samplegrad.md)                              | Samples a texture using a gradient to influence the way the sample location is calculated.                                                          |
+| [**SampleLevel**](texture2d-samplelevel.md)                            | Samples a texture on the specified mipmap level.                                                                                                    |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gather.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gather.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::Gather(S,float,int) function
-description: Samples a texture and returns all four components.
+description: Returns the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: b0355158-01c8-45a1-bb5d-29a8c43b1685
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::Gather(S,float,int) function
 
-Samples a texture and returns all four components.
+Returns the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatheralpha.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherAlpha(S,float,int) function
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: d7270277-53c1-4034-bf66-9a95bc1b51e4
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherAlpha(S,float,int) function
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatherblue.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatherblue.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherBlue(S,float,int) function
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: f81596b5-afd1-4baf-b6c0-ca4661a3ef22
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherBlue(S,float,int) function
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmp.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmp.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmp(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 ms.assetid: 7bb86448-cc73-4423-9ef4-149427cffc95
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmp(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpalpha.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpalpha.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpAlpha(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 ms.assetid: d5fc78eb-2378-4e63-a712-c6f4ef9fc729
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpAlpha(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpblue.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpblue.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpBlue(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 ms.assetid: 5fa23e27-368a-4c55-b6d6-33506c932a43
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpBlue(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpgreen.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpgreen.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpGreen(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 ms.assetid: baf14de9-5237-42a5-bffc-848e55cbc28f
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpGreen(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpred.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathercmpred.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpRed(S,float,float,int) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 ms.assetid: aa7fadf8-fe96-406a-9c93-9ae0c59ef087
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpRed(S,float,float,int) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathergreen.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gathergreen.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherGreen(S,float,int) function
-description: Samples a texture and returns the green component.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: bfe9ab9f-64f7-4a50-aa46-2ec6effebce2
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherGreen(S,float,int) function
 
-Samples a texture and returns the green component.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatherred.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray-gatherred.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherRed(S,float,int) function
-description: Samples a texture and returns the red component.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: cb9c21ef-87f4-4c32-b41a-9fc7478713a6
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherRed(S,float,int) function
 
-Samples a texture and returns the red component.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2darray.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2darray.md
@@ -21,28 +21,28 @@ Texture2DArray type ([as it exists in Shader Model 4](dx-graphics-hlsl-to-type.m
 
 
 
-| Method                                                                       | Description                                                                                |
-|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| [**Gather**](texture2darray-gather.md)                                      | Samples a texture and returns all components.                                              |
-| [**GatherRed**](texture2darray-gatherred.md)                                | Samples a texture and returns the red component.                                           |
-| [**GatherGreen**](texture2darray-gathergreen.md)                            | Samples a texture and returns the green component.                                         |
-| [**GatherBlue**](texture2darray-gatherblue.md)                              | Samples a texture and returns the blue component.                                          |
-| [**GatherAlpha**](texture2darray-gatheralpha.md)                            | Samples a texture and returns the alpha component.                                         |
-| [**GatherCmp**](texture2darray-gathercmp.md)                                | Samples and compares a texture and returns all components.                                 |
-| [**GatherCmpRed**](texture2darray-gathercmpred.md)                          | Samples and compares a texture and returns the red component.                              |
-| [**GatherCmpGreen**](texture2darray-gathercmpgreen.md)                      | Samples and compares a texture and returns the green component.                            |
-| [**GatherCmpBlue**](texture2darray-gathercmpblue.md)                        | Samples and compares a texture and returns the blue component.                             |
-| [**GatherCmpAlpha**](texture2darray-gathercmpalpha.md)                      | Samples and compares a texture and returns the alpha component.                            |
-| [**GetDimensions**](sm5-object-texture2darray-getdimensions.md)             | Gets the resource dimensions.                                                              |
-| [**Load**](texture2darray-load.md)                                          | Reads texture data.                                                                        |
-| [**mips.Operator\[\]\[\]**](sm5-object-texture2darray-mipsoperatorindex.md) | Gets a read-only resource variable.                                                        |
-| [**Operator\[\]**](sm5-object-texture2darray-operatorindex.md)              | Gets a read-only resource variable.                                                        |
-| [**Sample**](texture2darray-sample.md)                                      | Samples a texture.                                                                         |
-| [**SampleBias**](texture2darray-samplebias.md)                              | Samples a texture, after applying the bias value to the mipmap level.                      |
-| [**SampleCmp**](texture2darray-samplecmp.md)                                | Samples a texture, using a comparison value to reject samples.                             |
-| [**SampleCmpLevelZero**](texture2darray-samplecmplevelzero.md)              | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.       |
-| [**SampleGrad**](texture2darray-samplegrad.md)                              | Samples a texture using a gradient to influence the way the sample location is calculated. |
-| [**SampleLevel**](texture2darray-samplelevel.md)                            | Samples a texture on the specified mipmap level.                                           |
+| Method                                                                      | Description                                                                                                                                         |
+|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**Gather**](texture2darray-gather.md)                                      | Returns the four texel values that would be used in a bi-linear filtering operation.                                                                |
+| [**GatherRed**](texture2darray-gatherred.md)                                | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.                                          |
+| [**GatherGreen**](texture2darray-gathergreen.md)                            | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.                                        |
+| [**GatherBlue**](texture2darray-gatherblue.md)                              | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.                                         |
+| [**GatherAlpha**](texture2darray-gatheralpha.md)                            | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.                                        |
+| [**GatherCmp**](texture2darray-gathercmp.md)                                | For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.                      |
+| [**GatherCmpRed**](texture2darray-gathercmpred.md)                          | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.   |
+| [**GatherCmpGreen**](texture2darray-gathercmpgreen.md)                      | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value. |
+| [**GatherCmpBlue**](texture2darray-gathercmpblue.md)                        | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.  |
+| [**GatherCmpAlpha**](texture2darray-gathercmpalpha.md)                      | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value. |
+| [**GetDimensions**](sm5-object-texture2darray-getdimensions.md)             | Gets the resource dimensions.                                                                                                                       |
+| [**Load**](texture2darray-load.md)                                          | Reads texture data.                                                                                                                                 |
+| [**mips.Operator\[\]\[\]**](sm5-object-texture2darray-mipsoperatorindex.md) | Gets a read-only resource variable.                                                                                                                 |
+| [**Operator\[\]**](sm5-object-texture2darray-operatorindex.md)              | Gets a read-only resource variable.                                                                                                                 |
+| [**Sample**](texture2darray-sample.md)                                      | Samples a texture.                                                                                                                                  |
+| [**SampleBias**](texture2darray-samplebias.md)                              | Samples a texture, after applying the bias value to the mipmap level.                                                                               |
+| [**SampleCmp**](texture2darray-samplecmp.md)                                | Samples a texture, using a comparison value to reject samples.                                                                                      |
+| [**SampleCmpLevelZero**](texture2darray-samplecmplevelzero.md)              | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.                                                                |
+| [**SampleGrad**](texture2darray-samplegrad.md)                              | Samples a texture using a gradient to influence the way the sample location is calculated.                                                          |
+| [**SampleLevel**](texture2darray-samplelevel.md)                            | Samples a texture on the specified mipmap level.                                                                                                    |
 
 
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2dmsarray-getsampleposition.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2dmsarray-getsampleposition.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DMSArray::GetSamplePosition function
-description: Samples a texture and returns all four components.
+description: Gets the position of the specified sample.
 ms.assetid: e04717be-58b0-4242-87dd-d769834ae1c2
 keywords:
 - GetSamplePosition function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DMSArray::GetSamplePosition function
 
-Samples a texture and returns all four components.
+Gets the position of the specified sample.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/sm5-object-texture2dmsarray.md
+++ b/desktop-src/direct3dhlsl/sm5-object-texture2dmsarray.md
@@ -23,10 +23,10 @@ Texture2DMSArray type (as it exists in Shader Model 4) plus resource variables.
 
 | Method                                                                             | Description                                        |
 |------------------------------------------------------------------------------------|----------------------------------------------------|
-| [**GetDimensions**](sm5-object-texture2dmsarray-getdimensions.md)                 | Gets the resource dimensions.                      |
-| [**GetSamplePosition**](sm5-object-texture2dmsarray-getsampleposition.md)         | Samples a texture and returns all four components. |
-| [**Load**](texture2dmsarray-load.md)                                              | Gets one value.                                    |
-| [**sample.Operator\[\]\[\]**](sm5-object-texture2dmsarray-sampleoperatorindex.md) | Gets a read-only resource variable.                |
+| [**GetDimensions**](sm5-object-texture2dmsarray-getdimensions.md)                  | Gets the resource dimensions.                      |
+| [**GetSamplePosition**](sm5-object-texture2dmsarray-getsampleposition.md)          | Gets the position of the specified sample.         |
+| [**Load**](texture2dmsarray-load.md)                                               | Gets one value.                                    |
+| [**sample.Operator\[\]\[\]**](sm5-object-texture2dmsarray-sampleoperatorindex.md)  | Gets a read-only resource variable.                |
 
 
 

--- a/desktop-src/direct3dhlsl/t2array-gatherblue-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2array-gatherblue-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: GatherBlue(S,float,int2,int2,int2,int2) function (HLSL reference)
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 0DDD3235-4F12-4D74-975A-F70A271C1FC0
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # GatherBlue(S,float,int2,int2,int2,int2) function (HLSL reference)
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gather-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gather-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::Gather(S,float,int,uint) function
-description: Samples a texture and returns all four components along with status about the operation.
+description: Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 3B8733B0-BB80-4414-8BDD-033116D7EFE0
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::Gather(S,float,int,uint) function
 
-Samples a texture and returns all four components along with status about the operation.
+Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherAlpha(S,float,int,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: A05E9286-2DCA-4A85-A337-0E010EF98D7F
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherAlpha(S,float,int,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherAlpha(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 925A5085-33CB-4DFC-B4E3-1ADA5892C13A
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherAlpha(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherAlpha(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: C088BC6A-397C-4702-9BFA-0B2F10C833BD
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherAlpha(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherBlue(S,float,int,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 9E2A57C3-4EC4-4414-B16A-64AF759F04E9
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherBlue(S,float,int,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherBlue(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 0FFD3D82-E849-4C19-BEBC-85B9CCA40CA0
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # GatherBlue(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherBlue(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 74B2DAEC-3A94-441D-8A9E-286C2D2E9C8E
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherBlue(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmp-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmp-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmp(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 ms.assetid: A6610587-97C3-4CE5-86A7-3411D422BC8F
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmp(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpAlpha(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: 4E281512-2E0A-49A5-B568-8CE793A854F9
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpAlpha(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpAlpha(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: 4DB56BE2-503A-4D51-89FB-E4DD91EBF028
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpAlpha(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpalpha-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpAlpha(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 ms.assetid: C8325626-F281-4D10-9299-0E5DA01BB1BD
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpAlpha(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpBlue(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 ms.assetid: 05033555-32A8-4023-BDAB-00D5F7725CA9
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpBlue(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpBlue(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 ms.assetid: DAA41BF3-6037-404F-9B35-C5F1302367B9
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpBlue(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpblue-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpBlue(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 ms.assetid: 77051550-B2AC-4C51-9EA2-D803BDB2B153
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpBlue(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpGreen(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: 4A23DE5B-F9DE-45BC-ADF7-D952E4355F7F
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpGreen(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpGreen(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 ms.assetid: AC19838B-BA51-408D-8299-DC5F4551628C
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpGreen(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpgreen-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpGreen(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: E7EB3D17-3110-4167-B255-C451BA4EFB27
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpGreen(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpRed(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: 0FE5AB82-3FC1-46CF-AE9A-4B0B25385973
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpRed(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpRed(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 ms.assetid: B20A766E-0B4F-4FBA-A691-70ACE7BECF33
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpRed(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmpred-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherCmpRed(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: 69B1F8FF-CE29-49DD-B756-3308E11D866D
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherCmpRed(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherGreen(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the green component.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 043434C0-BB12-4A08-A3E5-34C9738DEBDB
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherGreen(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the green component.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherGreen(S,float,int,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: A50C41BC-FDF4-47E6-9776-F51B2B634713
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherGreen(S,float,int,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherGreen(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 61AAC31F-28BC-4DF8-A416-CBAD150829D8
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherGreen(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherRed(S,float,int,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: B49F738F-FB5C-4004-A3F3-D87C566DB597
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherRed(S,float,int,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherRed(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the red component.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 85C321CB-B77C-430B-921D-D56E5597B24A
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherRed(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the red component.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2D::GatherRed(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 7CDFAA5A-315A-40AE-A662-9AF97D486039
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2D::GatherRed(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gather-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gather-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::Gather(S,float,int,uint) function
-description: Samples a texture and returns all four components along with status about the operation.
+description: Returns the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 311A5042-19AA-41C7-8B22-2E34E4554250
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::Gather(S,float,int,uint) function
 
-Samples a texture and returns all four components along with status about the operation.
+Returns the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherAlpha(S,float,int,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: B04F29A7-0EC9-49F0-9662-00F1DD0F3E5B
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherAlpha(S,float,int,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherAlpha(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: A7F96B45-A097-437B-A0D0-18555FF76544
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherAlpha(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherAlpha(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 1B069708-FC77-4FD0-A264-3AB170F48D58
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherAlpha(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherBlue(S,float,int,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: A0745768-EE92-4036-84F5-2699D26441B3
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherBlue(S,float,int,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherBlue(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 82CDD092-D1C9-4FA9-BD85-65098BA457CD
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherBlue(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmp-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmp-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmp(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 ms.assetid: E68619B2-6AB0-4C57-9604-7759FD987446
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmp(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpAlpha(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: DCCF7F40-8A0D-47B8-910A-508382D3AE3F
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpAlpha(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpAlpha(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 ms.assetid: 0D6EC888-AB90-47C8-87D1-7B25E3EEB436
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpAlpha(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpalpha-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpAlpha(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: DDE72BD4-5F46-4C65-8C79-6B7A24170918
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpAlpha(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpBlue(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 ms.assetid: 60456C17-F7A4-408A-93A2-DF695CBBEEAA
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpBlue(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpBlue(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 ms.assetid: 1EAC38DC-51F5-41B8-926F-8D0626C37798
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpBlue(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpblue-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpBlue(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 ms.assetid: C47FD97F-2848-44F7-91E0-2120D08D89C7
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpBlue(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpGreen(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: 59DDC27B-EBC1-4C9F-8BF6-B5D82CDB1DAE
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpGreen(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpGreen(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 ms.assetid: 5A4B8AEB-B278-4456-893A-CAE61BFD6CA5
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpGreen(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpgreen-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpGreen(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: 53AC1FE7-ECC8-489B-8FEF-5028009BC080
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpGreen(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpRed(S,float,float,int,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: 83974A85-26CB-4724-A60F-64F214800723
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpRed(S,float,float,int,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpRed(S,float,float,int2,int2,int2,int2) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 ms.assetid: B436FB9A-C55C-477F-B8BE-933B1EB04AE1
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpRed(S,float,float,int2,int2,int2,int2) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathercmpred-s-float-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherCmpRed(S,float,float,int2,int2,int2,int2,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: E41E1328-AE31-445E-AF01-1DB201E8A278
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherCmpRed(S,float,float,int2,int2,int2,int2,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherGreen(S,float,int,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 90BEB8B3-F851-469B-B55A-E51CB8463CC8
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherGreen(S,float,int,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherGreen(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the green component.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 7E79442E-286F-4BDB-8D7A-2C20A0933585
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherGreen(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the green component.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherGreen(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 994320C6-3BE5-40F9-9B9F-1913134DA71A
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherGreen(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherRed(S,float,int,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 9FAFB594-5844-4A2D-9B45-7973B5F85E13
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherRed(S,float,int,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherRed(S,float,int2,int2,int2,int2) function
-description: Samples a texture and returns the red component.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: EB367373-D798-4CBA-AEB6-8BF89371D765
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherRed(S,float,int2,int2,int2,int2) function
 
-Samples a texture and returns the red component.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: Texture2DArray::GatherRed(S,float,int2,int2,int2,int2,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 9DD399A4-E6ED-499B-ACA3-28028C0AB271
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # Texture2DArray::GatherRed(S,float,int2,int2,int2,int2,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gather-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gather-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::Gather(S,float,uint) function
-description: Samples a texture and returns all four components along with status about the operation.
+description: Returns the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 23FA8135-ECF0-4CAE-9A1C-B05DA3676453
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::Gather(S,float,uint) function
 
-Samples a texture and returns all four components along with status about the operation.
+Returns the four texel values that would be used in a bi-linear filtering operation.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gatheralpha-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatheralpha-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherAlpha(S,float,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 19BD3024-D3E5-4AEA-8C8E-510A4EB527B5
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherAlpha(S,float,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gatherblue-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatherblue-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherBlue(S,float,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: B2099321-3E81-4A77-A023-AF73594C68C8
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherBlue(S,float,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathercmp-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathercmp-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherCmp(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 ms.assetid: 655F4851-708A-478B-BB31-9DC8CDD480D0
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherCmp(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathercmpalpha-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathercmpalpha-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherCmpAlpha(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: 8DC43B02-0B3C-49F0-AA94-80894A1A54BD
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherCmpAlpha(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathercmpblue-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathercmpblue-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherCmpBlue(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 ms.assetid: 1D1FFF0E-9CA7-48A4-A305-C0B6059056E7
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherCmpBlue(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathercmpgreen-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathercmpgreen-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherCmpGreen(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: 3EFCEFE1-BFE2-4448-962E-108C3C0861E5
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherCmpGreen(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathercmpred-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathercmpred-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherCmpRed(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: 99ADA450-9665-4870-924E-E4DAEFA912D5
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherCmpRed(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gathergreen-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathergreen-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherGreen(S,float,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: DB0A6386-70ED-4D8C-A4EE-C058496D2F12
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherGreen(S,float,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcube-gatherred-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatherred-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::GatherRed(S,float,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 6B298DFD-B996-40F4-9304-AA8283FDEC31
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCube::GatherRed(S,float,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gather-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gather-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::Gather(S,float,uint) function
-description: Samples a texture and returns all four components along with status about the operation.
+description: Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: B5C1843C-8DE4-4007-B619-2CC09B8A023B
 keywords:
 - Gather function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::Gather(S,float,uint) function
 
-Samples a texture and returns all four components along with status about the operation.
+Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gatheralpha-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatheralpha-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherAlpha(S,float,uint) function
-description: Samples a texture and returns the alpha component along with status about the operation.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: C6AF896A-C68E-44EA-A779-DD9DBA30A039
 keywords:
 - GatherAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherAlpha(S,float,uint) function
 
-Samples a texture and returns the alpha component along with status about the operation.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gatherblue-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatherblue-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherBlue(S,float,uint) function
-description: Samples a texture and returns the blue component along with status about the operation.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 85606EE7-9B05-439F-B525-A1CD42FE32F6
 keywords:
 - GatherBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherBlue(S,float,uint) function
 
-Samples a texture and returns the blue component along with status about the operation.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathercmp-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathercmp-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherCmp(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 ms.assetid: 758CD159-58B6-42AE-92B3-5AA3C72FD0F1
 keywords:
 - GatherCmp function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherCmp(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns all four components along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathercmpalpha-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathercmpalpha-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherCmpAlpha(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 ms.assetid: EA1D7176-3F70-4867-9854-80206A871B23
 keywords:
 - GatherCmpAlpha function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherCmpAlpha(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the alpha component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathercmpblue-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathercmpblue-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherCmpBlue(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 ms.assetid: 81F82EB1-D662-4A18-856F-26AE5C1A41C6
 keywords:
 - GatherCmpBlue function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherCmpBlue(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the blue component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathercmpgreen-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathercmpgreen-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherCmpGreen(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 ms.assetid: F1D8B0C2-08C8-4B5C-B929-3D7B4F3B69B7
 keywords:
 - GatherCmpGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherCmpGreen(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the green component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathercmpred-s-float-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathercmpred-s-float-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherCmpRed(S,float,float,uint) function
-description: Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+description: For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 ms.assetid: 2474ECF6-DA85-406F-8212-D71AD90730FD
 keywords:
 - GatherCmpRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherCmpRed(S,float,float,uint) function
 
-Samples a texture, tests the samples against a compare value, and returns the red component along with status about the operation.
+For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gathergreen-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathergreen-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherGreen(S,float,uint) function
-description: Samples a texture and returns the green component along with status about the operation.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 0DEB1810-F2C7-4097-B2D3-20ED4E297561
 keywords:
 - GatherGreen function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherGreen(S,float,uint) function
 
-Samples a texture and returns the green component along with status about the operation.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/tcubearray-gatherred-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatherred-s-float-uint-.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::GatherRed(S,float,uint) function
-description: Samples a texture and returns the red component along with status about the operation.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 ms.assetid: 9776A4B5-6DDB-4B9F-96CD-F97B8908B057
 keywords:
 - GatherRed function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # TextureCubeArray::GatherRed(S,float,uint) function
 
-Samples a texture and returns the red component along with status about the operation.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/texture2d-gather.md
+++ b/desktop-src/direct3dhlsl/texture2d-gather.md
@@ -18,6 +18,8 @@ api_location:
 
 Samples a [**Texture2D**](sm5-object-texture2d.md) and returns all four components.
 
+See the documentation on [gather4](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4--sm5---asm-) for more information describing the underlying DXBC instruction.
+
 ### Overload list
 
 

--- a/desktop-src/direct3dhlsl/texture2d-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/texture2d-gatheralpha.md
@@ -22,12 +22,12 @@ Samples a [**Texture2D**](sm5-object-texture2d.md) and returns the alpha compone
 
 
 
-| Method                                                                                                     | Description                                                                                         |
-|:-----------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherAlpha(S,float,int)**](sm5-object-texture2d-gatheralpha.md)                                       | Samples a texture and returns the alpha component.<br/>                                       |
-| [**GatherAlpha(S,float,int,uint)**](t2d-gatheralpha-s-float-int-uint-.md)                                 | Samples a texture and returns the alpha component along with status about the operation.<br/> |
-| [**GatherAlpha(S,float,int2,int2,int2,int2)**](t2d-gatheralpha-s-float-int2-int2-int2-int2-.md)           | Samples a texture and returns the alpha component.<br/>                                       |
-| [**GatherAlpha(S,float,int2,int2,int2,int2,uint)**](t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the alpha component along with status about the operation.<br/> |
+| Method                                                                                                     | Description                                                                                                                                       |
+|:-----------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherAlpha(S,float,int)**](sm5-object-texture2d-gatheralpha.md)                                        | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherAlpha(S,float,int,uint)**](t2d-gatheralpha-s-float-int-uint-.md)                                  | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherAlpha(S,float,int2,int2,int2,int2)**](t2d-gatheralpha-s-float-int2-int2-int2-int2-.md)            | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherAlpha(S,float,int2,int2,int2,int2,uint)**](t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md)  | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2d-gatherblue.md
+++ b/desktop-src/direct3dhlsl/texture2d-gatherblue.md
@@ -22,12 +22,12 @@ Samples a [**Texture2D**](sm5-object-texture2d.md) and returns the blue componen
 
 
 
-| Method                                                                                                   | Description                                                                                        |
-|:---------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| [**GatherBlue(S,float,int)**](sm5-object-texture2d-gatherblue.md)                                       | Samples a texture and returns the blue component.<br/>                                       |
-| [**GatherBlue(S,float,int,uint)**](t2d-gatherblue-s-float-int-uint-.md)                                 | Samples a texture and returns the blue component along with status about the operation.<br/> |
-| [**GatherBlue(S,float,int2,int2,int2,int2)**](t2d-gatherblue-s-float-int2-int2-int2-int2-.md)           | Samples a texture and returns the blue component.<br/>                                       |
-| [**GatherBlue(S,float,int2,int2,int2,int2,uint)**](t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the blue component along with status about the operation.<br/> |
+| Method                                                                                                  | Description                                                                                                                                      |
+|:--------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherBlue(S,float,int)**](sm5-object-texture2d-gatherblue.md)                                       | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherBlue(S,float,int,uint)**](t2d-gatherblue-s-float-int-uint-.md)                                 | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherBlue(S,float,int2,int2,int2,int2)**](t2d-gatherblue-s-float-int2-int2-int2-int2-.md)           | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherBlue(S,float,int2,int2,int2,int2,uint)**](t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md) | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2d-gathercmp.md
+++ b/desktop-src/direct3dhlsl/texture2d-gathercmp.md
@@ -16,7 +16,9 @@ api_location:
 
 # Texture2D::GatherCmp methods
 
-Samples and compares a [**Texture2D**](sm5-object-texture2d.md) and returns all components.
+For four texel values of a [**Texture2D**](sm5-object-texture2d.md) that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
+
+See the documentation on [gather4_c](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4-c--sm5---asm-) for more information describing the underlying DXBC instruction.
 
 ### Overload list
 

--- a/desktop-src/direct3dhlsl/texture2d-gathergreen.md
+++ b/desktop-src/direct3dhlsl/texture2d-gathergreen.md
@@ -22,12 +22,12 @@ Samples a [**Texture2D**](sm5-object-texture2d.md) and returns the green compone
 
 
 
-| Method                                                                                                     | Description                                                                                         |
-|:-----------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherGreen(S,float,int)**](sm5-object-texture2d-gathergreen.md)                                       | Samples a texture and returns the green component.<br/>                                       |
-| [**GatherGreen(S,float,int,uint)**](t2d-gathergreen-s-float-int-uint-.md)                                 | Samples a texture and returns the green component along with status about the operation.<br/> |
-| [**GatherGreen(S,float,int2,int2,int2,int2)**](t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md)     | Samples a texture and returns the green component.<br/>                                       |
-| [**GatherGreen(S,float,int2,int2,int2,int2,uint)**](t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the green component along with status about the operation.<br/> |
+| Method                                                                                                     | Description                                                                                                                                       |
+|:-----------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherGreen(S,float,int)**](sm5-object-texture2d-gathergreen.md)                                        | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherGreen(S,float,int,uint)**](t2d-gathergreen-s-float-int-uint-.md)                                  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherGreen(S,float,int2,int2,int2,int2)**](t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md)      | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherGreen(S,float,int2,int2,int2,int2,uint)**](t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md)  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2d-gatherred.md
+++ b/desktop-src/direct3dhlsl/texture2d-gatherred.md
@@ -16,18 +16,18 @@ api_location:
 
 # Texture2D::GatherRed methods
 
-Samples a [**Texture2D**](sm5-object-texture2d.md) and returns the red component.
+Returns the red components of a [**Texture2D**](sm5-object-texture2d.md)'s four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                                                   | Description                                                                                       |
-|:---------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
-| [**GatherRed(S,float,int)**](sm5-object-texture2d-gatherred.md)                                         | Samples a texture and returns the red component.<br/>                                       |
-| [**GatherRed(S,float,int,uint)**](t2d-gatherred-s-float-int-uint-.md)                                   | Samples a texture and returns the red component along with status about the operation.<br/> |
-| [**GatherRed(S,float,int2,int2,int2,int2)**](t2d-gatherred-s-float-int2-int2-int2-int2-.md)             | Samples a texture and returns the red component.<br/>                                       |
-| [**GatherRed(S,float,int2,int2,int2,int2,uint)**](t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the red component along with status about the operation.<br/> |
+| Method                                                                                                  | Description                                                                                                                                     |
+|:--------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherRed(S,float,int)**](sm5-object-texture2d-gatherred.md)                                         | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherRed(S,float,int,uint)**](t2d-gatherred-s-float-int-uint-.md)                                   | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherRed(S,float,int2,int2,int2,int2)**](t2d-gatherred-s-float-int2-int2-int2-int2-.md)             | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherRed(S,float,int2,int2,int2,int2,uint)**](t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md) | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gather.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gather.md
@@ -18,6 +18,8 @@ api_location:
 
 Returns the four texel values of a [**Texture2DArray**](sm5-object-texture2darray.md) that would be used in a bi-linear filtering operation.
 
+See the documentation on [gather4](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4--sm5---asm-) for more information describing the underlying DXBC instruction.
+
 ### Overload list
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gather.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gather.md
@@ -16,16 +16,16 @@ api_location:
 
 # Texture2DArray::Gather methods
 
-Samples a [**Texture2DArray**](sm5-object-texture2darray.md) and returns all four components.
+Returns the four texel values of a [**Texture2DArray**](sm5-object-texture2darray.md) that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                | Description                                                                                         |
-|:----------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**Gather(S,float,int)**](sm5-object-texture2darray-gather.md)       | Samples a texture and returns all four components.<br/>                                       |
-| [**Gather(S,float,int,uint)**](t2darray-gather-s-float-int-uint-.md) | Samples a texture and returns all four components along with status about the operation.<br/> |
+| Method                                                                | Description                                                                                                               |
+|:----------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| [**Gather(S,float,int)**](sm5-object-texture2darray-gather.md)        | Returns the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**Gather(S,float,int,uint)**](t2darray-gather-s-float-int-uint-.md)  | Returns the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gatheralpha.md
@@ -16,18 +16,18 @@ api_location:
 
 # Texture2DArray::GatherAlpha methods
 
-Samples a [**Texture2DArray**](sm5-object-texture2darray.md) and returns the alpha component.
+Returns the alpha components of a [**Texture2DArray**](sm5-object-texture2darray.md)'s four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                                                          | Description                                                                                         |
-|:----------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherAlpha(S,float,int)**](sm5-object-texture2darray-gatheralpha.md)                                       | Samples a texture and returns the alpha component.<br/>                                       |
-| [**GatherAlpha(S,float,int,uint)**](t2darray-gatheralpha-s-float-int-uint-.md)                                 | Samples a texture and returns the alpha component along with status about the operation.<br/> |
-| [**GatherAlpha(S,float,int2,int2,int2,int2)**](t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md)           | Samples a texture and returns the alpha component.<br/>                                       |
-| [**GatherAlpha(S,float,int2,int2,int2,int2,uint)**](t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the alpha component along with status about the operation.<br/> |
+| Method                                                                                                          | Description                                                                                                                                       |
+|:----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherAlpha(S,float,int)**](sm5-object-texture2darray-gatheralpha.md)                                        | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherAlpha(S,float,int,uint)**](t2darray-gatheralpha-s-float-int-uint-.md)                                  | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherAlpha(S,float,int2,int2,int2,int2)**](t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md)            | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherAlpha(S,float,int2,int2,int2,int2,uint)**](t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md)  | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gatherblue.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gatherblue.md
@@ -16,18 +16,18 @@ api_location:
 
 # Texture2DArray::GatherBlue methods
 
-Samples a [**Texture2DArray**](sm5-object-texture2darray.md) and returns the blue component.
+Returns the blue components of a [**Texture2DArray**](sm5-object-texture2darray.md)'s four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                                                        | Description                                                                                        |
-|:--------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| [**GatherBlue(S,float,int)**](sm5-object-texture2darray-gatherblue.md)                                       | Samples a texture and returns the blue component.<br/>                                       |
-| [**GatherBlue(S,float,int,uint)**](t2darray-gatherblue-s-float-int-uint-.md)                                 | Samples a texture and returns the blue component along with status about the operation.<br/> |
-| [**GatherBlue(S,float,int2,int2,int2,int2)**](t2array-gatherblue-s-float-int2-int2-int2-int2-.md)            | Samples a texture and returns the blue component.<br/>                                       |
-| [**GatherBlue(S,float,int2,int2,int2,int2,uint)**](t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the blue component along with status about the operation.<br/> |
+| Method                                                                                                        | Description                                                                                                                                      |
+|:--------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherBlue(S,float,int)**](sm5-object-texture2darray-gatherblue.md)                                        | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherBlue(S,float,int,uint)**](t2darray-gatherblue-s-float-int-uint-.md)                                  | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherBlue(S,float,int2,int2,int2,int2)**](t2array-gatherblue-s-float-int2-int2-int2-int2-.md)             | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherBlue(S,float,int2,int2,int2,int2,uint)**](t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md)  | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gathercmp.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gathercmp.md
@@ -16,7 +16,9 @@ api_location:
 
 # Texture2DArray::GatherCmp methods
 
-Samples and compares a [**Texture2DArray**](sm5-object-texture2darray.md) and returns all components.
+For four texel values of a [**Texture2DArray**](sm5-object-texture2darray.md) that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
+
+See the documentation on [gather4_c](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4-c--sm5---asm-) for more information describing the underlying DXBC instruction.
 
 ### Overload list
 

--- a/desktop-src/direct3dhlsl/texture2darray-gathergreen.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gathergreen.md
@@ -16,18 +16,18 @@ api_location:
 
 # Texture2DArray::GatherGreen methods
 
-Samples a [**Texture2DArray**](sm5-object-texture2darray.md) and returns the green component.
+Returns the green components of a [**Texture2DArray**](sm5-object-texture2darray.md)'s four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                                                          | Description                                                                                         |
-|:----------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherGreen(S,float,int)**](sm5-object-texture2darray-gathergreen.md)                                       | Samples a texture and returns the green component.<br/>                                       |
-| [**GatherGreen(S,float,int,uint)**](t2darray-gathergreen-s-float-int-uint-.md)                                 | Samples a texture and returns the green component along with status about the operation.<br/> |
-| [**GatherGreen(S,float,int2,int2,int2,int2)**](t2darray-gathergreen-s-float-int2-int2-int2-int2-.md)           | Samples a texture and returns the green component.<br/>                                       |
-| [**GatherGreen(S,float,int2,int2,int2,int2,uint)**](t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the green component along with status about the operation.<br/> |
+| Method                                                                                                          | Description                                                                                                                                       |
+|:----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherGreen(S,float,int)**](sm5-object-texture2darray-gathergreen.md)                                        | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherGreen(S,float,int,uint)**](t2darray-gathergreen-s-float-int-uint-.md)                                  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherGreen(S,float,int2,int2,int2,int2)**](t2darray-gathergreen-s-float-int2-int2-int2-int2-.md)            | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherGreen(S,float,int2,int2,int2,int2,uint)**](t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md)  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texture2darray-gatherred.md
+++ b/desktop-src/direct3dhlsl/texture2darray-gatherred.md
@@ -16,18 +16,18 @@ api_location:
 
 # Texture2DArray::GatherRed methods
 
-Samples a [**Texture2DArray**](sm5-object-texture2darray.md) and returns the red component.
+Returns the red components of a [**Texture2DArray**](sm5-object-texture2darray.md)'s four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                                                      | Description                                                                                       |
-|:------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
-| [**GatherRed(S,float,int)**](sm5-object-texture2darray-gatherred.md)                                       | Samples a texture and returns the red component.<br/>                                       |
-| [**GatherRed(S,float,int,uint)**](t2darray-gatherred-s-float-int-uint-.md)                                 | Samples a texture and returns the red component along with status about the operation.<br/> |
-| [**GatherRed(S,float,int2,int2,int2,int2)**](t2darray-gatherred-s-float-int2-int2-int2-int2-.md)           | Samples a texture and returns the red component.<br/>                                       |
-| [**GatherRed(S,float,int2,int2,int2,int2,uint)**](t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md) | Samples a texture and returns the red component along with status about the operation.<br/> |
+| Method                                                                                                      | Description                                                                                                                                     |
+|:------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherRed(S,float,int)**](sm5-object-texture2darray-gatherred.md)                                        | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherRed(S,float,int,uint)**](t2darray-gatherred-s-float-int-uint-.md)                                  | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
+| [**GatherRed(S,float,int2,int2,int2,int2)**](t2darray-gatherred-s-float-int2-int2-int2-int2-.md)            | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                 |
+| [**GatherRed(S,float,int2,int2,int2,int2,uint)**](t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md)  | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecube-gather.md
+++ b/desktop-src/direct3dhlsl/texturecube-gather.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::TextureCube Gather methods
-description: Samples a texture and returns all four components.
+description: Returns the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 4891A62A-9D54-4F7E-92C2-9CDDF1453671
 keywords:
 - Gather methods HLSL
@@ -16,7 +16,7 @@ api_location:
 
 # TextureCube::Gather methods
 
-Samples a texture and returns all four components.
+Returns the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 

--- a/desktop-src/direct3dhlsl/texturecube-gather.md
+++ b/desktop-src/direct3dhlsl/texturecube-gather.md
@@ -18,6 +18,8 @@ api_location:
 
 Returns the four texel values that would be used in a bi-linear filtering operation.
 
+See the documentation on [gather4](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4--sm5---asm-) for more information describing the underlying DXBC instruction.
+
 ### Overload list
 
 

--- a/desktop-src/direct3dhlsl/texturecube-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/texturecube-gatheralpha.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::TextureCube GatherAlpha methods
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 1384BB1D-9AE7-4014-AB99-3EE84B383653
 keywords:
 - GatherAlpha methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCube::GatherAlpha methods
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                               | Description                                                                                         |
-|:---------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherAlpha(S,float,uint)**](tcube-gatheralpha-s-float-uint-.md) | Samples a texture and returns the alpha component along with status about the operation.<br/> |
+| Method                                                               | Description                                                                                                                                       |
+|:---------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherAlpha(S,float,uint)**](tcube-gatheralpha-s-float-uint-.md)  | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecube-gatherblue.md
+++ b/desktop-src/direct3dhlsl/texturecube-gatherblue.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::TextureCube GatherBlue methods
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 933B1358-DD7D-477B-AC12-488C94127C92
 keywords:
 - GatherBlue methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCube::GatherBlue methods
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                             | Description                                                                                        |
-|:-------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| [**GatherBlue(S,float,uint)**](tcube-gatherblue-s-float-uint-.md) | Samples a texture and returns the blue component along with status about the operation.<br/> |
+| Method                                                             | Description                                                                                                                                      |
+|:-------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherBlue(S,float,uint)**](tcube-gatherblue-s-float-uint-.md)  | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecube-gathercmp.md
+++ b/desktop-src/direct3dhlsl/texturecube-gathercmp.md
@@ -16,7 +16,9 @@ api_location:
 
 # TextureCube::GatherCmp methods
 
-Samples and compares a texture and returns all components.
+For four texel values of a [**TextureCube**](texturecube.md) that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
+
+See the documentation on [gather4_c](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4-c--sm5---asm-) for more information describing the underlying DXBC instruction.
 
 ### Overload list
 

--- a/desktop-src/direct3dhlsl/texturecube-gathergreen.md
+++ b/desktop-src/direct3dhlsl/texturecube-gathergreen.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::TextureCube GatherGreen methods
-description: Samples a texture and returns the green component.
+description: Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: F70AA57B-D54C-4F78-ABD1-7F8D3AD44997
 keywords:
 - GatherGreen methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCube::GatherGreen methods
 
-Samples a texture and returns the green component.
+Returns the green components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                               | Description                                                                                         |
-|:---------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherGreen(S,float,uint)**](tcube-gathergreen-s-float-uint-.md) | Samples a texture and returns the green component along with status about the operation.<br/> |
+| Method                                                               | Description                                                                                                                                       |
+|:---------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherGreen(S,float,uint)**](tcube-gathergreen-s-float-uint-.md)  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecube-gatherred.md
+++ b/desktop-src/direct3dhlsl/texturecube-gatherred.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCube::TextureCube GatherRed methods
-description: Samples a texture and returns the red component.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: DDBFE342-C22D-46A3-BC7D-1D34ED2C0AD6
 keywords:
 - GatherRed methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCube::GatherRed methods
 
-Samples a texture and returns the red component.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                           | Description                                                                                       |
-|:-----------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
-| [**GatherRed(S,float,uint)**](tcube-gatherred-s-float-uint-.md) | Samples a texture and returns the red component along with status about the operation.<br/> |
+| Method                                                           | Description                                                                                                                                     |
+|:-----------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherRed(S,float,uint)**](tcube-gatherred-s-float-uint-.md)  | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecube.md
+++ b/desktop-src/direct3dhlsl/texturecube.md
@@ -28,24 +28,24 @@ The **TextureCube** object has these methods.
 
 
 
-| Method                                                       | Description                                                                                           |
-|:-------------------------------------------------------------|:------------------------------------------------------------------------------------------------------|
-| [**Gather**](texturecube-gather.md)                         | Samples a texture and returns all components.<br/>                                              |
-| [**GatherAlpha**](texturecube-gatheralpha.md)               | Samples a texture and returns the alpha component.<br/>                                         |
-| [**GatherBlue**](texturecube-gatherblue.md)                 | Samples a texture and returns the blue component.<br/>                                          |
-| [**GatherCmp**](texturecube-gathercmp.md)                   | Samples and compares a texture and returns all components.<br/>                                 |
-| [**GatherCmpAlpha**](texturecube-gathercmpalpha.md)         | Samples and compares a texture and returns the alpha component.<br/>                            |
-| [**GatherCmpBlue**](texturecube-gathercmpblue.md)           | Samples and compares a texture and returns the blue component.<br/>                             |
-| [**GatherCmpGreen**](texturecube-gathercmpgreen.md)         | Samples and compares a texture and returns the green component.<br/>                            |
-| [**GatherCmpRed**](texturecube-gathercmpred.md)             | Samples and compares a texture and returns the red component.<br/>                              |
-| [**GatherGreen**](texturecube-gathergreen.md)               | Samples a texture and returns the green component.<br/>                                         |
-| [**GatherRed**](texturecube-gatherred.md)                   | Samples a texture and returns the red component.<br/>                                           |
-| [**Sample**](texturecube-sample.md)                         | Samples a texture.<br/>                                                                         |
-| [**SampleBias**](texturecube-samplebias.md)                 | Samples a texture, after applying the bias value to the mipmap level.<br/>                      |
-| [**SampleCmp**](texturecube-samplecmp.md)                   | Samples a texture, using a comparison value to reject samples.<br/>                             |
-| [**SampleCmpLevelZero**](texturecube-samplecmplevelzero.md) | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.<br/>       |
-| [**SampleGrad**](texturecube-samplegrad.md)                 | Samples a texture using a gradient to influence the way the sample location is calculated.<br/> |
-| [**SampleLevel**](texturecube-samplelevel.md)               | Samples a texture on the specified mipmap level.<br/>                                           |
+| Method                                                      | Description                                                                                                                                             |
+|:------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**Gather**](texturecube-gather.md)                         | Returns the four texel values that would be used in a bi-linear filtering operation.<br/>                                                                |
+| [**GatherAlpha**](texturecube-gatheralpha.md)               | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                        |
+| [**GatherBlue**](texturecube-gatherblue.md)                 | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                         |
+| [**GatherCmp**](texturecube-gathercmp.md)                   | For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.<br/>                      |
+| [**GatherCmpAlpha**](texturecube-gathercmpalpha.md)         | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.<br/> |
+| [**GatherCmpBlue**](texturecube-gathercmpblue.md)           | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.<br/>  |
+| [**GatherCmpGreen**](texturecube-gathercmpgreen.md)         | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.<br/> |
+| [**GatherCmpRed**](texturecube-gathercmpred.md)             | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.<br/>   |
+| [**GatherGreen**](texturecube-gathergreen.md)               | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                        |
+| [**GatherRed**](texturecube-gatherred.md)                   | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                          |
+| [**Sample**](texturecube-sample.md)                         | Samples a texture.<br/>                                                                                                                                  |
+| [**SampleBias**](texturecube-samplebias.md)                 | Samples a texture, after applying the bias value to the mipmap level.<br/>                                                                               |
+| [**SampleCmp**](texturecube-samplecmp.md)                   | Samples a texture, using a comparison value to reject samples.<br/>                                                                                      |
+| [**SampleCmpLevelZero**](texturecube-samplecmplevelzero.md) | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.<br/>                                                                |
+| [**SampleGrad**](texturecube-samplegrad.md)                 | Samples a texture using a gradient to influence the way the sample location is calculated.<br/>                                                          |
+| [**SampleLevel**](texturecube-samplelevel.md)               | Samples a texture on the specified mipmap level.<br/>                                                                                                    |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gather.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gather.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::TextureCubeArray Gather methods
-description: Samples a texture and returns all four components.
+description: Returns the red components of four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: B459E455-EF22-46A7-ADFE-322ED808F83E
 keywords:
 - Gather methods HLSL
@@ -16,16 +16,16 @@ api_location:
 
 # TextureCubeArray::Gather methods
 
-Samples a texture and returns all four components.
+Returns the red components of four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                          | Description                                                                                                              |
-|:----------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------|
-| [**Gather(S,float)**](dx-graphics-hlsl-to-gather.md)           | Samples a texture and returns the four samples (red component only) that are used for bilinear interpolation.<br/> |
-| [**Gather(S,float,uint)**](tcubearray-gather-s-float-uint-.md) | Samples a texture and returns all four components along with status about the operation.<br/>                      |
+| Method                                                          | Description                                                                                                                                |
+|:----------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------|
+| [**Gather(S,float)**](dx-graphics-hlsl-to-gather.md)           | Returns the red components of four texel values (red component only) that would be used in a bi-linear filtering operation. <br/>           |
+| [**Gather(S,float,uint)**](tcubearray-gather-s-float-uint-.md) | Returns the red components of four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gather.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gather.md
@@ -18,6 +18,8 @@ api_location:
 
 Returns the red components of four texel values that would be used in a bi-linear filtering operation.
 
+See the documentation on [gather4](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4--sm5---asm-) for more information describing the underlying DXBC instruction.
+
 ### Overload list
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gatheralpha.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gatheralpha.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::TextureCubeArray GatherAlpha methods
-description: Samples a texture and returns the alpha component.
+description: Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: C7D4B78D-B756-4ADA-B0EA-3360007C02E1
 keywords:
 - GatherAlpha methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCubeArray::GatherAlpha methods
 
-Samples a texture and returns the alpha component.
+Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                    | Description                                                                                         |
-|:--------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherAlpha(S,float,uint)**](tcubearray-gatheralpha-s-float-uint-.md) | Samples a texture and returns the alpha component along with status about the operation.<br/> |
+| Method                                                                    | Description                                                                                                                                      |
+|:--------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherAlpha(S,float,uint)**](tcubearray-gatheralpha-s-float-uint-.md) | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gatherblue.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gatherblue.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::TextureCubeArray GatherBlue methods
-description: Samples a texture and returns the blue component.
+description: Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: 709EF549-20F6-44E1-8E8C-1FF71C259FC7
 keywords:
 - GatherBlue methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCubeArray::GatherBlue methods
 
-Samples a texture and returns the blue component.
+Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                  | Description                                                                                        |
-|:------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------|
-| [**GatherBlue(S,float,uint)**](tcubearray-gatherblue-s-float-uint-.md) | Samples a texture and returns the blue component along with status about the operation.<br/> |
+| Method                                                                  | Description                                                                                                                                      |
+|:------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherBlue(S,float,uint)**](tcubearray-gatherblue-s-float-uint-.md)  | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gathercmp.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gathercmp.md
@@ -16,7 +16,9 @@ api_location:
 
 # TextureCubeArray::GatherCmp methods
 
-Samples and compares a texture and returns all components.
+For four texel values of a [**TextureCubeArray**](texturecubearray.md) that would be used in a bi-linear filtering operation, returns their comparison against a compare value.
+
+See the documentation on [gather4_c](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/gather4-c--sm5---asm-) for more information describing the underlying DXBC instruction.
 
 ### Overload list
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gathergreen.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gathergreen.md
@@ -22,9 +22,9 @@ Samples a texture and returns the green component.
 
 
 
-| Method                                                                    | Description                                                                                         |
-|:--------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
-| [**GatherGreen(S,float,uint)**](tcubearray-gathergreen-s-float-uint-.md) | Samples a texture and returns the green component along with status about the operation.<br/> |
+| Method                                                                    | Description                                                                                                                                       |
+|:--------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherGreen(S,float,uint)**](tcubearray-gathergreen-s-float-uint-.md)  | Returns the green components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray-gatherred.md
+++ b/desktop-src/direct3dhlsl/texturecubearray-gatherred.md
@@ -1,6 +1,6 @@
 ---
 title: TextureCubeArray::TextureCubeArray GatherRed methods
-description: Samples a texture and returns the red component.
+description: Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 ms.assetid: EF52E362-D65B-4D5C-A09F-5E67303502C5
 keywords:
 - GatherRed methods HLSL
@@ -16,15 +16,15 @@ api_location:
 
 # TextureCubeArray::GatherRed methods
 
-Samples a texture and returns the red component.
+Returns the red components of the four texel values that would be used in a bi-linear filtering operation.
 
 ### Overload list
 
 
 
-| Method                                                                | Description                                                                                       |
-|:----------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
-| [**GatherRed(S,float,uint)**](tcubearray-gatherred-s-float-uint-.md) | Samples a texture and returns the red component along with status about the operation.<br/> |
+| Method                                                                | Description                                                                                                                                     |
+|:----------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**GatherRed(S,float,uint)**](tcubearray-gatherred-s-float-uint-.md)  | Returns the red components of the four texel values that would be used in a bi-linear filtering operation, along with tile-mapping status.<br/> |
 
 
 

--- a/desktop-src/direct3dhlsl/texturecubearray.md
+++ b/desktop-src/direct3dhlsl/texturecubearray.md
@@ -28,24 +28,24 @@ The **TextureCubeArray** object has these methods.
 
 
 
-| Method                                                            | Description                                                                                           |
-|:------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------|
-| [**Gather**](texturecubearray-gather.md)                         | Samples a texture and returns all components.<br/>                                              |
-| [**GatherAlpha**](texturecubearray-gatheralpha.md)               | Samples a texture and returns the alpha component.<br/>                                         |
-| [**GatherBlue**](texturecubearray-gatherblue.md)                 | Samples a texture and returns the blue component.<br/>                                          |
-| [**GatherCmp**](texturecubearray-gathercmp.md)                   | Samples and compares a texture and returns all components.<br/>                                 |
-| [**GatherCmpAlpha**](texturecubearray-gathercmpalpha.md)         | Samples and compares a texture and returns the alpha component.<br/>                            |
-| [**GatherCmpBlue**](texturecubearray-gathercmpblue.md)           | Samples and compares a texture and returns the blue component.<br/>                             |
-| [**GatherCmpGreen**](texturecubearray-gathercmpgreen.md)         | Samples and compares a texture and returns the green component.<br/>                            |
-| [**GatherCmpRed**](texturecubearray-gathercmpred.md)             | Samples and compares a texture and returns the red component.<br/>                              |
-| [**GatherGreen**](texturecubearray-gathergreen.md)               | Samples a texture and returns the green component.<br/>                                         |
-| [**GatherRed**](texturecubearray-gatherred.md)                   | Samples a texture and returns the red component.<br/>                                           |
-| [**Sample**](texturecubearray-sample.md)                         | Samples a texture.<br/>                                                                         |
-| [**SampleBias**](texturecubearray-samplebias.md)                 | Samples a texture, after applying the bias value to the mipmap level.<br/>                      |
-| [**SampleCmp**](texturecubearray-samplecmp.md)                   | Samples a texture, using a comparison value to reject samples.<br/>                             |
-| [**SampleCmpLevelZero**](texturecubearray-samplecmplevelzero.md) | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.<br/>       |
-| [**SampleGrad**](texturecubearray-samplegrad.md)                 | Samples a texture using a gradient to influence the way the sample location is calculated.<br/> |
-| [**SampleLevel**](texturecubearray-samplelevel.md)               | Samples a texture on the specified mipmap level.<br/>                                           |
+| Method                                                           | Description                                                                                                                                              |
+|:-----------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [**Gather**](texturecubearray-gather.md)                         | Returns the four texel values that would be used in a bi-linear filtering operation.<br/>                                                                |
+| [**GatherAlpha**](texturecubearray-gatheralpha.md)               | Returns the alpha components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                        |
+| [**GatherBlue**](texturecubearray-gatherblue.md)                 | Returns the blue components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                         |
+| [**GatherCmp**](texturecubearray-gathercmp.md)                   | For four texel values that would be used in a bi-linear filtering operation, returns their comparison against a compare value.<br/>                      |
+| [**GatherCmpAlpha**](texturecubearray-gathercmpalpha.md)         | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their alpha component against a compare value.<br/> |
+| [**GatherCmpBlue**](texturecubearray-gathercmpblue.md)           | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their blue component against a compare value.<br/>  |
+| [**GatherCmpGreen**](texturecubearray-gathercmpgreen.md)         | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their green component against a compare value.<br/> |
+| [**GatherCmpRed**](texturecubearray-gathercmpred.md)             | For four texel values that would be used in a bi-linear filtering operation, returns a comparison of their red component against a compare value.<br/>   |
+| [**GatherGreen**](texturecubearray-gathergreen.md)               | Returns the green components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                        |
+| [**GatherRed**](texturecubearray-gatherred.md)                   | Returns the red components of the four texel values that would be used in a bi-linear filtering operation.<br/>                                          |
+| [**Sample**](texturecubearray-sample.md)                         | Samples a texture.<br/>                                                                                                                                  |
+| [**SampleBias**](texturecubearray-samplebias.md)                 | Samples a texture, after applying the bias value to the mipmap level.<br/>                                                                               |
+| [**SampleCmp**](texturecubearray-samplecmp.md)                   | Samples a texture, using a comparison value to reject samples.<br/>                                                                                      |
+| [**SampleCmpLevelZero**](texturecubearray-samplecmplevelzero.md) | Samples a texture (mipmap level 0 only), using a comparison value to reject samples.<br/>                                                                |
+| [**SampleGrad**](texturecubearray-samplegrad.md)                 | Samples a texture using a gradient to influence the way the sample location is calculated.<br/>                                                          |
+| [**SampleLevel**](texturecubearray-samplelevel.md)               | Samples a texture on the specified mipmap level.<br/>                                                                                                    |
 
 
 


### PR DESCRIPTION
The API reference docs for all the Gather* aren't correct and appear like they might've been erroneously copypasted from Sample. After all it isn't really right to say that Gather does a sample (Sample is what does a sample), it sort of does the first part of a very limited kind of sample. It would be better to say more clearly what it does.

This issue affects the whole family of methods (cmp / single-channel / overloads that return status) so it touches a lot of places to fix all of them.

An example of an affected page is https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/texture2d-gather

This is intended to fix https://github.com/MicrosoftDocs/feedback/issues/2251

Additionally, there was a spot where Texture2DMSArray::GetSamplePosition also had the same text "Samples a texture and returns all four components" which is just clearly wrong so this fixes it.