### PR TITLE
Clarify Unicode status of Windows Console

### DIFF
--- a/desktop-src/Intl/code-pages.md
+++ b/desktop-src/Intl/code-pages.md
@@ -12,7 +12,7 @@ Most applications written today handle character data primarily as [Unicode](uni
 
 -   To communicate with legacy applications.
 -   To communicate with older mail and news servers, which might not always support Unicode.
--   To communicate with the Windows Console.
+-   To communicate with the Windows Console for legacy purposes. (The console does support Unicode, but some legacy command-line application tools may not.)
 
 > [!Note]  
 > New Windows applications should use [Unicode](unicode.md) to avoid the inconsistencies of varied code pages and for ease of localization.


### PR DESCRIPTION
Modify bullet point 3 to clarify that the console does support Unicode, but some connected legacy tools might not.