### PR TITLE
Update getqueuedcompletionstatusex-func.md

### DIFF
--- a/desktop-src/FileIO/getqueuedcompletionstatusex-func.md
+++ b/desktop-src/FileIO/getqueuedcompletionstatusex-func.md
@@ -85,7 +85,11 @@ The number of milliseconds that the caller is willing to wait for a completion p
 
 If *dwMilliseconds* is **INFINITE** (0xFFFFFFFF), the function will never time out. If *dwMilliseconds* is zero and there is no I/O operation to dequeue, the function will time out immediately.
 
-</dd> <dt>
+<b>Windows XP, Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 and Windows Server 2008 R2:  </b>The <i>dwMilliseconds</i> value does include time spent in low-power states. For example, the timeout does keep counting down while the computer is asleep.
+
+<b>Windows 8, Windows Server 2012, Windows 8.1, Windows Server 2012 R2, Windows 10 and Windows Server 2016:  </b>The <i>dwMilliseconds</i> value does not include time spent in low-power states. For example, the timeout does not keep counting down while the computer is asleep.
+
+</dd>  <dt>
 
 *fAlertable* \[in\]
 </dt> <dd>


### PR DESCRIPTION
This information was added to WaitForXXXObject but not here where it is also needed. This information is critical for developers to understand a breaking change made to Windows 8/2012.

There would be other API docs that might be in this information (GetQueuedCompletionStatus/GetOverlappedResultEx) but I cannot figure out how to find those in this API doc set.