### PR TITLE
Corrected typo FIPS-complaint to FIPS-compliant

### DIFF
--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
@@ -19,7 +19,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
 
 For Windows Server 2022, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 


### PR DESCRIPTION
The proper word is COMPLIANT, not complaint