### PR TITLE
Update create-a-tooltip-for-a-control.md

### DIFF
--- a/desktop-src/Controls/create-a-tooltip-for-a-control.md
+++ b/desktop-src/Controls/create-a-tooltip-for-a-control.md
@@ -48,7 +48,7 @@ HWND CreateToolTip(int toolID, HWND hDlg, PTSTR pszText)
     HWND hwndTool = GetDlgItem(hDlg, toolID);
     
     // Create the tooltip. g_hInst is the global instance handle.
-    HWND hwndTip = CreateWindowEx(NULL, TOOLTIPS_CLASS, NULL,
+    HWND hwndTip = CreateWindowEx(0, TOOLTIPS_CLASS, NULL,
                               WS_POPUP |TTS_ALWAYSTIP | TTS_BALLOON,
                               CW_USEDEFAULT, CW_USEDEFAULT,
                               CW_USEDEFAULT, CW_USEDEFAULT,


### PR DESCRIPTION
First argument of CreateWindowEx is supposed to be a DWORD, while NULL is a void*. Fixed.