### PR TITLE
Qualify outdated references to Freecell, Solitaire, Minesweeper

### DIFF
--- a/desktop-src/Controls/cookbook-overview.md
+++ b/desktop-src/Controls/cookbook-overview.md
@@ -115,10 +115,10 @@ The following topics describe the steps for applying visual styles to different 
 The following are examples of applications that do not use third-party extensions.
 
 -   Calculator
--   FreeCell
--   Minesweeper
+-   FreeCell (in Windows Vista and Windows 7)
+-   Minesweeper (in Windows Vista and Windows 7)
 -   Notepad
--   Solitaire
+-   Solitaire (in Windows Vista and Windows 7)
 
 **To create a manifest and enable your application to use visual styles.**
 


### PR DESCRIPTION
These games aren't included with clean installs of operating system as of Windows 8 and later. 

Games with similar functionalities are on the Microsoft Store, however this page isn't referring to those. To fix this it should qualify what OS they were part of.

This change pertains to the page [https://docs.microsoft.com/en-us/windows/win32/controls/cookbook-overview](https://docs.microsoft.com/en-us/windows/win32/controls/cookbook-overview)