### PR TITLE
Fix "profile sample" casing

### DIFF
--- a/desktop-src/NativeWiFi/bootstrap-profile-sample.md
+++ b/desktop-src/NativeWiFi/bootstrap-profile-sample.md
@@ -1,7 +1,7 @@
 ---
 description: Used to authenticate to a wireless network for the first time before the computer has joined a domain.
 ms.assetid: e1a5ce76-9761-4c65-8b26-a44bf2eb1835
-title: Bootstrap Profile Sample
+title: Bootstrap profile sample
 ms.topic: article
 ms.date: 05/31/2018
 topic_type: 
@@ -11,7 +11,7 @@ api_type:
 api_location: 
 ---
 
-# Bootstrap Profile Sample
+# Bootstrap profile sample
 
 The Bootstrap profile sample can be used to authenticate to a wireless network for the first time before the computer has joined a domain.
 

--- a/desktop-src/NativeWiFi/fips-profile-sample.md
+++ b/desktop-src/NativeWiFi/fips-profile-sample.md
@@ -1,7 +1,7 @@
 ---
 description: Used to connect to a network that requires security settings that comply with Federal Information Processing Standards (FIPS) 140-2 standard.
 ms.assetid: 169df4a3-e8b9-4f05-874f-a7eef6658d01
-title: FIPS Profile Sample
+title: FIPS profile sample
 ms.topic: article
 ms.date: 05/31/2018
 topic_type: 
@@ -11,7 +11,7 @@ api_type:
 api_location: 
 ---
 
-# FIPS Profile Sample
+# FIPS profile sample
 
 The FIPS profile sample can be used to connect to a network that requires security settings that comply with Federal Information Processing Standards (FIPS) 140-2 standard. For more information about FIPS, see [**FIPSMode**](wlan-profileschema-fipsmode-authencryption-element.md).
 

--- a/desktop-src/NativeWiFi/non-broadcast-profile-sample.md
+++ b/desktop-src/NativeWiFi/non-broadcast-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Used to connect to networks which do not broadcast their network name or SSID.
 ms.assetid: 564324ad-6723-4676-ab5c-0b5d2957d201
-title: Non-Broadcast Profile Sample
+title: Non-Broadcast profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# Non-Broadcast Profile Sample
+# Non-Broadcast profile sample
 
 The non-broadcast profile sample can be used to connect to networks which do not broadcast their network name or SSID.
 

--- a/desktop-src/NativeWiFi/single-sign-on-profile-sample.md
+++ b/desktop-src/NativeWiFi/single-sign-on-profile-sample.md
@@ -1,7 +1,7 @@
 ---
 description: Used for scenarios that require 802.1X authentication before Windows logon.
 ms.assetid: 76c8d416-3912-41b1-ac9d-3e6e86a76ceb
-title: Single Sign-On Profile Sample
+title: Single Sign-On profile sample
 ms.topic: article
 ms.date: 05/31/2018
 topic_type: 
@@ -11,7 +11,7 @@ api_type:
 api_location: 
 ---
 
-# Single Sign-On Profile Sample
+# Single Sign-On profile sample
 
 The single sign-on (SSO) profile sample can be used for scenarios that require 802.1X authentication before Windows logon.
 

--- a/desktop-src/NativeWiFi/wireless-profile-samples.md
+++ b/desktop-src/NativeWiFi/wireless-profile-samples.md
@@ -17,20 +17,19 @@ The following topics show sample XML profiles for various wireless configuration
 
 You can add a wireless profile to the profile store programmatically by calling [**WlanSetProfile**](/windows/desktop/api/wlanapi/nf-wlanapi-wlansetprofile). You can also add a profile to the profile store using the **netsh** command-line utility. For more information, see [Netsh Commands for Wireless Local Area Network (wlan)](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc755301(v=ws.10)).
 
--   [Bootstrap Profile Sample](bootstrap-profile-sample.md)
--   [FIPS Profile Sample](fips-profile-sample.md)
--   [Non-Broadcast Profile Sample](non-broadcast-profile-sample.md)
--   [Single Sign-On Profile Sample](single-sign-on-profile-sample.md)
--   [WPA-Enterprise with PEAP-MSCHAPv2 Profile Sample](wpa-enterprise-with-peap-mschapv2-profile-sample.md)
--   [WPA-Enterprise with TLS Profile Sample](wpa-enterprise-with-tls-profile-sample.md)
--   [WPA-Personal Profile Sample](wpa-personal-profile-sample.md)
--   [WPA2-Enterprise with PEAP-MSCHAPv2 Profile Sample](wpa2-enterprise-with-peap-mschapv2-profile-sample.md)
--   [WPA2-Enterprise with TLS Profile Sample](wpa2-enterprise-with-tls-profile-sample.md)
--   [WPA2-Personal Profile Sample](wpa2-personal-profile-sample.md)
+-   [Bootstrap profile sample](bootstrap-profile-sample.md)
+-   [FIPS profile sample](fips-profile-sample.md)
+-   [Non-Broadcast profile sample](non-broadcast-profile-sample.md)
+-   [Single Sign-On profile sample](single-sign-on-profile-sample.md)
+-   [WPA-Enterprise with PEAP-MSCHAPv2 profile sample](wpa-enterprise-with-peap-mschapv2-profile-sample.md)
+-   [WPA-Enterprise with TLS profile sample](wpa-enterprise-with-tls-profile-sample.md)
+-   [WPA-Personal profile sample](wpa-personal-profile-sample.md)
+-   [WPA2-Enterprise with PEAP-MSCHAPv2 profile sample](wpa2-enterprise-with-peap-mschapv2-profile-sample.md)
+-   [WPA2-Enterprise with TLS profile sample](wpa2-enterprise-with-tls-profile-sample.md)
+-   [WPA2-Personal profile sample](wpa2-personal-profile-sample.md)
 -   [EAP-AKA profile sample](eap-aka-profile-sample.md)
 
 ## Related topics
 
 * [WLAN_profile schema elements](wlan-profileschema-elements.md)
-* [OneX schema elements](onexschema-elements.md)
-* 
+* [OneX schema elements](onexschema-elements.md) 

--- a/desktop-src/NativeWiFi/wpa-enterprise-with-peap-mschapv2-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa-enterprise-with-peap-mschapv2-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses Protected Extensible Authentication Protocol with Microsoft Challenge Handshake Authentication Protocol version 2, with WPA-Enterprise.
 ms.assetid: e344c360-4ab5-4a5f-a1b2-b0fa890b8666
-title: WPA-Enterprise with PEAP-MSCHAPv2 Profile Sample
+title: WPA-Enterprise with PEAP-MSCHAPv2 profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA-Enterprise with PEAP-MSCHAPv2 Profile Sample
+# WPA-Enterprise with PEAP-MSCHAPv2 profile sample
 
 This sample profile uses Protected Extensible Authentication Protocol with Microsoft Challenge Handshake Authentication Protocol version 2 (PEAP-MSCHAPv2) with *UserName***/***Password* to authenticate to the network. The user is prompted to enter credentials.
 

--- a/desktop-src/NativeWiFi/wpa-enterprise-with-tls-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa-enterprise-with-tls-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses Extensible Authentication Protocol Transport Level Security (EAP-TLS) with certificates to authenticate to the network (WPA-Enterprise).
 ms.assetid: fceeae22-3761-48ab-a190-1a7b1568ed64
-title: WPA-Enterprise with TLS Profile Sample
+title: WPA-Enterprise with TLS profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA-Enterprise with TLS Profile Sample
+# WPA-Enterprise with TLS profile sample
 
 This sample profile uses Extensible Authentication Protocol Transport Level Security (EAP-TLS) with certificates to authenticate to the network.
 

--- a/desktop-src/NativeWiFi/wpa-personal-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa-personal-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses a pre-shared key for network authentication. This sample profile uses Wi-Fi Protected Access security running in Personal mode (WPA-Personal).
 ms.assetid: f04de28b-a98d-40cd-91c8-e446cf669555
-title: WPA-Personal Profile Sample
+title: WPA-Personal profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA-Personal Profile Sample
+# WPA-Personal profile sample
 
 This sample profile uses a pre-shared key for network authentication. The key is shared with the client and the access point. This sample profile is configured to use Wi-Fi Protected Access security running in Personal mode (WPA-Personal). Temporal Key Integrity Protocol (TKIP) is used for encryption.
 

--- a/desktop-src/NativeWiFi/wpa2-enterprise-with-peap-mschapv2-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa2-enterprise-with-peap-mschapv2-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses Protected Extensible Authentication Protocol with Microsoft Challenge Handshake Authentication Protocol version 2, with WPA2-Enterprise.
 ms.assetid: fcbc74a6-1990-45a0-af2e-1c343a84497a
-title: WPA2-Enterprise with PEAP-MSCHAPv2 Profile Sample
+title: WPA2-Enterprise with PEAP-MSCHAPv2 profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA2-Enterprise with PEAP-MSCHAPv2 Profile Sample
+# WPA2-Enterprise with PEAP-MSCHAPv2 profile sample
 
 This sample profile uses Protected Extensible Authentication Protocol with Microsoft Challenge Handshake Authentication Protocol version 2 (PEAP-MSCHAPv2) with *UserName***/***Password* to authenticate to the network. The user is prompted to enter credentials.
 

--- a/desktop-src/NativeWiFi/wpa2-enterprise-with-tls-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa2-enterprise-with-tls-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses Extensible Authentication Protocol Transport Level Security (EAP-TLS) with certificates to authenticate to the network (WPA2-Enterprise).
 ms.assetid: ded07fda-ea7f-4c5a-9433-60196c3f14af
-title: WPA2-Enterprise with TLS Profile Sample
+title: WPA2-Enterprise with TLS profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA2-Enterprise with TLS Profile Sample
+# WPA2-Enterprise with TLS profile sample
 
 This sample profile uses Extensible Authentication Protocol Transport Level Security (EAP-TLS) with certificates to authenticate to the network.
 

--- a/desktop-src/NativeWiFi/wpa2-personal-profile-sample.md
+++ b/desktop-src/NativeWiFi/wpa2-personal-profile-sample.md
@@ -1,12 +1,12 @@
 ---
 description: Uses a pre-shared key for network authentication. This sample profile uses Wi-Fi Protected Access 2 security running in Personal mode (WPA2-Personal).
 ms.assetid: dbbadac6-1b7e-4161-a775-a934cf201c9d
-title: WPA2-Personal Profile Sample
+title: WPA2-Personal profile sample
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# WPA2-Personal Profile Sample
+# WPA2-Personal profile sample
 
 This sample profile uses a pre-shared key for network authentication. The key is shared with the client and the access point. This sample profile is configured to use Wi-Fi Protected Access 2 security running in Personal mode (WPA2-Personal). The Advanced Encryption Standard (AES) cipher type is used for encryption.
 


### PR DESCRIPTION
-Changed entries to lowercase in nativewifi/wireless-profile-samples and children pages
-Removes empty bullet point entry in wireless-profile-samples