### PR TITLE
Adding note about scope of queries supported

### DIFF
--- a/desktop-src/ADSI/attribute-range-retrieval.md
+++ b/desktop-src/ADSI/attribute-range-retrieval.md
@@ -45,7 +45,7 @@ There are several different ways to retrieve a range of property values. The [**
 
 If an automation language is used, the ActiveX Directory Objects (ADO) can be used to retrieve a range of property values. For more information about using ADO for range retrieval, see [Using ADO for Range Retrieval](using-ado-for-range-retrieval.md).
 
-If C++ is used, the [**IDirectorySearch**](/windows/desktop/api/Iads/nn-iads-idirectorysearch) and [**IDirectoryObject**](/windows/desktop/api/Iads/nn-iads-idirectoryobject) interfaces can be used to retrieve a range of property values. For more information about using **IDirectorySearch** and **IDirectoryObject** for range retrieval, see [Using IDirectorySearch and IDirectoryObject for Range Retrieval](using-idirectorysearch-and-idirectoryobject-for-range-retrieval.md).
+If C++ is used, the [**IDirectorySearch**](/windows/desktop/api/Iads/nn-iads-idirectorysearch) and [**IDirectoryObject**](/windows/desktop/api/Iads/nn-iads-idirectoryobject) interfaces can be used to retrieve a range of property values. For more information about using **IDirectorySearch** and **IDirectoryObject** for range retrieval, see [Using IDirectorySearch and IDirectoryObject for Range Retrieval](using-idirectorysearch-and-idirectoryobject-for-range-retrieval.md).  This type of retrieval should be done on queries with a scope type of Base (ADS_SCOPE_BASE).
 
  
 


### PR DESCRIPTION
A customer brought this up, and after conferring with our AD escalation engineers, this type of retrieval needs a base scope query (or a subtree search that returns one item).  Otherwise, results may, and after are, missing.  This is the long term behavior so I believe that documenting it rather than looking into changing it makes the the most sense.