### PR TITLE
Standard subject to change warning for RtlGetUnloadEventTraceEx

### DIFF
--- a/desktop-src/DevNotes/rtlgetunloadeventtraceex.md
+++ b/desktop-src/DevNotes/rtlgetunloadeventtraceex.md
@@ -17,6 +17,8 @@ api_location:
 
 # RtlGetUnloadEventTraceEx function
 
+\[This function may be changed or removed from Windows without further notice.\]
+
 Retrieves the size and location of the dynamically unloaded module list for the current process.
 
 ## Syntax


### PR DESCRIPTION
The non Ex version has the warning, so I assume that it should be on the Ex version too.