### PR TITLE
Updated notes for D3DX_DXGIFormatConvert.inl

### DIFF
--- a/desktop-src/direct3dhlsl/format-conversion-functions.md
+++ b/desktop-src/direct3dhlsl/format-conversion-functions.md
@@ -4,11 +4,11 @@ description: The section contains the format conversion functions used in Comput
 ms.assetid: 05575ee8-4428-437f-bfb6-e5c676405d65
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - apiref
-api_name: 
-api_type: 
-api_location: 
+api_name:
+api_type:
+api_location:
 ---
 
 # Format conversion functions (HLSL reference)
@@ -17,6 +17,8 @@ The section contains the format conversion functions used in Compute and Pixel S
 
 -   [Converter Functions](#converter-functions)
 -   [Related topics](#related-topics)
+
+> The D3DX_DXGIFormatConvert.inl header ships in the legacy DirectX SDK and relied on XNAMath for C++ support. It is also included in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet package. The latest version uses DirectXMath for C++ support, and all functions are defined in the **DirectX** C++ namespace.
 
 ## Converter Functions
 
@@ -164,7 +166,3 @@ The section contains the format conversion functions used in Compute and Pixel S
  
 
  
-
-
-
-

--- a/desktop-src/direct3dhlsl/inline-format-conversion-reference.md
+++ b/desktop-src/direct3dhlsl/inline-format-conversion-reference.md
@@ -4,11 +4,11 @@ description: This section contains the following sections.
 ms.assetid: 75e7ff03-0946-406d-a769-73f3da8d1dc1
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - kbArticle
-api_name: 
-api_type: 
-api_location: 
+api_name:
+api_type:
+api_location:
 ---
 
 # Inline Format Conversion Reference
@@ -17,6 +17,8 @@ This section contains the following sections
 
 -   [Functions](format-conversion-functions.md)
 -   [Structures](format-conversion-structures.md)
+
+> The D3DX_DXGIFormatConvert.inl header ships in the legacy DirectX SDK and relied on XNAMath for C++ support. It is also included in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet package. The latest version uses DirectXMath for C++ support, and all functions are defined in the **DirectX** C++ namespace.
 
 ## Related topics
 
@@ -31,7 +33,3 @@ This section contains the following sections
  
 
  
-
-
-
-

--- a/desktop-src/direct3dhlsl/xmint2.md
+++ b/desktop-src/direct3dhlsl/xmint2.md
@@ -50,6 +50,14 @@ y-component of the vector.
 
 </dd> </dl>
 
+
+
+## Remarks
+
+This structure is defined in the ``D3DX\_DXGIFormatConvert.inl`` header in the DirectX SDK (June 2010) for use from C++. The latest version of this header in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet Package no longer defines it, and relies on [DirectX::XMINT2](https://docs.microsoft.com/en-us/windows/win32/api/directxmath/ns-directxmath-xmint2) in DirectXMath instead.
+
+
+
 ## Requirements
 
 
@@ -69,12 +77,3 @@ y-component of the vector.
 
 [Unpacking and Packing DXGI\_FORMAT for In-Place Image Editing](dx-graphics-hlsl-unpacking-packing-dxgi-format.md)
 </dt> </dl>
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/xmint4.md
+++ b/desktop-src/direct3dhlsl/xmint4.md
@@ -78,6 +78,12 @@ w-component of the vector.
 
 
 
+## Remarks
+
+This structure is defined in the ``D3DX\_DXGIFormatConvert.inl`` header in the DirectX SDK (June 2010) for use from C++. The latest version of this header in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet Package no longer defines it, and relies on [DirectX::XMINT4](https://docs.microsoft.com/en-us/windows/win32/api/directxmath/ns-directxmath-xmint4) in DirectXMath instead.
+
+
+
 ## See also
 
 <dl> <dt>
@@ -87,12 +93,3 @@ w-component of the vector.
 
 [Unpacking and Packing DXGI\_FORMAT for In-Place Image Editing](dx-graphics-hlsl-unpacking-packing-dxgi-format.md)
 </dt> </dl>
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/xmuint2.md
+++ b/desktop-src/direct3dhlsl/xmuint2.md
@@ -50,6 +50,14 @@ y-component of the vector.
 
 </dd> </dl>
 
+
+
+## Remarks
+
+This structure is defined in the ``D3DX\_DXGIFormatConvert.inl`` header in the DirectX SDK (June 2010) for use from C++. The latest version of this header in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet Package no longer defines it, and relies on [DirectX::XMUINT2](https://docs.microsoft.com/en-us/windows/win32/api/directxmath/ns-directxmath-xmuint2) in DirectXMath instead.
+
+
+
 ## Requirements
 
 
@@ -69,12 +77,3 @@ y-component of the vector.
 
 [Unpacking and Packing DXGI\_FORMAT for In-Place Image Editing](dx-graphics-hlsl-unpacking-packing-dxgi-format.md)
 </dt> </dl>
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/xmuint4.md
+++ b/desktop-src/direct3dhlsl/xmuint4.md
@@ -68,6 +68,16 @@ w-component of the vector.
 
 </dd> </dl> </dd> </dl> </dd> </dl>
 
+
+
+
+## Remarks
+
+This structure is defined in the ``D3DX\_DXGIFormatConvert.inl`` header in the DirectX SDK (June 2010) for use from C++. The latest version of this header in the [Microsoft.DXSDK.D3DX](https://www.nuget.org/packages/Microsoft.DXSDK.D3DX) NuGet Package no longer defines it, and relies on [DirectX::XMUINT4](https://docs.microsoft.com/en-us/windows/win32/api/directxmath/ns-directxmath-xmuint4) in DirectXMath instead.
+
+
+
+
 ## Requirements
 
 
@@ -87,12 +97,3 @@ w-component of the vector.
 
 [Unpacking and Packing DXGI\_FORMAT for In-Place Image Editing](dx-graphics-hlsl-unpacking-packing-dxgi-format.md)
 </dt> </dl>
-
- 
-
- 
-
-
-
-
-


### PR DESCRIPTION
``D3DX_DXGIFormatConvert.inl`` originally shipped in the legacy DirectX SDK. It now ships in the Microsoft.DXSDK.D3DX NuGet.

I recently updated the package so that the headers work better with the modern Windows SDK, including updating this header from XNAMath (DXSDK) to DirectXMath.

> The whitespace change all came from using Atom to edit.