### PR TITLE
Fix code example to assign to hr before reading it

### DIFF
--- a/desktop-src/DirectWrite/how-to-align-text.md
+++ b/desktop-src/DirectWrite/how-to-align-text.md
@@ -12,9 +12,11 @@ You can align [DirectWrite](direct-write-portal.md) text by using the [**SetText
 
 
 ```C++
-if (SUCCEEDED(hr))
+HRESULT hr = pTextFormat_->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+
+if (FAILED(hr))
 {
-    hr = pTextFormat_->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    // Report the error
 }
 ```
 


### PR DESCRIPTION
The example read the variable `hr` before it was checked. I fixed the code to handle the possible error from the function call.