### PR TITLE
Update loopback-recording.md

### DIFF
--- a/desktop-src/CoreAudio/loopback-recording.md
+++ b/desktop-src/CoreAudio/loopback-recording.md
@@ -53,7 +53,7 @@ If your audio adapter contains a hardware loopback device, you can use the Windo
 1.  To run Mmsys.cpl, open a Command Prompt window and enter the following command:
 
     ```C++
-    control mmsys.cpl,,1
+    control mmsys.cpl
     ```
 
     

--- a/desktop-src/CoreAudio/loopback-recording.md
+++ b/desktop-src/CoreAudio/loopback-recording.md
@@ -52,7 +52,7 @@ If your audio adapter contains a hardware loopback device, you can use the Windo
 
 1.  To run Mmsys.cpl, open a Command Prompt window and enter the following command:
 
-    ```C++
+    ```ps1
     control mmsys.cpl
     ```
 


### PR DESCRIPTION
Hi. I was reading a document about [loopback-recording](https://docs.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording) and found one malfunctioning command, which is
```C++
control mmsys.cpl,,1
```

When I tried that command, it does not work and throws only a `ParserError`. I guess it needs to be changed to the code below.
```ps1
control mmsys.cpl
```

Despite the command `control mmsys.cpl,1` works as well, but I think the following `,1` is not necessary.

Furthermore, I also change the *language type* of the script from `C++` to `ps1`.

Thank you for reading and please inform me if there is anything wrong.