### PR TITLE
HLSL compiler #pragma message fix

### DIFF
--- a/desktop-src/direct3dhlsl/message-pragma-directive--directx-hlsl-.md
+++ b/desktop-src/direct3dhlsl/message-pragma-directive--directx-hlsl-.md
@@ -21,7 +21,7 @@ Pragma directive that produces compiler-time messages.
 
 
 
-| \#pragma message "*token-string*" |
+| \#pragma message("*token-string*") |
 |-----------------------------------|
 
 


### PR DESCRIPTION
The example doesn't actually work as-is (nothing is printed by fxc.exe), but just wrapping it with parens fixes it and prints the message.