### PR TITLE
Added GUID_LIDSWITCH_STATE_CHANGE for laptop lid status change event

### DIFF
--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -267,19 +267,14 @@ This notification is sent only to user-mode applications running in an interacti
 BA3E0F4D-B817-4094-A2D1-D56379E6A0F3
 </dt> <dt>
 
-
-
-Lid state changes.
-
-
-Specifies the current state of the lid (open or closed). The callback won't be called at all until a lid device is found and its current state is known.
+The state of the lid has changed (open or closed). The callback won't be called until a lid device is found and its current state is known.
 
 <dl> <dt>
 
-0x0 - closed.
+0x0 - The lid is closed.
 </dt> <dt>
 
-0x1 - opened.
+0x1 - The lid is opened.
 </dt> <dt>
 
 </dl> </dd> <dt>

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -260,6 +260,29 @@ This notification is sent only to user-mode applications running in an interacti
  
 
 </dl> </dd> <dt>
+ 
+<span id="GUID_LIDSWITCH_STATE_CHANGE"></span><span id="guid_lidswitch_state_change"></span>**GUID\_LIDSWITCH\_STATE\_CHANGE**
+</dt> <dd> <dl> <dt>
+
+BA3E0F4D-B817-4094-A2D1-D56379E6A0F3
+</dt> <dt>
+
+
+
+Lid state changes.
+
+
+Specifies the current state of the lid (open or closed). The callback won't be called at all until a lid device is found and its current state is known.
+
+<dl> <dt>
+
+0x0 - closed.
+</dt> <dt>
+
+0x1 - opened.
+</dt> <dt>
+
+</dl> </dd> <dt>
 
 <span id="GUID_SYSTEM_AWAYMODE"></span><span id="guid_system_awaymode"></span>**GUID\_SYSTEM\_AWAYMODE**
 </dt> <dd> <dl> <dt>


### PR DESCRIPTION
GUID_LIDSWITCH_STATE_CHANGE can be received with event PBT_POWERSETTINGCHANGE. The doc fails to mention it.
The GUID and its description is given in ddk\wddmv2\official\18362\Include\10.0.18362.0\um\winnt.h