### PR TITLE
Fix typos in Windows 11 memory limits

### DIFF
--- a/desktop-src/Memory/memory-limits-for-windows-releases.md
+++ b/desktop-src/Memory/memory-limits-for-windows-releases.md
@@ -40,11 +40,11 @@ The following table specifies the limits on physical memory for Windows 11.
 
 | Version               | Limit on X86    | Limit on X64     | Limit on ARM64     |
 |-----------------------|-----------------|------------------|------------------|
-| Windows 10 Enterprise | 4 GB<br/> | 6 TB<br/>   | 6 TB<br/>   |
-| Windows 10 Education  | 4 GB<br/> | 2 TB<br/>   | 2 TB<br/>   |
-| Windows 10 Pro for Workstations  | 4 GB<br/> | 6 TB<br/>   | 6 TB<br/>   |
-| Windows 10 Pro        | 4 GB<br/> | 2 TB<br/>   | 2 TB<br/>   |
-| Windows 10 Home       | 4 GB<br/> | 128 GB<br/> | 128 GB<br/> |
+| Windows 11 Enterprise | 4 GB<br/> | 6 TB<br/>   | 6 TB<br/>   |
+| Windows 11 Education  | 4 GB<br/> | 2 TB<br/>   | 2 TB<br/>   |
+| Windows 11 Pro for Workstations  | 4 GB<br/> | 6 TB<br/>   | 6 TB<br/>   |
+| Windows 11 Pro        | 4 GB<br/> | 2 TB<br/>   | 2 TB<br/>   |
+| Windows 11 Home       | 4 GB<br/> | 128 GB<br/> | 128 GB<br/> |
 
 ## Physical Memory Limits: Windows 10
 


### PR DESCRIPTION
Heading is Windows 11, but table entries are Windows 10, this is probably a typo.