### PR TITLE
Fix xml namespaces

### DIFF
--- a/desktop-src/WES/identifying-the-provider.md
+++ b/desktop-src/WES/identifying-the-provider.md
@@ -18,8 +18,8 @@ The following example shows how to use the **provider** element to identify a pr
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/localizing-message-strings.md
+++ b/desktop-src/WES/localizing-message-strings.md
@@ -16,8 +16,8 @@ The following example shows how to define a string table. You must specify the s
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>

--- a/desktop-src/WES/writing-an-instrumentation-manifest.md
+++ b/desktop-src/WES/writing-an-instrumentation-manifest.md
@@ -46,8 +46,8 @@ The following example shows the skeleton of a fully defined event manifest.
 ```XML
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"    
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     >
 
     <instrumentation>


### PR DESCRIPTION
The given xml namespaces need to be http.  https does not work, and `mc.exe` throws errors for them.