### PR TITLE
Check the size of aac_profiles before accessing it in Tutorial: Encoding an MP4 File

### DIFF
--- a/desktop-src/medfound/tutorial--encoding-an-mp4-file-.md
+++ b/desktop-src/medfound/tutorial--encoding-an-mp4-file-.md
@@ -499,7 +499,7 @@ The following code creates the audio stream attributes.
 ```C++
 HRESULT CreateAACProfile(DWORD index, IMFAttributes **ppAttributes)
 {
-    if (index >= ARRAYSIZE(h264_profiles))
+    if (index >= ARRAYSIZE(aac_profiles))
     {
         return E_INVALIDARG;
     }


### PR DESCRIPTION
This code sample incorrectly checks the size of h264_profiles instead of aac_profiles.