### PR TITLE
WM_COPY must return a nonzero value on success.

### DIFF
--- a/desktop-src/dataxchg/wm-copy.md
+++ b/desktop-src/dataxchg/wm-copy.md
@@ -47,7 +47,7 @@ This parameter is not used and must be zero.
 
 ## Return value
 
-This message does not return a value.
+Returns nonzero value on success, else zero.
 
 ## Remarks
 


### PR DESCRIPTION
If you overwrite WM_COPY, and return zero then an edit control will not delete the Text in response to a WM_CUT message.
I think it does internally call the WM_COPY handler, and then deletes the text only if WM_COPY handler returned a nonzero value.
Please review/correct the documentation.