### PR TITLE
Fixed CODECAPI_AVLowLatencyMode variant type

### DIFF
--- a/desktop-src/medfound/codecapi-avlowlatencymode.md
+++ b/desktop-src/medfound/codecapi-avlowlatencymode.md
@@ -12,7 +12,7 @@ Enables low-latency mode in a codec.
 
 ## Data type
 
-**ULONG** (**VT\_BOOL**)
+**USHORT** (**VT\_UI4**)
 
 ## Property GUID
 


### PR DESCRIPTION
Using the suggested `VT_BOOL` variant type throws an exception with the message `WinRT originate error - 0x80070057 : 'Invalid argument (VT_UI4 != pValue->vt)'` and causes `SetValue()` to return `E_INVALIDARG`. Changing the variant type to `VT_UI4` fixes this issue.

Windows 10 retail build 19041.985