### PR TITLE
The D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY link is dead

### DIFF
--- a/desktop-src/WmiCoreProv/wmimonitorconnectionparams.md
+++ b/desktop-src/WmiCoreProv/wmimonitorconnectionparams.md
@@ -85,7 +85,7 @@ Data type: **uint32**
 Access type: Read-only
 </dt> </dl>
 
-Video output technology connection type. Valid values are documented in the [D3DKMDT\_VIDEO\_OUTPUT\_TECHNOLOGY](https://msdn.microsoft.com/library/ms794498.aspx) (<--fix this please) enumeration.
+Video output technology connection type. Valid values are documented in the [D3DKMDT\_VIDEO\_OUTPUT\_TECHNOLOGY](/windows-hardware/drivers/ddi/d3dkmdt/ne-d3dkmdt-_d3dkmdt_video_output_technology) enumeration.
 
 </dd> </dl>
 

--- a/desktop-src/WmiCoreProv/wmimonitorconnectionparams.md
+++ b/desktop-src/WmiCoreProv/wmimonitorconnectionparams.md
@@ -85,7 +85,7 @@ Data type: **uint32**
 Access type: Read-only
 </dt> </dl>
 
-Video output technology connection type. Valid values are documented in the [D3DKMDT\_VIDEO\_OUTPUT\_TECHNOLOGY](https://msdn.microsoft.com/library/ms794498.aspx) enumeration.
+Video output technology connection type. Valid values are documented in the [D3DKMDT\_VIDEO\_OUTPUT\_TECHNOLOGY](https://msdn.microsoft.com/library/ms794498.aspx) (<--fix this please) enumeration.
 
 </dd> </dl>
 


### PR DESCRIPTION
https://msdn.microsoft.com/library/ms794498.aspx redirects to docs homepage. instead of intended D3DKMDT_VIDEO_OUTPUT_TECHNOLOGY page