### PR TITLE
Fix reference to BC1 which should be BC4

### DIFF
--- a/desktop-src/direct3d10/d3d10-graphics-programming-guide-resources-block-compression.md
+++ b/desktop-src/direct3d10/d3d10-graphics-programming-guide-resources-block-compression.md
@@ -46,9 +46,9 @@ The uncompressed data is laid out in memory sequentially and requires 16 bytes, 
 
 ### Storing Compressed Data
 
-Now that you've seen how much memory an uncompressed image uses, take a look at how much memory a compressed image saves. The [BC1](#bc1) compression format stores 2 colors (1 byte each) and 16 3-bit indices (48 bits, or 6 bytes) that are used to interpolate the original colors in the texture, as shown in the following illustration.
+Now that you've seen how much memory an uncompressed image uses, take a look at how much memory a compressed image saves. The [BC4](#bc4) compression format stores 2 colors (1 byte each) and 16 3-bit indices (48 bits, or 6 bytes) that are used to interpolate the original colors in the texture, as shown in the following illustration.
 
-![illustration of the bc1 compression format](images/d3d10-block-compress-3.png)
+![illustration of the bc4 compression format](images/d3d10-block-compress-3.png)
 
 The total space required to store the compressed data is 8 bytes which is a 50-percent memory savings over the uncompressed example. The savings are even larger when more than one color component is used.
 


### PR DESCRIPTION
The [Storing Compressed Data section](https://docs.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#storing-compressed-data) references BC1, saying it's an 8-byte block with 1-byte color values and 16 x 3-bit interpolation indices, but [BC1](https://docs.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc1) has 2-byte color values and 16 x 2-bit interpolation indices. It's actually [BC4](https://docs.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc4) which has 1-byte color values and 16 x 3-bit interpolation indices.