### PR TITLE
Invalid return value specified for OpenDatabase

### DIFF
--- a/desktop-src/Msi/installer-opendatabase.md
+++ b/desktop-src/Msi/installer-opendatabase.md
@@ -66,8 +66,8 @@ A parameter from the following list or a string that contains the path name of t
 </dd> </dl>
 
 ## Return value
-
-[**Database**](database-object.md)
+ 
+A [**Database**](database-object.md) object that represents the existing or new  installer database that was opened.
 
 ## Remarks
 

--- a/desktop-src/Msi/installer-opendatabase.md
+++ b/desktop-src/Msi/installer-opendatabase.md
@@ -67,7 +67,7 @@ A parameter from the following list or a string that contains the path name of t
 
 ## Return value
 
-This method does not return a value.
+[**Database**](database-object.md)
 
 ## Remarks
 

--- a/desktop-src/Msi/installer-opendatabase.md
+++ b/desktop-src/Msi/installer-opendatabase.md
@@ -66,8 +66,8 @@ A parameter from the following list or a string that contains the path name of t
 </dd> </dl>
 
 ## Return value
- 
-A [**Database**](database-object.md) object that represents the existing or new  installer database that was opened.
+
+A [**Database**](database-object.md) object that represents the existing or new installer database that was opened.
 
 ## Remarks
 


### PR DESCRIPTION
In the description it says the method returns a Database object but in Return value it says it returns nothing.

Seems like multiple methods of the Installer object have the same issue. Missing return value.