### PR TITLE
Updated MCN_GETDAYSTATE topic

### DIFF
--- a/desktop-src/Controls/mcn-getdaystate.md
+++ b/desktop-src/Controls/mcn-getdaystate.md
@@ -36,7 +36,7 @@ MCN_GETDAYSTATE
 *lParam* 
 </dt> <dd>
 
-Pointer to an [**NMDAYSTATE**](/windows/win32/api/commctrl/ns-commctrl-nmdaystate) structure. The structure contains information about the time frame for which the control needs information, and it receives the address of an array that provides this data.
+Pointer to an [**NMDAYSTATE**](/windows/win32/api/commctrl/ns-commctrl-nmdaystate) structure. The structure contains information about the time frame for which the control needs information, and a stack-allocated array of bitfields to write this data into.
 
 </dd> </dl>
 


### PR DESCRIPTION
NMDAYSTATE->prgDayState array is pre-allocated on the stack by the sender of this notification (calendar.cpp). Developer who handles this notification should not be allocating a new array that provides bitfields with bold dates, they should set bits in the given array.  See this topic for the correct handling of this notification: https://docs.microsoft.com/en-us/cpp/mfc/setting-the-day-state-of-a-month-calendar-control?view=msvc-160