### PR TITLE
Update countbits.md

### DIFF
--- a/desktop-src/direct3dhlsl/countbits.md
+++ b/desktop-src/direct3dhlsl/countbits.md
@@ -17,7 +17,7 @@ api_location:
 
 # countbits function
 
-Counts the number of bits (per component) in the input integer.
+Counts the number of bits (per component) set in the input integer.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/countbits.md
+++ b/desktop-src/direct3dhlsl/countbits.md
@@ -1,6 +1,6 @@
 ---
 title: countbits function
-description: Counts the number of bits (per component) in the input integer.
+description: Counts the number of bits (per component) set in the input integer.
 ms.assetid: c4fafbc8-e21c-48cb-b433-8241a989ec85
 keywords:
 - countbits function HLSL


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/countbits---sm5---asm-
Here we have the following description :

>    **_Counts the number of bits set in a number_**

Meantime in the current page of documentation the following :

>    **_Counts the number of bits (per component) in the input integer_**

And then the question appears. 
  

> Does it work like **_sizeof_** in C++, or it work like the function from the first link?

In attempt to avoid this question, added one word in description.

