### PR TITLE
"Using Raw Input": Remove unneeded call to DefRawInputProc()

### DIFF
--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -192,9 +192,6 @@ case MSG_GETRIBUFFER: // Private message
             pri = NEXTRAWINPUTBLOCK(pri);
         }
 
-        // to clean the buffer
-        DefRawInputProc(paRawInput, nInput, sizeof(RAWINPUTHEADER));
-
         free(paRawInput);
     }
     free(pRawInput);


### PR DESCRIPTION
As explained in https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-defrawinputproc, the function doesn't do any processing.