### PR TITLE
Fix time_t truncation in TimetToFileTime

### DIFF
--- a/desktop-src/SysInfo/converting-a-time-t-value-to-a-file-time.md
+++ b/desktop-src/SysInfo/converting-a-time-t-value-to-a-file-time.md
@@ -1,33 +1,42 @@
 ---
-description: The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time.
+description: The time functions included in the C run-time use the **time_t** type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a **time_t** value to a [FILETIME](/windows/win32/api/minwinbase/ns-minwinbase-filetime).
 ms.assetid: f626c0b2-a5a1-475d-9a24-64e7b0407278
-title: Converting a time_t Value to a File Time
+title: Converting a time_t value to a FILETIME
 ms.topic: article
-ms.date: 05/31/2018
+ms.date: 12/03/2021
 ---
 
-# Converting a time\_t Value to a File Time
+# Converting a time\_t value to a FILETIME
 
-The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time.
+The time functions included in the C run-time use the **time_t** type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a **time_t** value to a [FILETIME](/windows/win32/api/minwinbase/ns-minwinbase-filetime).
 
-
-```C++
+```cpp
 #include <windows.h>
 #include <time.h>
 
-void TimetToFileTime( time_t t, LPFILETIME pft )
+void TimetToFileTime(time_t t, LPFILETIME pft)
 {
-    ULARGE_INTEGER ll;
-    ll.QuadPart = (t * 10000000ll) + 116444736000000000ll;
-    pft->dwLowDateTime = ll.LowPart;
-    pft->dwHighDateTime = ll.HighPart;
+    ULARGE_INTEGER time_value;
+    time_value.QuadPart = (t * 10000000LL) + 116444736000000000LL;
+    pft->dwLowDateTime = time_value.LowPart;
+    pft->dwHighDateTime = time_value.HighPart;
 }
 ```
 
+After you've a [FILETIME](/windows/win32/api/minwinbase/ns-minwinbase-filetime), you can convert the value to system time using the [**FileTimeToSystemTime**](/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime) function.
 
+## Legacy code example
 
-After you have obtained a file time, you can convert this value to system time using the [**FileTimeToSystemTime**](/windows/win32/api/timezoneapi/nf-timezoneapi-filetimetosystemtime) function.
+The code example in the previous section is good for any architecture. But if you build for a 32-bit architecture and you define **_USE_32BIT_TIME_T**, then **time_t** is a 32-bit value. In that case you have the option to use the following code example instead.
 
- 
+```cpp
+#include <windows.h>
+#include <time.h>
 
- 
+void TimetToFileTime(time_t t, LPFILETIME pft)
+{
+    LONGLONG time_value = Int32x32To64(t, 10000000) + 116444736000000000;
+    pft->dwLowDateTime = (DWORD) time_value;
+    pft->dwHighDateTime = time_value >> 32;
+}
+```

--- a/desktop-src/SysInfo/converting-a-time-t-value-to-a-file-time.md
+++ b/desktop-src/SysInfo/converting-a-time-t-value-to-a-file-time.md
@@ -1,5 +1,5 @@
 ---
-description: The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time, using the Int32x32To64 function.
+description: The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time.
 ms.assetid: f626c0b2-a5a1-475d-9a24-64e7b0407278
 title: Converting a time_t Value to a File Time
 ms.topic: article
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Converting a time\_t Value to a File Time
 
-The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time, using the [**Int32x32To64**](/windows/desktop/api/winnt/nf-winnt-int32x32to64) function.
+The time functions included in the C run-time use the time\_t type to represent the number of seconds elapsed since midnight, January 1, 1970. The following example converts a time\_t value to a file time.
 
 
 ```C++
@@ -17,9 +17,10 @@ The time functions included in the C run-time use the time\_t type to represent 
 
 void TimetToFileTime( time_t t, LPFILETIME pft )
 {
-    LONGLONG ll = Int32x32To64(t, 10000000) + 116444736000000000;
-    pft->dwLowDateTime = (DWORD) ll;
-    pft->dwHighDateTime = ll >>32;
+    ULARGE_INTEGER ll;
+    ll.QuadPart = (t * 10000000ll) + 116444736000000000ll;
+    pft->dwLowDateTime = ll.LowPart;
+    pft->dwHighDateTime = ll.HighPart;
 }
 ```
 


### PR DESCRIPTION
Using `Int32x32To64`on time_t truncates the value. It can be observed via Compiler Explorer, where `movsxd  rax, DWORD PTR t$[rsp]` is used to load `time_t` to a register.
https://godbolt.org/z/T9h9vvec7

After my change, `imul    rax, QWORD PTR t$[rsp], 10000000` is used so the value is not truncated.