### PR TITLE
Task 36552572: Edit signtool docs /fd /td info

### DIFF
--- a/desktop-src/SecCrypto/signtool.md
+++ b/desktop-src/SecCrypto/signtool.md
@@ -13,7 +13,7 @@ SignTool is a command-line tool that digitally signs files, verifies the signatu
 SignTool is available as part of the Windows SDK, which you can download from <https://developer.microsoft.com/windows/downloads/windows-10-sdk/>.
 
 > [!Note]  
-> The Windows 10 SDK, Windows 10 HLK, Windows 10 WDK and Windows 10 ADK **builds 20236 and above** will now require specifying the digest algorithm. The SignTool sign command requires the /fd `file digest algorithm` and the /td `timestamp digest algorithm` option to be specified during signing and timestamping, respectively. A warning (error code 0, initially) will be thrown if /fd is not specified during signing and if /td is not specified during timestamping. In later versions of SignTool, the warning will become an error. SHA256 is recommended and considered to be more secure than SHA1 by the industry.  
+> A warning (error code 0, initially) will be thrown if /fd is not specified during signing and if /td is not specified during timestamping. In later versions of SignTool, the warning will become an error. " --> An error (error code 1) will be thrown if /fd is not specified during signing and if /td is not specified during timestamping  
 
 
 ## Syntax  
@@ -84,8 +84,8 @@ The following commands are supported by SignTool.
 |`/du`  *URL*|Specifies a Uniform Resource Locator (URL) for the expanded description of the signed content.|  
 |`/dxml`  |When used with the <strong>/dg</strong> option, produces an XML file. The output file will be: *Path\FileName.dig.xml*.|  
 |`/f`  *SignCertFile*|Specifies the signing certificate in a file. If the file is in Personal Information Exchange (PFX) format and protected by a password, use the `/p` option to specify the password. If the file does not contain private keys, use the `/csp` and `/kc` options to specify the CSP and private key container name.|  
-|`/fd` *alg*|Specifies the file digest algorithm to use for creating file signatures. </br> **Note:** A warning is generated if <strong>/fd</strong> switch is not provided while signing. The default alg is SHA1 but SHA256 is recommended.|
-|`/fd`  *certHash*|Specifying the string certHash will default to the algorithm used on the signing certificate. </br> **Note:** Only available in Windows 10 kit builds 20236 and greater.|  
+|`/fd` *alg*|Specifies the file digest algorithm to use for creating file signatures. </br> **Note:** An error  is generated if the /fd switch is not provided while signing.|
+|`/fd`  *certHash*|Specifying the string certHash will default to the algorithm used on the signing certificate. </br> **Note:** An error  is generated if the /fd switch is not provided while signing.|  
 |`/i`  *IssuerName*|Specifies the name of the issuer of the signing certificate. This value can be a substring of the entire issuer name.|  
 |`/kc`  *PrivKeyContainerName*|Specifies the private key container name.|  
 |`/n`  *SubjectName*|Specifies the name of the subject of the signing certificate. This value can be a substring of the entire subject name.|  
@@ -100,7 +100,7 @@ The following commands are supported by SignTool.
 |`/sha1`  *Hash*|Specifies the SHA1 hash of the signing certificate. The SHA1 hash is commonly specified when multiple certificates satisfy the criteria specified by the remaining switches.|  
 |`/sm`|Specifies that a machine store, instead of a user store, is used.|  
 |`/t`  *URL*|Specifies the URL of the time stamp server. If this option (or `/tr`) is not present, the signed file will not be time stamped. A warning is generated if time stamping fails. This option cannot be used with the `/tr` option.|  
-|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** A warning is generated if <strong>/td</strong> switch is not provided while timestamping. The default alg is SHA1 but SHA256 is recommended. <br/> The <strong>/td</strong> switch must be declared after the <strong>/tr</strong> switch, not before. If the <strong>/td</strong> switch is declared before the <strong>/tr</strong> switch, the timestamp that is returned is from an SHA1 algorithm instead of the intended SHA256 algorithm. |
+|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping." (there is no default anymore <- does not need to go in doc.|
 |`/tr`  *URL*|Specifies the URL of the RFC 3161 time stamp server. If this option (or `/t`) is not present, the signed file will not be time stamped. A warning is generated if time stamping fails. This option cannot be used with the `/t` option.|  
 |`/u`  *Usage*|Specifies the enhanced key usage (EKU) that must be present in the signing certificate. The usage value can be specified by OID or string. The default usage is "Code Signing" (1.3.6.1.5.5.7.3.3).|  
 |`/uw`|Specifies usage of "Windows System Component Verification" (1.3.6.1.4.1.311.10.3.6).|  
@@ -116,7 +116,7 @@ The following commands are supported by SignTool.
 |----|----|  
 |`/p7`|Time stamps PKCS #7 files.|  
 |`/t`  *URL*|Specifies the URL of the time stamp server. The file being time stamped must have previously been signed. Either the `/t` or the `/tr` option is required.|  
-|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** A warning is generated if <strong>/td</strong> switch is not provided while timestamping. The default alg is SHA1 but SHA256 is recommended. <br/> The <strong>/td</strong> switch must be declared after the <strong>/tr</strong> switch, not before. If the <strong>/td</strong> switch is declared before the <strong>/tr</strong> switch, the timestamp that is returned is from an SHA1 algorithm instead of the intended SHA256 algorithm. |
+|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping." (there is no default anymore <- does not need to go in doc |
 |`/tp` *index*|Time stamps the signature at *index*.|  
 |`/tr`  *URL*|Specifies the URL of the RFC 3161 time stamp server. The file being time stamped must have previously been signed. Either the `/tr` or the `/t` option is required.|  
 

--- a/desktop-src/SecCrypto/signtool.md
+++ b/desktop-src/SecCrypto/signtool.md
@@ -100,7 +100,7 @@ The following commands are supported by SignTool.
 |`/sha1`  *Hash*|Specifies the SHA1 hash of the signing certificate. The SHA1 hash is commonly specified when multiple certificates satisfy the criteria specified by the remaining switches.|  
 |`/sm`|Specifies that a machine store, instead of a user store, is used.|  
 |`/t`  *URL*|Specifies the URL of the time stamp server. If this option (or `/tr`) is not present, the signed file will not be time stamped. A warning is generated if time stamping fails. This option cannot be used with the `/tr` option.|  
-|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping." (there is no default anymore <- does not need to go in doc.|
+|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping.|
 |`/tr`  *URL*|Specifies the URL of the RFC 3161 time stamp server. If this option (or `/t`) is not present, the signed file will not be time stamped. A warning is generated if time stamping fails. This option cannot be used with the `/t` option.|  
 |`/u`  *Usage*|Specifies the enhanced key usage (EKU) that must be present in the signing certificate. The usage value can be specified by OID or string. The default usage is "Code Signing" (1.3.6.1.5.5.7.3.3).|  
 |`/uw`|Specifies usage of "Windows System Component Verification" (1.3.6.1.4.1.311.10.3.6).|  
@@ -116,7 +116,7 @@ The following commands are supported by SignTool.
 |----|----|  
 |`/p7`|Time stamps PKCS #7 files.|  
 |`/t`  *URL*|Specifies the URL of the time stamp server. The file being time stamped must have previously been signed. Either the `/t` or the `/tr` option is required.|  
-|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping." (there is no default anymore <- does not need to go in doc |
+|`/td`  *alg*|Used with the `/tr` option to request a digest algorithm used by the RFC 3161 time stamp server. </br> **Note:** An error is generated if /td is not provided while timestamping.|
 |`/tp` *index*|Time stamps the signature at *index*.|  
 |`/tr`  *URL*|Specifies the URL of the RFC 3161 time stamp server. The file being time stamped must have previously been signed. Either the `/tr` or the `/t` option is required.|  
 


### PR DESCRIPTION
Changes
1)Top Note: "A warning (error code 0, initially) will be thrown if /fd is not specified during signing and if /td is not specified during timestamping. In later versions of SignTool, the warning will become an error. " --> An error (error code 1) will be thrown if /fd is not specified during signing and if /td is not specified during timestamping.

2) All table rows where /td specified the note in the row needs to be updated to "An error is generated if /td is not provided while timestamping." (there is no default anymore <- does not need to go in doc"

3)All table rows where /fd is specified the note in the row needs to be updated to "An error  is generated if the/fd switch is not provided while signing."