### PR TITLE
Update direct3d-12-video-overview.md

### DIFF
--- a/desktop-src/medfound/direct3d-12-video-overview.md
+++ b/desktop-src/medfound/direct3d-12-video-overview.md
@@ -114,7 +114,10 @@ An implementation will also usually have a fence for each output buffer. In the 
 ## Related topics
 
 <dl> <dt>
+ 
 [Direct3D 12 Video APIs](direct3d-12-video-apis.md)
+</dt> <dt>
+ 
 [Media Foundation Programming Guide](media-foundation-programming-guide.md)
 </dt> </dl>
 


### PR DESCRIPTION
Fix broken links - redid the 'Related topics' list to properly use the dl/dt tags and make the links actually clickable. (Now follows the style of other files in this folder like [dxva-hd.md](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/medfound/dxva-hd.md) )