### PR TITLE
Correct offset type of GatherCmp intrinsic

### DIFF
--- a/desktop-src/direct3dhlsl/t2d-gathercmp-s-float-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathercmp-s-float-float-int-uint-.md
@@ -27,7 +27,7 @@ TemplateType GatherCmp(
   in  SamplerState S,
   in  float        Location,
   in  float        CompareValue,
-  in  int          Offset,
+  in  int2         Offset,
   out uint         Status
 );
 ```
@@ -68,9 +68,9 @@ A value to compare each against each sampled value.
 *Offset* \[in\]
 </dt> <dd>
 
-Type: **int**
+Type: **int2**
 
-The offset applied to the texture coordinates before sampling.
+The offset in texels applied to the texture coordinates before sampling. Must be a literal value.
 
 </dd> <dt>
 


### PR DESCRIPTION
As the other `GatherCmp*` variants and the actual implementation [prototype ](https://github.com/microsoft/DirectXShaderCompiler/blob/650db999f961930b16dc992ea1718b8a3f7e4e7b/utils/hct/gen_intrin_main.txt#L468) indicate , the offsets parameter must be `int2`, not `int` to account for the 2D access of a 2D texture.