### PR TITLE
Fix code example typos

### DIFF
--- a/desktop-src/gdi/setting-and-retrieving-the-device-context-brush-color-value.md
+++ b/desktop-src/gdi/setting-and-retrieving-the-device-context-brush-color-value.md
@@ -13,10 +13,10 @@ The following example shows how an application can retrieve the current DC brush
 
 ```C++
 SelectObject(hdc,GetStockObject(DC_BRUSH));
-SetDCBrushColor(hdc, RGB(00,0xff;00);
-PatBlt(0,0,200,200,PATCOPY)
-SetDCBrushColor(hdc,RGB(00,00,0xff);
-PatBlt(0,0,200,200,PATCOPY);
+SetDCBrushColor(hdc,RGB(00,0xff,00));
+PatBlt(hdc,0,0,200,200,PATCOPY);
+SetDCBrushColor(hdc,RGB(00,00,0xff));
+PatBlt(hdc,0,0,200,200,PATCOPY);
 ```
 
 


### PR DESCRIPTION
Added missing first HDC param to PatBlt and fixed missing ending collum and misplaced semicolon.