### PR TITLE
Update dx-graphics-hlsl-writing-shaders-9.md

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-writing-shaders-9.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-writing-shaders-9.md
@@ -688,7 +688,7 @@ This example returns the scalar result of an expression:
 
 
 ```
-return  light.enabled = true ;
+return  light.enabled;
 ```
 
 


### PR DESCRIPTION
return  light.enabled = true;
Equality operator (==) should not be confused with the assignment operator(=).
Since light.enabled is a boolean value, just return it.