### PR TITLE
Fix run that doesn't end on a word boundary

### DIFF
--- a/desktop-src/gdi/bitmap-compression.md
+++ b/desktop-src/gdi/bitmap-compression.md
@@ -26,13 +26,13 @@ When the **Compression** member of the bitmap information header structure is BI
 
  
 
--   In *absolute mode*, the first byte is zero and the second byte is a value in the range 03H through FFH. The second byte represents the number of bytes that follow, each of which contains the color index of a single pixel. When the second byte is two or less, the escape has the same meaning as encoded mode. In absolute mode, each run must be aligned on a word boundary.
+-   In *absolute mode*, the first byte is zero and the second byte is a value in the range 03H through FFH. The second byte represents the number of bytes that follow, each of which contains the color index of a single pixel. When the second byte is two or less, the escape has the same meaning as encoded mode. In absolute mode, each run must be zero-padded to end on a 16-bit word boundary.
 
 The following example shows the hexadecimal values of an 8-bit compressed bitmap:
 
 
 ```C++
-[03 04] [05 06] [00 03 45 56 67] [02 78] [00 02 05 01] 
+[03 04] [05 06] [00 03 45 56 67 00] [02 78] [00 02 05 01] 
 [02 78] [00 00] [09 1E] [00 01] 
 ```
 


### PR DESCRIPTION
There was a discussion on StackOverflow about this run and how it is wrong, see it below for more detailed information on what this commit fixes.

The StackOverflow answers show proof that the padding byte is necessary, along with a link to nearly identical documentation that *does* include the padding byte.

I've also chosen to reword `each run must be aligned on a word boundary` to `each run must be zero-padded to end on a 16-bit word boundary`, as per these comments on that StackOverflow page:

> Presumably, this means that runs with an odd-numbered length must be zero-padded (although not specified, I assume words are 16 bits long in this context).

> Don't they mean that it has to start on a word-aligned address (in uncompressed form)? It's certainly vague, but that would be true in the example.

https://stackoverflow.com/questions/46349718/align-with-word-boundary-in-rle-bitmap-contradiction-in-microsoft-documentation