### PR TITLE
Fix link to blog post about Windows 10 file association changes.

### DIFF
--- a/desktop-src/shell/vista-managing-defaults.md
+++ b/desktop-src/shell/vista-managing-defaults.md
@@ -11,7 +11,7 @@ ms.date: 05/31/2018
 The **Set Program Access and Computer Defaults** (SPAD) feature was added to Windows XP and later versions of Windows to manage per-computer defaults. In addition to SPAD, Windows Vista introduced the concept of per-user default applications and the **Default Programs** item in Control Panel.
 
 > [!IMPORTANT]
-> This topic does not apply for Windows 10. The way that default file associations work changed in Windows 10. For more information, see the section on **Changes to how Windows 10 handles default apps** in [this post](https://blogs.windows.com/bloggingwindows/2015/05/20/announcing-windows-10-insider-preview-build-10122-for-pcs/).
+> This topic does not apply for Windows 10. The way that default file associations work changed in Windows 10. For more information, see the section on **Changes to how Windows 10 handles default apps** in [this post](https://blogs.windows.com/windows-insider/2015/05/20/announcing-windows-10-insider-preview-build-10122-for-pcs/).
 
  
 


### PR DESCRIPTION
The URL keeps redirecting between itself (https) and the http version in a loop.

Maybe the information in the blog post regarding *Changes to how Windows 10 handles default apps* should be added to the docs if that hasn't been done already?