### PR TITLE
Fix wParam value

### DIFF
--- a/desktop-src/Controls/cb-findstringexact.md
+++ b/desktop-src/Controls/cb-findstringexact.md
@@ -27,7 +27,7 @@ Finds the first list box string in a combo box that matches the string specified
 *wParam* 
 </dt> <dd>
 
-The zero-based index of the item preceding the first item to be searched. When the search reaches the bottom of the list box, it continues from the top of the list box back to the item specified by the *wParam* parameter. If *wParam* is  1, the entire list box is searched from the beginning.
+The zero-based index of the item preceding the first item to be searched. When the search reaches the bottom of the list box, it continues from the top of the list box back to the item specified by the *wParam* parameter. If *wParam* is -1, the entire list box is searched from the beginning.
 
 </dd> <dt>
 


### PR DESCRIPTION
If want to search from the beginning of the list box, should be set wParam to -1, not 1.