### PR TITLE
Fixes markdown for "mofcomp MOFfile.mof"

### DIFF
--- a/desktop-src/WmiSdk/running-the-mof-compiler-on-a-file.md
+++ b/desktop-src/WmiSdk/running-the-mof-compiler-on-a-file.md
@@ -17,7 +17,7 @@ Until you run the MOF compiler, [**Mofcomp.exe**](mofcomp.md), a provider is not
 
 1.  Call the MOF compiler from the command line, using the following syntax.
 
-    **mofcomp** *MOFfile***.mof**
+    **mofcomp** _MOFfile_**.mof**
 
     The MOF compiler supports a variety of switches to control special processing situations. All of the switches are optional, and any combination of switches is allowed. However, it does not make sense to use some of the switches in combination with others. For example, to combine the **-class:updateonly** and **-class:createonly** switches results in the compiler not performing any action.
 


### PR DESCRIPTION
Markdown was incorrect for "mofcomp MOFfile.mof"