### PR TITLE
Fix description which states Delta bytes their vertical components go down, as they probably go up

### DIFF
--- a/desktop-src/gdi/bitmap-compression.md
+++ b/desktop-src/gdi/bitmap-compression.md
@@ -16,11 +16,11 @@ When the **Compression** member of the bitmap information header structure is BI
 
 
 
-| Value | Meaning                                                                                                                                                     |
-|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0     | End of line.                                                                                                                                                |
-| 1     | End of bitmap.                                                                                                                                              |
-| 2     | Delta. The 2 bytes following the escape contain unsigned values indicating the horizontal and vertical offsets of the next pixel from the current position. |
+| Value | Meaning                                                                                                                                                |
+|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0     | End of line.                                                                                                                                           |
+| 1     | End of bitmap.                                                                                                                                         |
+| 2     | Delta. The 2 bytes following the escape contain unsigned values indicating the offset to the right and up of the next pixel from the current position. |
 
 
 

--- a/desktop-src/gdi/bitmap-compression.md
+++ b/desktop-src/gdi/bitmap-compression.md
@@ -46,7 +46,7 @@ The bitmap expands as follows (two-digit values represent a color index for a si
 06 06 06 06 06 
 45 56 67 
 78 78 
-move current position 5 right and 1 down 
+move current position 5 right and 1 up 
 78 78 
 end of line 
 1E 1E 1E 1E 1E 1E 1E 1E 1E 
@@ -78,7 +78,7 @@ The bitmap expands as follows (single-digit values represent a color index for a
 0 6 0 6 0 
 4 5 5 6 6 7 
 7 8 7 8 
-move current position 5 right and 1 down 
+move current position 5 right and 1 up 
 7 8 7 8 
 end of line 
 1 E 1 E 1 E 1 E 1 


### PR DESCRIPTION
So I'm reading the [Microsoft Docs on bitmaps][1] and it has this part:

> Delta. The 2 bytes following the escape contain unsigned values indicating the horizontal and vertical offsets of the next pixel from the current position.

It doesn't specify whether horizontal means going left/right and it doesn't specify whether vertical means going up/down, but the `contain unsigned values` at least suggests that only one direction is possible for both of the axes.

There's an example at the bottom of that page that is supposed to clarify this ambiguity:

`[00 02 05 01]` means `move current position 5 right and 1 down`

So this sounds great and seems intuitive, but I think this is incorrect.

The [Wikipedia page on bitmaps][2] states this:

> Note that the bitmap data starts with the lower left hand corner of the image.

And [another source][3] I've found:

> The scan lines in the bitmap are stored from bottom up. This means that the first byte in the array represents the pixels in the lower-left corner of the bitmap and the last byte represents the pixels in the upper-right corner.

So you start reading from the bottom-left of a BMP, and you're then moving to the right, and once you reach the end of a row you move up.

This doesn't make sense with the `05 01 = 5 right and 1 down` from before though, because why would an (unsigned!) vertical value of 1 move you *down* when you start reading at the bottom row? I am not 100% sure that this is a mistake as I'm currently still trying to get my own RLE8 decompression code running, but this suggests that you're able to move *back*.

  [1]: https://docs.microsoft.com/en-us/windows/win32/gdi/bitmap-compression
  [2]: https://en.wikipedia.org/wiki/BMP_file_format#Compression
  [3]: http://www.martinreddy.net/gfx/2d/BMP.txt