### PR TITLE
Improve readability of creating-a-hash-with-cng.md

### DIFF
--- a/desktop-src/SecCNG/creating-a-hash-with-cng.md
+++ b/desktop-src/SecCNG/creating-a-hash-with-cng.md
@@ -8,11 +8,27 @@ ms.date: 05/31/2018
 
 # Creating a Hash with CNG
 
-A [*hash*](/windows/desktop/SecGloss/h-gly) is a one way operation that is performed on a block of data to create a unique hash value that represents the contents of the data. No matter when the hash is performed, the same [*hashing algorithm*](/windows/desktop/SecGloss/h-gly) performed on the same data will always produce the same hash value. If any of the data changes, the hash value will change appropriately.
+A [*hash*](/windows/desktop/SecGloss/h-gly) is a one way operation that is
+performed on a block of data to create a unique hash value that represents the
+contents of the data. No matter when the hash is performed, the same
+[*hashing algorithm*](/windows/desktop/SecGloss/h-gly) performed on the same
+data will always produce the same hash value. If any of the data changes, the
+hash value will change appropriately.
 
-Hashes are not useful for encrypting data because they are not intended to be used to reproduce the original data from the hash value. Hashes are most useful to verify the integrity of the data when used with an asymmetric signing algorithm. For example, if you hashed a text message, signed the hash, and included the signed hash value with the original message, the recipient could verify the signed hash, create the hash value for the received message, and then compare this hash value with the signed hash value included with the original message. If the two hash values are identical, the recipient can be reasonably sure that the original message has not been modified.
+Hashes are not useful for encrypting data because they are not intended to be
+used to reproduce the original data from the hash value. Hashes are most useful
+to verify the integrity of the data when used with an asymmetric signing
+algorithm. For example, if you hashed a text message, signed the hash, and
+included the signed hash value with the original message, the recipient could
+verify the signed hash, create the hash value for the received message, and
+then compare this hash value with the signed hash value included with the
+original message. If the two hash values are identical, the recipient can be
+reasonably sure that the original message has not been modified.
 
-The size of the hash value is fixed for a particular hashing algorithm. What this means is that no matter how large or small the data block is, the hash value will always be the same size. As an example, the SHA256 hashing algorithm has a hash value size of 256 bits.
+The size of the hash value is fixed for a particular hashing algorithm. What
+this means is that no matter how large or small the data block is, the hash
+value will always be the same size. As an example, the SHA256 hashing algorithm
+has a hash value size of 256 bits.
 
 -   [Creating a Hashing Object](#creating-a-hashing-object)
 -   [Creating a Reusable Hashing Object](#creating-a-reusable-hashing-object)
@@ -22,32 +38,56 @@ The size of the hash value is fixed for a particular hashing algorithm. What thi
 
 To create a hash using CNG, perform the following steps:
 
-1.  Open an algorithm provider that supports the desired algorithm. Typical hashing algorithms include MD2, MD4, MD5, SHA-1, and SHA256. Call the [**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider) function and specify the appropriate algorithm identifier in the *pszAlgId* parameter. The function returns a handle to the provider.
+1.  Open an algorithm provider that supports the desired algorithm. Typical
+    hashing algorithms include MD2, MD4, MD5, SHA-1, and SHA256. Call the
+    [**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider)
+    function and specify the appropriate algorithm identifier in the *pszAlgId*
+    parameter. The function returns a handle to the provider.
+
 2.  Perform the following steps to create the hashing object:
 
-    1.  Obtain the size of the object by calling the [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) function to retrieve the **BCRYPT\_OBJECT\_LENGTH** property.
+    1.  Obtain the size of the object by calling the
+        [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty)
+        function to retrieve the **BCRYPT\_OBJECT\_LENGTH** property.
     2.  Allocate memory to hold the hash object.
-    3.  Create the object by calling the [**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash) function.
+    3.  Create the object by calling the
+        [**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash)
+        function.
 
-3.  Hash the data. This involves calling the [**BCryptHashData**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcrypthashdata) function one or more times. Each call appends the specified data to the hash.
+3.  Hash the data. This involves calling the
+    [**BCryptHashData**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcrypthashdata)
+    function one or more times. Each call appends the specified data to the
+    hash.
+
 4.  Perform the following steps to obtain the hash value:
 
-    1.  Retrieve the size of the value by calling the [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) function to get the **BCRYPT\_HASH\_LENGTH** property.
+    1.  Retrieve the size of the value by calling the
+        [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty)
+        function to get the **BCRYPT\_HASH\_LENGTH** property.
     2.  Allocate memory to hold the value.
-    3.  Retrieve the hash value by calling the [**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash) function. After this function has been called, the hash object is no longer valid.
+    3.  Retrieve the hash value by calling the
+        [**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash)
+        function. After this function has been called, the hash object is no
+        longer valid.
 
 5.  To complete this procedure, you must perform the following cleanup steps:
 
-    1.  Close the hash object by passing the hash handle to the [**BCryptDestroyHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroyhash) function.
+    1.  Close the hash object by passing the hash handle to the
+        [**BCryptDestroyHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroyhash)
+        function.
     2.  Free the memory you allocated for the hash object.
-    3.  If you will not be creating any more hash objects, close the algorithm provider by passing the provider handle to the [**BCryptCloseAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider) function.
+    3.  If you will not be creating any more hash objects, close the algorithm
+        provider by passing the provider handle to the
+        [**BCryptCloseAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider)
+        function.
 
-        If you will be creating more hash objects, we suggest you reuse the algorithm provider rather than creating and destroying the same type of algorithm provider many times.
+        If you will be creating more hash objects, we suggest you reuse the
+        algorithm provider rather than creating and destroying the same type of
+        algorithm provider many times.
 
     4.  When you have finished using the hash value memory, free it.
 
 The following example shows how to create a hash value by using CNG.
-
 
 ```C++
 // THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
@@ -64,191 +104,226 @@ Abstract:
 
 --*/
 
-
 #include <windows.h>
 #include <stdio.h>
 #include <bcrypt.h>
 
+#pragma comment(lib, "bcrypt.lib")
+
+#define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
+#define STATUS_UNSUCCESSFUL ((NTSTATUS)0xC0000001L)
 
 
-#define NT_SUCCESS(Status)          (((NTSTATUS)(Status)) >= 0)
-
-#define STATUS_UNSUCCESSFUL         ((NTSTATUS)0xC0000001L)
+static const BYTE rgbMsg[] = {0x61, 0x62, 0x63};
 
 
-static const BYTE rgbMsg[] = 
-{
-    0x61, 0x62, 0x63
-};
+void wmain_cleanup(
+    BCRYPT_ALG_HANDLE hAlg,
+    BCRYPT_HASH_HANDLE hHash,
+    PBYTE pbHashObject,
+    PBYTE pbHash
+) {
+    if (hAlg) {
+        BCryptCloseAlgorithmProvider(hAlg, 0);
+    }
 
+    if (hHash) {
+        BCryptDestroyHash(hHash);
+    }
 
-void __cdecl wmain(
-                   int                      argc, 
-                   __in_ecount(argc) LPWSTR *wargv)
-{
+    if (pbHashObject) {
+        HeapFree(GetProcessHeap(), 0, pbHashObject);
+    }
 
-    BCRYPT_ALG_HANDLE       hAlg            = NULL;
-    BCRYPT_HASH_HANDLE      hHash           = NULL;
-    NTSTATUS                status          = STATUS_UNSUCCESSFUL;
-    DWORD                   cbData          = 0,
-                            cbHash          = 0,
-                            cbHashObject    = 0;
-    PBYTE                   pbHashObject    = NULL;
-    PBYTE                   pbHash          = NULL;
+    if (pbHash) {
+        HeapFree(GetProcessHeap(), 0, pbHash);
+    }
+}
+
+int __cdecl wmain(int argc, __in_ecount(argc) LPWSTR* wargv) {
+
+    NTSTATUS status = STATUS_UNSUCCESSFUL;
+    BCRYPT_HASH_HANDLE hHash = NULL;
+    BCRYPT_ALG_HANDLE hAlg = NULL;
+    PBYTE pbHashObject = NULL;
+    DWORD cbHashObject = 0;
+    PBYTE pbHash = NULL;
+    DWORD cbData = 0;
+    DWORD cbHash = 0;
 
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(wargv);
 
     //open an algorithm handle
-    if(!NT_SUCCESS(status = BCryptOpenAlgorithmProvider(
-                                                &hAlg,
-                                                BCRYPT_SHA256_ALGORITHM,
-                                                NULL,
-                                                0)))
-    {
-        wprintf(L"**** Error 0x%x returned by BCryptOpenAlgorithmProvider\n", status);
-        goto Cleanup;
+    status = BCryptOpenAlgorithmProvider(
+        &hAlg, BCRYPT_SHA256_ALGORITHM, NULL, 0
+    );
+
+    if (!NT_SUCCESS(status)) {
+        wprintf(
+            L"**** Error 0x%x returned by BCryptOpenAlgorithmProvider\n",
+            status
+        );
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
     //calculate the size of the buffer to hold the hash object
-    if(!NT_SUCCESS(status = BCryptGetProperty(
-                                        hAlg, 
-                                        BCRYPT_OBJECT_LENGTH, 
-                                        (PBYTE)&cbHashObject, 
-                                        sizeof(DWORD), 
-                                        &cbData, 
-                                        0)))
-    {
+    status = BCryptGetProperty(
+        hAlg,
+        BCRYPT_OBJECT_LENGTH,
+        (PBYTE)&cbHashObject,
+        sizeof(DWORD),
+        &cbData,
+        0
+    );
+
+    if (!NT_SUCCESS(status)) {
         wprintf(L"**** Error 0x%x returned by BCryptGetProperty\n", status);
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
     //allocate the hash object on the heap
-    pbHashObject = (PBYTE)HeapAlloc (GetProcessHeap (), 0, cbHashObject);
-    if(NULL == pbHashObject)
-    {
+    pbHashObject = (PBYTE)HeapAlloc(GetProcessHeap(), 0, cbHashObject);
+
+    if (pbHashObject == NULL) {
         wprintf(L"**** memory allocation failed\n");
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
-   //calculate the length of the hash
-    if(!NT_SUCCESS(status = BCryptGetProperty(
-                                        hAlg, 
-                                        BCRYPT_HASH_LENGTH, 
-                                        (PBYTE)&cbHash, 
-                                        sizeof(DWORD), 
-                                        &cbData, 
-                                        0)))
-    {
+    //calculate the length of the hash
+    status = BCryptGetProperty(
+        hAlg,
+        BCRYPT_HASH_LENGTH,
+        (PBYTE)&cbHash,
+        sizeof(DWORD),
+        &cbData,
+        0
+    );
+
+    if (!NT_SUCCESS(status)) {
         wprintf(L"**** Error 0x%x returned by BCryptGetProperty\n", status);
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
     //allocate the hash buffer on the heap
-    pbHash = (PBYTE)HeapAlloc (GetProcessHeap (), 0, cbHash);
-    if(NULL == pbHash)
-    {
+    pbHash = (PBYTE)HeapAlloc(GetProcessHeap(), 0, cbHash);
+
+    if (pbHash == NULL) {
         wprintf(L"**** memory allocation failed\n");
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
     //create a hash
-    if(!NT_SUCCESS(status = BCryptCreateHash(
-                                        hAlg, 
-                                        &hHash, 
-                                        pbHashObject, 
-                                        cbHashObject, 
-                                        NULL, 
-                                        0, 
-                                        0)))
-    {
+    status = BCryptCreateHash(
+        hAlg, &hHash, pbHashObject, cbHashObject, NULL, 0, 0
+    );
+
+    if (!NT_SUCCESS(status)) {
         wprintf(L"**** Error 0x%x returned by BCryptCreateHash\n", status);
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
-    
+
 
     //hash some data
-    if(!NT_SUCCESS(status = BCryptHashData(
-                                        hHash,
-                                        (PBYTE)rgbMsg,
-                                        sizeof(rgbMsg),
-                                        0)))
-    {
+    status = BCryptHashData(hHash, (PBYTE)rgbMsg, sizeof(rgbMsg), 0);
+
+    if (!NT_SUCCESS(status)) {
         wprintf(L"**** Error 0x%x returned by BCryptHashData\n", status);
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
-    
+
     //close the hash
-    if(!NT_SUCCESS(status = BCryptFinishHash(
-                                        hHash, 
-                                        pbHash, 
-                                        cbHash, 
-                                        0)))
-    {
+    status = BCryptFinishHash(hHash, pbHash, cbHash, 0);
+
+    if (!NT_SUCCESS(status)) {
         wprintf(L"**** Error 0x%x returned by BCryptFinishHash\n", status);
-        goto Cleanup;
+        wmain_cleanup(hAlg, hHash, pbHashObject, pbHash);
+        return STATUS_UNSUCCESSFUL;
     }
 
     wprintf(L"Success!\n");
-
-Cleanup:
-
-    if(hAlg)
-    {
-        BCryptCloseAlgorithmProvider(hAlg,0);
-    }
-
-    if (hHash)    
-    {
-        BCryptDestroyHash(hHash);
-    }
-
-    if(pbHashObject)
-    {
-        HeapFree(GetProcessHeap(), 0, pbHashObject);
-    }
-
-    if(pbHash)
-    {
-        HeapFree(GetProcessHeap(), 0, pbHash);
-    }
-
+    return 0;
 }
 
 ```
 
-
-
 ## Creating a Reusable Hashing Object
 
-Beginning with Windows 8 and Windows Server 2012, you can create a reusable hashing object for scenarios that require you to compute multiple hashes or HMACs in rapid succession. Do this by specifying the **BCRYPT\_HASH\_REUSABLE\_FLAG** when calling the [**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider) function. All Microsoft hash algorithm providers support this flag. A hashing object created by using this flag can be reused immediately after calling [**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash) just as if it had been freshly created by calling [**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash). Perform the following steps to create a reusable hashing object:
+Beginning with Windows 8 and Windows Server 2012, you can create a reusable
+hashing object for scenarios that require you to compute multiple hashes or
+HMACs in rapid succession. Do this by specifying the
+**BCRYPT\_HASH\_REUSABLE\_FLAG** when calling the
+[**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider)
+function. All Microsoft hash algorithm providers support this flag. A hashing
+object created by using this flag can be reused immediately after calling
+[**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash)
+just as if it had been freshly created by calling
+[**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash).
+Perform the following steps to create a reusable hashing object:
 
-1.  Open an algorithm provider that supports the desired hashing algorithm. Call the [**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider) function and specify the appropriate algorithm identifier in the *pszAlgId* parameter and **BCRYPT\_HASH\_REUSABLE\_FLAG** in the *dwFlags* parameter. The function returns a handle to the provider.
+1.  Open an algorithm provider that supports the desired hashing algorithm.
+    Call the
+    [**BCryptOpenAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptopenalgorithmprovider)
+    function and specify the appropriate algorithm identifier in the *pszAlgId*
+    parameter and **BCRYPT\_HASH\_REUSABLE\_FLAG** in the *dwFlags* parameter.
+    The function returns a handle to the provider.
+
 2.  Perform the following steps to create the hashing object:
 
-    1.  Obtain the size of the object by calling the [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) function to retrieve the **BCRYPT\_OBJECT\_LENGTH** property.
+    1.  Obtain the size of the object by calling the
+        [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty)
+        function to retrieve the **BCRYPT\_OBJECT\_LENGTH** property.
     2.  Allocate memory to hold the hash object.
-    3.  Create the object by calling the [**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash) function. Specify **BCRYPT\_HASH\_REUSABLE\_FLAG** in the *dwFlags* parameter.
+    3.  Create the object by calling the
+        [**BCryptCreateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptcreatehash)
+        function. Specify **BCRYPT\_HASH\_REUSABLE\_FLAG** in the *dwFlags* parameter.
 
-3.  Hash the data by calling the [**BCryptHashData**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcrypthashdata) function.
+3.  Hash the data by calling the
+    [**BCryptHashData**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcrypthashdata)
+    function.
+
 4.  Perform the following steps to obtain the hash value:
 
-    1.  Obtain the size of the hash value by calling the [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty) function to get the **BCRYPT\_HASH\_LENGTH** property.
+    1.  Obtain the size of the hash value by calling the
+        [**BCryptGetProperty**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptgetproperty)
+        function to get the **BCRYPT\_HASH\_LENGTH** property.
     2.  Allocate memory to hold the value.
-    3.  Get the hash value by calling [**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash).
+    3.  Get the hash value by calling
+        [**BCryptFinishHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptfinishhash).
 
 5.  To reuse the hashing object with new data, go to step 3.
 6.  To complete this procedure, you must perform the following cleanup steps:
 
-    1.  Close the hash object by passing the hash handle to the [**BCryptDestroyHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroyhash) function.
+    1.  Close the hash object by passing the hash handle to the
+        [**BCryptDestroyHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptdestroyhash)
+        function.
     2.  Free the memory you allocated for the hash object.
-    3.  If you will not be creating any more hash objects, close the algorithm provider by passing the provider handle to the [**BCryptCloseAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider) function.
+    3.  If you will not be creating any more hash objects, close the algorithm
+        provider by passing the provider handle to the
+        [**BCryptCloseAlgorithmProvider**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptclosealgorithmprovider)
+        function.
     4.  When you have finished using the hash value memory, free it.
 
 ## Duplicating a Hash Object
 
-In some circumstances, it may be useful to hash some amount of common data and then create two separate hash objects from the common data. You do not have to create two separate hash objects and hash the common data twice to accomplish this. You can create a single hash object and add all of the common data to the hash object. Then, you can use the [**BCryptDuplicateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptduplicatehash) function to create a duplicate of the original hash object. The duplicate hash object contains all of the same state information and hashed data as the original, but it is a completely independent hash object. You can now add the unique data to each of the hash objects and obtain the hash value as shown in the example. This technique is useful when hashing a possibly large amount of common data. You only have to add the common data to the original hash one time, and then you can duplicate the hash object to obtain a unique hash object.
-
- 
-
- 
+In some circumstances, it may be useful to hash some amount of common data and
+then create two separate hash objects from the common data. You do not have to
+create two separate hash objects and hash the common data twice to accomplish
+this. You can create a single hash object and add all of the common data to the
+hash object. Then, you can use the
+[**BCryptDuplicateHash**](/windows/desktop/api/Bcrypt/nf-bcrypt-bcryptduplicatehash)
+function to create a duplicate of the original hash object. The duplicate hash
+object contains all of the same state information and hashed data as the
+original, but it is a completely independent hash object. You can now add the
+unique data to each of the hash objects and obtain the hash value as shown in
+the example. This technique is useful when hashing a possibly large amount of
+common data. You only have to add the common data to the original hash one
+time, and then you can duplicate the hash object to obtain a unique hash
+object.


### PR DESCRIPTION
Improved the code and documentation readability and maintainability. 

Some of the used criteria:

* Goto usage should be discouraged as it may be difficult to debug and dificultes the 
   CPU concurrency optimization and jump predictions.
* Complex nested evaluations in if statements should be discouraged and simplified.
* Excess of white space usage in variables declaration and initialization difficult the 
   code maintainability.
* Code and markdown should respect a max width as large lines may be difficult to 
   read depending on the editor you use.