### PR TITLE
Fix winmain--the-application-entry-point.md

### DIFF
--- a/desktop-src/LearnWin32/winmain--the-application-entry-point.md
+++ b/desktop-src/LearnWin32/winmain--the-application-entry-point.md
@@ -41,7 +41,7 @@ Here is an empty **WinMain** function.
 
 
 ```C++
-INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     PSTR lpCmdLine, INT nCmdShow)
 {
     return 0;


### PR DESCRIPTION
Add calling convention to example