### PR TITLE
Update international-components-for-unicode--icu.md: CoInitializeEx is only needed on Windows < 1903

### DIFF
--- a/desktop-src/Intl/international-components-for-unicode--icu-.md
+++ b/desktop-src/Intl/international-components-for-unicode--icu-.md
@@ -96,7 +96,7 @@ Then, you can call whatever ICU C API from these libraries you want. (No C++ API
 > [!Note]  
 >
 > - This is the configuration for “All Platforms”.
-> - For Win32 apps to use ICU on Windows versions before 1903, they need to call [CoInitializeEx](/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex) first.
+> - For Win32 apps to use ICU, they need to call [CoInitializeEx](/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex) first. On Windows 10 version 1903 and above, where the combined ICU library (icu.dll/icu.lib) is available, you can omit the CoInitializeEx call by using the combined library.
 > - Not all data returned by ICU APIs will align with the Windows OS, as this alignment work is still in progress. 
 
 ## ICU Example App

--- a/desktop-src/Intl/international-components-for-unicode--icu-.md
+++ b/desktop-src/Intl/international-components-for-unicode--icu-.md
@@ -96,7 +96,7 @@ Then, you can call whatever ICU C API from these libraries you want. (No C++ API
 > [!Note]  
 >
 > - This is the configuration for “All Platforms”.
-> - For Win32 apps to use ICU, they need to call [CoInitializeEx](/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex) first.
+> - For Win32 apps to use ICU on Windows versions before 1903, they need to call [CoInitializeEx](/windows/win32/api/combaseapi/nf-combaseapi-coinitializeex) first.
 > - Not all data returned by ICU APIs will align with the Windows OS, as this alignment work is still in progress. 
 
 ## ICU Example App


### PR DESCRIPTION
[That's what Raymond Chen says, anyway.](https://devblogs.microsoft.com/oldnewthing/20210527-00/?p=105255) @jefgen or @daniel-ju - I believe you're the domain experts here; would you kindly fact check me when you get time?