### PR TITLE
Fix typos in programmatic default DPI API table

### DIFF
--- a/desktop-src/hidpi/setting-the-default-dpi-awareness-for-a-process.md
+++ b/desktop-src/hidpi/setting-the-default-dpi-awareness-for-a-process.md
@@ -110,10 +110,10 @@ There are multiple APIs that let you specify the default DPI awareness for your 
 </thead>
 <tbody>
 <tr class="odd">
-<td><a href="/windows/win32/api/winuser/nf-winuser-setprocessdpiaware">SetProcessDpiAware</a></td>
+<td><a href="/windows/win32/api/winuser/nf-winuser-setprocessdpiaware">SetProcessDPIAware</a></td>
 <td>Windows Vista</td>
 <td>N/A</td>
-<td>SetProcessDpiAware()</td>
+<td>SetProcessDPIAware()</td>
 <td>N/A</td>
 </tr>
 <tr class="even">

--- a/desktop-src/hidpi/setting-the-default-dpi-awareness-for-a-process.md
+++ b/desktop-src/hidpi/setting-the-default-dpi-awareness-for-a-process.md
@@ -120,8 +120,8 @@ There are multiple APIs that let you specify the default DPI awareness for your 
 <td><a href="/windows/win32/api/shellscalingapi/nf-shellscalingapi-setprocessdpiawareness"><strong>SetProcessDpiAwareness</strong></a></td>
 <td>Windows 8.1</td>
 <td>SetProcessDpiAwareness(PROCESS_DPI_UNAWARE)</td>
-<td>SetProcessDpiAwareness(PROCESS_DPI_SYSTEM_DPI_AWARE)</td>
-<td>SetProcessDpiAwareness(PROCESS_DPI_PER_MONITOR_DPI_AWARE)</td>
+<td>SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)</td>
+<td>SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)</td>
 </tr>
 <tr class="odd">
 <td><a href="/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext"><strong>SetProcessDpiAwarenessContext</strong></a></td>


### PR DESCRIPTION
- `SetProcessDpiAwareness` accepts an argument from the [`PROCESS_DPI_AWARENESS` enum](https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/ne-shellscalingapi-process_dpi_awareness), but the arguments in the examples have typos.
- The correct capitalization for the API is `SetProcessDPIAware`, not `SetProcessDpiAware`.