### PR TITLE
Add relationship with I/O and Memory priorities

### DIFF
--- a/desktop-src/TaskSchd/taskschedulerschema-priority-settingstype-element.md
+++ b/desktop-src/TaskSchd/taskschedulerschema-priority-settingstype-element.md
@@ -43,24 +43,23 @@ The **Priority** element is defined by the [**settingsType**](taskschedulerschem
 
 Priority level 0 is the highest priority, and priority level 10 is the lowest priority. The default value is 7. The minimum and maximum values are set by the [**priorityType**](taskschedulerschema-prioritytype-simpletype.md) simple type. Priority levels 7 and 8 are used for background tasks, and priority levels 4, 5, and 6 are used for interactive tasks.
 
-The task's action is started in a process with a priority that is based on a Priority Class value. A Priority Level value (thread priority) is used for COM handler, message box, and email task actions. For more information about the Priority Class and Priority Level values, see [Scheduling Priorities](/windows/desktop/ProcThread/scheduling-priorities). The following table lists the possible values for the **Priority** element, and the corresponding Priority Class and Priority Level values.
+The task's action is started in a process with a priority that is based on a Priority Class value. A Priority Level value (thread priority) is used for COM handler, message box, and email task actions. For more information about the Priority Class and Priority Level values, see [Scheduling Priorities](/windows/desktop/ProcThread/scheduling-priorities); for more information about I/O Priority values, see [IO_PRIORITY_HINT enumeration](/windows-hardware/drivers/ddi/wdm/ne-wdm-_io_priority_hint); for information about Memory Priority values, see [MEMORY_PRIORITY_INFORMATION structure](/windows/win32/api/processthreadsapi/ns-processthreadsapi-memory_priority_information). The following table lists the possible values for the **Priority** element, and the corresponding Priority Class, Priority Level, I/O Priority and Memory Priority values.
 
 
 
-| Task Priority | Priority Class                 | Priority Level                   |
-|---------------|--------------------------------|----------------------------------|
-| 0             | REALTIME\_PRIORITY\_CLASS      | THREAD\_PRIORITY\_TIME\_CRITICAL |
-| 1             | HIGH\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_HIGHEST        |
-| 2             | ABOVE\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_ABOVE\_NORMAL  |
-| 3             | ABOVE\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_ABOVE\_NORMAL  |
-| 4             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         |
-| 5             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         |
-| 6             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         |
-| 7             | BELOW\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_BELOW\_NORMAL  |
-| 8             | BELOW\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_BELOW\_NORMAL  |
-| 9             | IDLE\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_LOWEST         |
-| 10            | IDLE\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_IDLE           |
-
+| Task Priority | Priority Class                 | Priority Level                   | I/O Priority      | Memory Priority                 |
+|---------------|--------------------------------|----------------------------------|-------------------|---------------------------------|
+| 0             | REALTIME\_PRIORITY\_CLASS      | THREAD\_PRIORITY\_TIME\_CRITICAL | IoPriorityNormal  | MEMORY\_PRIORITY\_NORMAL        |
+| 1             | HIGH\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_HIGHEST        | IoPriorityNormal  | MEMORY\_PRIORITY\_NORMAL        |
+| 2             | ABOVE\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_ABOVE\_NORMAL  | IoPriorityNormal  | MEMORY\_PRIORITY\_NORMAL        |
+| 3             | ABOVE\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_ABOVE\_NORMAL  | IoPriorityNormal  | MEMORY\_PRIORITY\_NORMAL        |
+| 4             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         | IoPriorityNormal  | MEMORY\_PRIORITY\_NORMAL        |
+| 5             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         | IoPriorityNormal  | MEMORY\_PRIORITY\_BELOW\_NORMAL |
+| 6             | NORMAL\_PRIORITY\_CLASS        | THREAD\_PRIORITY\_NORMAL         | IoPriorityNormal  | MEMORY\_PRIORITY\_MEDIUM        |
+| 7             | BELOW\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_BELOW\_NORMAL  | IoPriorityLow     | MEMORY\_PRIORITY\_LOW           |
+| 8             | BELOW\_NORMAL\_PRIORITY\_CLASS | THREAD\_PRIORITY\_BELOW\_NORMAL  | IoPriorityLow     | MEMORY\_PRIORITY\_VERY\_LOW     |
+| 9             | IDLE\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_LOWEST         | IoPriorityVeryLow | MEMORY\_PRIORITY\_VERY\_LOW     |
+| 10            | IDLE\_PRIORITY\_CLASS          | THREAD\_PRIORITY\_IDLE           | IoPriorityVeryLow | MEMORY\_PRIORITY\_VERY\_LOW     |
 
 
  


### PR DESCRIPTION
The relationship between _Task Priority_ and both _I/O Priority_ and _Memory Priority_ is unclear: there are several resources online where this subject has been brought up, usually triggered by unexpectedly bad performance or confused users. The entry which particularly motivated this change request was [Windows-Dev-Performance issue 55](https://github.com/microsoft/Windows-Dev-Performance/issues/55): specifically [comment 932419198](https://github.com/microsoft/Windows-Dev-Performance/issues/55#issuecomment-932419198).
The values for _I/O Priority_ and _Memory Priority_ were confirmed experimentally, i.e., by creating tasks for all 11 _Task Priority_ values and checking assigned values using [Process Explorer](https://docs.microsoft.com/en-us/sysinternals/downloads/process-explorer) and cross-checking with [Process Hacker](https://processhacker.sourceforge.io/).