### PR TITLE
Update wer-settings.md

### DIFF
--- a/desktop-src/wer/wer-settings.md
+++ b/desktop-src/wer/wer-settings.md
@@ -384,7 +384,7 @@ The maximum number of full live dumps that may be on disk at any given time. The
 
 **REG\_QWORD**
 
-A [SystemTime](/windows/desktop/api/minwinbase/ns-minwinbase-systemtime) indicating the last full live report time, for the system or a specific ReportType. This is used to calculate whether a policy threshold has been satisfied.
+A [FileTime](/windows/desktop/api/minwinbase/ns-minwinbase-filetime) indicating the last full live report time, for the system or a specific ReportType. This is used to calculate whether a policy threshold has been satisfied.
 
 </dd> <dt>
 


### PR DESCRIPTION
I believe the LastFullLiveReport value is a FileTime value, not a SystemTime value, at least on my Windows 10, version 20H2, build 19042.1052 x64 edition.