### PR TITLE
Updated link to Known Folders sample

### DIFF
--- a/desktop-src/shell/known-folders.md
+++ b/desktop-src/shell/known-folders.md
@@ -58,9 +58,5 @@ A C++ sample that demonstrates the Known Folder APIs is included in the Windows 
 
 <dl> <dt>
 
-[Known Folders Sample](/previous-versions/windows/desktop/legacy/dd940364(v=vs.85))
+[Known Folders Sample](/windows/win32/shell/samples-knownfolders)
 </dt> </dl>
-
- 
-
- 


### PR DESCRIPTION
Replaced the link to the legacy sample page with a link to the updated sample page for Known Folders.

Legacy page: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/dd940364(v=vs.85)
Updated page: https://docs.microsoft.com/en-us/windows/win32/shell/samples-knownfolders