### PR TITLE
Reparse point limit is not always 63

### DIFF
--- a/desktop-src/FileIO/reparse-points.md
+++ b/desktop-src/FileIO/reparse-points.md
@@ -21,7 +21,7 @@ The following restrictions apply to reparse points:
 -   Reparse point data, including the tag and optional **GUID**, cannot exceed 16 kilobytes. Setting a reparse point fails if the amount of data to be placed in the reparse point exceeds this limit.
 -   There is a limit of 63 reparse points on any given path.
     
-    **NOTE:** The limit can be reduced depending on the length of the reparse point e.g: if your reparse point targets a fully qualified path, the limit becomes 31.
+    **NOTE:** The limit can be reduced depending on the length of the reparse point. For example, if your reparse point targets a fully qualified path, the limit becomes 31.
     
     **Windows Server 2003 and Windows XP:** There is a limit of 31 reparse points on any given path.
 

--- a/desktop-src/FileIO/reparse-points.md
+++ b/desktop-src/FileIO/reparse-points.md
@@ -20,7 +20,9 @@ The following restrictions apply to reparse points:
 -   Reparse points and extended attributes are mutually exclusive. The NTFS file system cannot create a reparse point when the file contains extended attributes, and it cannot create extended attributes on a file that contains a reparse point.
 -   Reparse point data, including the tag and optional **GUID**, cannot exceed 16 kilobytes. Setting a reparse point fails if the amount of data to be placed in the reparse point exceeds this limit.
 -   There is a limit of 63 reparse points on any given path.
-
+    
+    **NOTE:** The limit can be reduced depending on the length of the reparse point e.g: if your reparse point targets a fully qualified path, the limit becomes 31.
+    
     **Windows Server 2003 and Windows XP:** There is a limit of 31 reparse points on any given path.
 
 ## In this section


### PR DESCRIPTION
Empirically, I can see that when you use a full path as the target, the limit becomes 31.
However, I am not sure what's the exact logic behind.

Here's the code I used: https://gist.github.com/Jozkee/189555fd29796d9cd6068fa093f480e7