### PR TITLE
[Rejected] Fix damaged note block

### DIFF
--- a/desktop-src/SysInfo/version-helper-apis.md
+++ b/desktop-src/SysInfo/version-helper-apis.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Version Helper functions
 
-The following functions can be used to determine the current operating system version or identify whether it is a Windows or Windows Server release. These functions provide simple tests that use the [VerifyVersionInfo](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function and the recommended greater than or equal to comparisons that are proven as a robust means to determine the operating system version.
+The following functions can be used to determine the current operating system version or identify whether it is a Windows or Windows Server release. These functions provide simple tests that use the [VerifyVersionInfo](/windows/win32/api/Winbase/nf-winbase-verifyversioninfoa) function and the recommended greater than or equal to comparisons that are proven as a robust means to determine the operating system version.
 
 > [!Note]  
 > These APIs are defined by **versionhelpers.h**, which is included in the Windows 8.1 software development kit (SDK). This file can be used with other Microsoft Visual Studio releases to implement the same functionality for Windows versions prior to Windows 8.1.
@@ -76,11 +76,8 @@ The following functions can be used to determine the current operating system ve
 <tr class="even">
 <td><a href="/windows/desktop/api/VersionHelpers/nf-versionhelpers-iswindowsversionorgreater"><strong>IsWindowsVersionOrGreater</strong></a></td>
 <td>
-
-> [!Note]  
-> You should only use this function if the other provided version helper functions do not fit your scenario.
-
-Indicates if the current OS version matches, or is greater than, the provided version information. This function is useful in confirming a version of Windows Server that doesn't share a version number with a client release.
+<blockquote>You should only use this function if the other provided version helper functions do not fit your scenario.</blockquote>
+<br/>Indicates if the current OS version matches, or is greater than, the provided version information. This function is useful in confirming a version of Windows Server that doesn't share a version number with a client release.
 </td>
 </tr>
 </tbody>
@@ -95,10 +92,10 @@ For example, if your application requires Windows 8 or later, use the following 
 ```C++
 #include <VersionHelpers.h>
  
-    if (!IsWindows8OrGreater())
-    {
-       MessageBox(NULL, "You need at least Windows 8", "Version Not Supported", MB_OK);
-    }
+if (!IsWindows8OrGreater())
+{
+   MessageBox(NULL, "You need at least Windows 8", "Version Not Supported", MB_OK);
+}
 ```
 
 ## Related topics

--- a/desktop-src/SysInfo/version-helper-apis.md
+++ b/desktop-src/SysInfo/version-helper-apis.md
@@ -8,20 +8,12 @@ ms.date: 05/31/2018
 
 # Version Helper functions
 
-The following functions can be used to determine the current operating system version or identify whether it is a Windows or Windows Server release. These functions provide simple tests that use the [**VerifyVersionInfo**](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function and the recommended greater than or equal to comparisons that are proven as a robust means to determine the operating system version.
+The following functions can be used to determine the current operating system version or identify whether it is a Windows or Windows Server release. These functions provide simple tests that use the [VerifyVersionInfo](/windows/desktop/api/Winbase/nf-winbase-verifyversioninfoa) function and the recommended greater than or equal to comparisons that are proven as a robust means to determine the operating system version.
 
 > [!Note]  
 > These APIs are defined by **versionhelpers.h**, which is included in the Windows 8.1 software development kit (SDK). This file can be used with other Microsoft Visual Studio releases to implement the same functionality for Windows versions prior to Windows 8.1.
 
- 
-
-
-
 <table>
-<colgroup>
-<col style="width: 50%" />
-<col style="width: 50%" />
-</colgroup>
 <thead>
 <tr class="header">
 <th>Function</th>
@@ -83,25 +75,22 @@ The following functions can be used to determine the current operating system ve
 </tr>
 <tr class="even">
 <td><a href="/windows/desktop/api/VersionHelpers/nf-versionhelpers-iswindowsversionorgreater"><strong>IsWindowsVersionOrGreater</strong></a></td>
-<td><blockquote>
-[!Note]<br />
-You should only use this function if the other provided version helper functions do not fit your scenario.
-</blockquote>
-<br/> Indicates if the current OS version matches, or is greater than, the provided version information. This function is useful in confirming a version of Windows Server that doesn't share a version number with a client release.<br/></td>
+<td>
+
+> [!Note]  
+> You should only use this function if the other provided version helper functions do not fit your scenario.
+
+Indicates if the current OS version matches, or is greater than, the provided version information. This function is useful in confirming a version of Windows Server that doesn't share a version number with a client release.
+</td>
 </tr>
 </tbody>
 </table>
-
-
-
- 
 
 ## Example
 
 The inline functions defined in the **VersionHelpers.h** header file let you verify the operating system version by returning a **Boolean** value when testing for a version of Windows.
 
 For example, if your application requires Windows 8 or later, use the following test.
-
 
 ```C++
 #include <VersionHelpers.h>
@@ -112,19 +101,6 @@ For example, if your application requires Windows 8 or later, use the following 
     }
 ```
 
-
-
 ## Related topics
 
-<dl> <dt>
-
-[**OSVERSIONINFOEX**](/windows/desktop/api/Winnt/ns-winnt-osversioninfoexa)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
+- [OSVERSIONINFOEX](/windows/desktop/api/Winnt/ns-winnt-osversioninfoexa)


### PR DESCRIPTION
**This proposal has been rejected** with the following note from the author:

> Unfortunately, ]markdown formatting is not allowed in HTML tables. I adjusted the text formatting accordingly.

Original text:
>The PR intends to fix the damaged state of the "Version Helper functions" page on Microsoft Docs. Perhaps a couple of images best show what it tries to accomplish.
>
>Currently, the page looks like this:
>![How it is](https://user-images.githubusercontent.com/17097175/111882801-c8323780-89cc-11eb-8afb-e4766b392d1a.png)
>
>I believe the author intended it to look like this:
>![How it must be](https://user-images.githubusercontent.com/17097175/111882775-a9cc3c00-89cc-11eb-8d85-cbf1932b1179.png)

