### PR TITLE
Fix case of XML attribute in taskschedulerschema-exec-actiongroup-element.md

### DIFF
--- a/desktop-src/TaskSchd/taskschedulerschema-exec-actiongroup-element.md
+++ b/desktop-src/TaskSchd/taskschedulerschema-exec-actiongroup-element.md
@@ -55,7 +55,7 @@ The **Exec** element is defined by the [**actionGroup**](taskschedulerschema-act
 
 | Name | Type       | Description                                                    |
 |------|------------|----------------------------------------------------------------|
-| Id   | **string** | The identifier of the action performed by the task.<br/> |
+| id   | **string** | The identifier of the action performed by the task.<br/> |
 
 
 


### PR DESCRIPTION
On the Exec element, the correct case of the id attribute is `id` not `Id`.

You can confirm this by checking the schema, or trying to create a task from XML using `schtasks.exe`

XML attribute names are case-sensitive, and using the wrong case causes an error.