### PR TITLE
Fixed a critical error in the documentation

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-per-component-math.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-per-component-math.md
@@ -423,9 +423,9 @@ A column-major matrix is laid out like the following:
         34<br/>
     :::column-end:::
     :::column:::
-        14<br/>
-        24<br/>
-        34<br/>
+        41<br/>
+        42<br/>
+        43<br/>
         44<br/>
     :::column-end:::
 :::row-end:::


### PR DESCRIPTION
According to the previous version of the documentation, column-major matrices (which happen to be the default in HLSL) store elements 14, 24, 34 twice, and don’t store elements 41, 42, 43 at all.

That’s not how they work.