### PR TITLE
Change the message loop to exit on error and add comments

### DIFF
--- a/desktop-src/LearnWin32/your-first-windows-program.md
+++ b/desktop-src/LearnWin32/your-first-windows-program.md
@@ -66,7 +66,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine
     // Run the message loop.
 
     MSG msg = { };
-    while (GetMessage(&msg, NULL, 0, 0))
+    while (GetMessage(&msg, NULL, 0, 0) > 0)
     {
         TranslateMessage(&msg);
         DispatchMessage(&msg);
@@ -88,7 +88,7 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             PAINTSTRUCT ps;
             HDC hdc = BeginPaint(hwnd, &ps);
 
-
+            // All painting occurs here, between BeginPaint and EndPaint.
 
             FillRect(hdc, &ps.rcPaint, (HBRUSH) (COLOR_WINDOW+1));
 


### PR DESCRIPTION
Even though GetMessage returns a BOOL type, it is actually possible that the function returns a negative value (due to the fact that BOOL is defined as an int in WinUser.h).
Thus, if we just hand the return value of GetMessage to the loop itself, it'll ignore the occasional errors.

Also, I grabbed the comment from desktop-src/LearnWin32/painting-the-window.md so it fills the empty break lines in the WindowProc function.