### PR TITLE
Update and rename tls-cipher-suites-in-windows-10-v21H1.md to tls-cip…

### DIFF
--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
@@ -1,11 +1,11 @@
 ---
 description: Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
-title: TLS Cipher Suites in Windows 10 v21H1.
+title: TLS Cipher Suites in Windows Server 2022.
 ms.topic: article
 ms.date: 12/17/2020
 ---
 
-# TLS Cipher Suites in Windows 10 v21H1
+# TLS Cipher Suites in Windows Server 2022
 
 Cipher suites can only be negotiated for TLS versions which support them. The highest supported TLS version is always preferred in the TLS handshake.
 
@@ -21,7 +21,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
 FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
 
-For Windows 10, version 21H1, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
+For Windows Server 2022, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
 
 


### PR DESCRIPTION
…her-suites-in-windows-server-2022.md

Changed title from "Windows 10 21H1", which is not an official release, to "Windows Server 2022".