### PR TITLE
Update cb-findstringexact.md

### DIFF
--- a/desktop-src/Controls/cb-findstringexact.md
+++ b/desktop-src/Controls/cb-findstringexact.md
@@ -27,7 +27,7 @@ Finds the first list box string in a combo box that matches the string specified
 *wParam* 
 </dt> <dd>
 
-The zero-based index of the item preceding the first item to be searched. When the search reaches the bottom of the list box, it continues from the top of the list box back to the item specified by the *wParam* parameter. If *wParam* is  1, the entire list box is searched from the beginning.
+The zero-based index of the item preceding the first item to be searched. When the search reaches the bottom of the list box, it continues from the top of the list box back to the item specified by the *wParam* parameter. If *wParam* is -1, the entire list box is searched from the beginning.
 
 </dd> <dt>
 


### PR DESCRIPTION
Seems that wParam should be -1 to search the entire list box from the beginning.
The message result is the same for both 1 and -1 because when the search reaches the bottom of the list box, it continues from the top of the list box back to the 1st item.
It is -1 for [CB_FINDSTRING](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/Controls/cb-findstring.md
) and [CB_SELECTSTRING](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/Controls/cb-selectstring.md).
