### PR TITLE
Update internetgetproxyinfo.md

### DIFF
--- a/desktop-src/WinInet/internetgetproxyinfo.md
+++ b/desktop-src/WinInet/internetgetproxyinfo.md
@@ -18,12 +18,10 @@ ms.date: 05/31/2018
 
 # InternetGetProxyInfo function
 
-The InternetGetProxyInfo function is no longer available on Windows 11.
+> [!IMPORTANT]
+> This function is deprecated on Windows 10, and it is not supported on Windows 11. For autoproxy support, use HTTP Services (WinHTTP) version 5.1 instead. For more information, see [WinHTTP AutoProxy Support](../winhttp/winhttp-autoproxy-support.md).
 
-> [!NOTE]
-> This function is deprecated. For autoproxy support, use HTTP Services (WinHTTP) version 5.1 instead. For more information, see [WinHTTP AutoProxy Support](../winhttp/winhttp-autoproxy-support.md).
-
-Retrieves proxy data for accessing specified resources. This function can only be called by dynamically linking to "JSProxy.dll".
+Retrieves proxy data for accessing specified resources. This function can be called only by explicitly loading `JSProxy.dll`.
 
 ## Syntax
 
@@ -116,23 +114,21 @@ To call **InternetGetProxyInfo**, you must dynamically link to it using the defi
   // The pIGPI function pointer can now be used to call InternetGetProxyInfo.
 ```
 
-Like all other aspects of the WinINet API, this function cannot be safely called from within DllMain or the constructors and destructors of global objects.
+Like all other aspects of the WinINet API, this function can't be safely called from within **DllMain** or the constructors and destructors of global objects.
 
-> [!Note]  
+> [!NOTE]  
 > WinINet does not support server implementations. In addition, it should not be used from a service. For server implementations or services use [Microsoft Windows HTTP Services (WinHTTP)](/windows/desktop/WinHttp/winhttp-start-page).
 
 ## Requirements
 
 | Requirement | Value |
-|-------------------------------------|----------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/>                             |
-| Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>                                   |
+|-------------------------------------|--------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/>Unsupported on Windows 11  |
+| Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>                                 |
 | DLL<br/>                      | <dl> <dt>JSProxy.dll</dt> </dl> |
 
 ## See also
 
-[**InternetInitializeAutoProxyDll**](/windows/win32/api/winineti/nf-winineti-internetinitializeautoproxydll)
-
-[**InternetDeInitializeAutoProxyDll**](/previous-versions/windows/desktop/legacy/aa384580(v=vs.85))
-
-[**DetectAutoProxyUrl**](/windows/win32/api/winineti/nf-winineti-detectautoproxyurl)
+* [**InternetInitializeAutoProxyDll**](/windows/win32/api/winineti/nf-winineti-internetinitializeautoproxydll)
+* [**InternetDeInitializeAutoProxyDll**](/previous-versions/windows/desktop/legacy/aa384580(v=vs.85))
+* [**DetectAutoProxyUrl**](/windows/win32/api/winineti/nf-winineti-detectautoproxyurl)

--- a/desktop-src/WinInet/internetgetproxyinfo.md
+++ b/desktop-src/WinInet/internetgetproxyinfo.md
@@ -18,6 +18,8 @@ ms.date: 05/31/2018
 
 # InternetGetProxyInfo function
 
+The InternetGetProxyInfo function is no longer available on Windows 11.
+
 > [!NOTE]
 > This function is deprecated. For autoproxy support, use HTTP Services (WinHTTP) version 5.1 instead. For more information, see [WinHTTP AutoProxy Support](../winhttp/winhttp-autoproxy-support.md).
 

--- a/desktop-src/WinInet/internetgetproxyinfo.md
+++ b/desktop-src/WinInet/internetgetproxyinfo.md
@@ -19,7 +19,7 @@ ms.date: 05/31/2018
 # InternetGetProxyInfo function
 
 > [!IMPORTANT]
-> This function is deprecated on Windows 10, and it is not supported on Windows 11. For autoproxy support, use HTTP Services (WinHTTP) version 5.1 instead. For more information, see [WinHTTP AutoProxy Support](../winhttp/winhttp-autoproxy-support.md).
+> This function is deprecated on Windows 10, and it is unsupported as of Windows 11. For autoproxy support, use HTTP Services (WinHTTP) version 5.1 instead. For more information, see [WinHTTP AutoProxy Support](../winhttp/winhttp-autoproxy-support.md).
 
 Retrieves proxy data for accessing specified resources. This function can be called only by explicitly loading `JSProxy.dll`.
 
@@ -122,9 +122,9 @@ Like all other aspects of the WinINet API, this function can't be safely called 
 ## Requirements
 
 | Requirement | Value |
-|-------------------------------------|--------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/>Unsupported on Windows 11  |
-| Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>                                 |
+|-------------------------------------|-----------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows 2000 Professional \[desktop apps only\]<br/>Unsupported as of Windows 11  |
+| Minimum supported server<br/> | Windows 2000 Server \[desktop apps only\]<br/>                                    |
 | DLL<br/>                      | <dl> <dt>JSProxy.dll</dt> </dl> |
 
 ## See also


### PR DESCRIPTION
The InternetGetProxyInfo function is no longer available on Windows 11. The function always returns FALSE.