### PR TITLE
Update dwritecore-overview.md with link to DX Landing Page

### DIFF
--- a/desktop-src/DirectWrite/dwritecore-overview.md
+++ b/desktop-src/DirectWrite/dwritecore-overview.md
@@ -14,7 +14,8 @@ DWriteCore is the [Project Reunion](/windows/apps/project-reunion/) implementati
 
 This introductory topic describes what DWriteCore is, and shows how to install it into your dev environment and program with it.
 
-Make sure that you visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/) for more resources for DirectX developers.
+> [!TIP]
+> For descriptions of, and links to, DirectX components in active development, see the blog post [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/).
 
 ## The value proposition of DWriteCore
 

--- a/desktop-src/DirectWrite/dwritecore-overview.md
+++ b/desktop-src/DirectWrite/dwritecore-overview.md
@@ -14,6 +14,8 @@ DWriteCore is the [Project Reunion](/windows/apps/project-reunion/) implementati
 
 This introductory topic describes what DWriteCore is, and shows how to install it into your dev environment and program with it.
 
+Make sure that you visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/) for more resources for DirectX developers.
+
 ## The value proposition of DWriteCore
 
 [DirectWrite](./direct-write-portal.md) itself supports a rich array of features that makes it the font-rendering tool of choice on Windows for most apps&mdash;whether that's through direct calls, or via [Direct2D](../direct2d/direct2d-portal.md). DirectWrite includes a device-independent text layout system, high quality sub-pixel [Microsoft ClearType](/typography/cleartype/) text rendering, hardware-accelerated text, multi-format text, advanced [OpenType®](/typography/opentype/) typography features, wide language support, and [GDI](../gdi/windows-gdi.md)-compatible layout and rendering. DirectWrite has been available since Windows Vista SP2, and it has evolved over the years to include more advanced features such as variable fonts, which enables you to apply styles, weights, and other attributes to a font with only one font resource.

--- a/desktop-src/DirectWrite/dwritecore-overview.md
+++ b/desktop-src/DirectWrite/dwritecore-overview.md
@@ -15,7 +15,7 @@ DWriteCore is the [Project Reunion](/windows/apps/project-reunion/) implementati
 This introductory topic describes what DWriteCore is, and shows how to install it into your dev environment and program with it.
 
 > [!TIP]
-> For descriptions of, and links to, DirectX components in active development, see the blog post [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/).
+> For descriptions of and links to DirectX components in active development, see the blog post [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/).
 
 ## The value proposition of DWriteCore
 


### PR DESCRIPTION
Added link to the DirectX Landing Page at the top of this readme to make sure all DX-related components link back to our new single source of truth.