### PR TITLE
Update broken link in system-wake-up-events.md

### DIFF
--- a/desktop-src/Power/system-wake-up-events.md
+++ b/desktop-src/Power/system-wake-up-events.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # System Wake-up Events
 
-The following information applies to wakes from [sleep (S3) and hibernate (S4)](/windows-hardware/drivers/kernel/system-sleeping-states). For wakes from Modern Standby (S0 Low Power Idle), please refer to [transitions from idle to active](/windows-hardware/design/device-experiences/transition-from-idle-to-active).
+The following information applies to wakes from [sleep (S3) and hibernate (S4)](/windows-hardware/drivers/kernel/system-sleeping-states). For wakes from Modern Standby (S0 Low Power Idle), please refer to [transitioning between idle and active states](/windows-hardware/design/device-experiences/transitioning-between-idle-and-active-states).
 
 Your application can restore a computer that is in a sleep state to the working state by using a scheduled timer or a device event. This is known as a *wake-up event*. Use a [waitable timer object](/windows/desktop/Sync/waitable-timer-objects) to specify the time at which the system should wake. To create the object, use the [**CreateWaitableTimer**](/windows/win32/api/synchapi/nf-synchapi-createwaitabletimerw) function. To set the timer, use the [**SetWaitableTimer**](/windows/desktop/api/synchapi/nf-synchapi-setwaitabletimer) function. The *pDueTime* parameter specifies when the timer will be signaled. To specify that the system should wake when the timer is signaled, set the *fResume* parameter to **TRUE**.
 


### PR DESCRIPTION
The link to Transitioning Between Idle and Active States was mistitled and broken.