### PR TITLE
Update taskschedulerschema-executiontimelimit-triggerbasetype-element.md

### DIFF
--- a/desktop-src/TaskSchd/taskschedulerschema-executiontimelimit-triggerbasetype-element.md
+++ b/desktop-src/TaskSchd/taskschedulerschema-executiontimelimit-triggerbasetype-element.md
@@ -17,7 +17,7 @@ api_location:
 
 # ExecutionTimeLimit (triggerBaseType) Element
 
-Specifies the maximum amount of time in which the task can be started by the trigger. The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months, nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes, and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month, four days, two hours, and five minutes). For more information about the duration type, see <https://go.microsoft.com/fwlink/p/?linkid=106886>.
+The maximum amount of time that the task launched by the trigger is allowed to run. The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months, nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes, and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month, four days, two hours, and five minutes). For more information about the duration type, see <https://go.microsoft.com/fwlink/p/?linkid=106886>.
 
 ``` syntax
 <xs:element name="ExecutionTimeLimit"


### PR DESCRIPTION
Update taskschedulerschema-executiontimelimit-triggerbasetype-element.md description to have the correct definition.