### PR TITLE
Update "Hungarian notation" to explain it is discouraged by core guid…

### DIFF
--- a/desktop-src/LearnWin32/windows-coding-conventions.md
+++ b/desktop-src/LearnWin32/windows-coding-conventions.md
@@ -104,8 +104,8 @@ In its original form, Hungarian notation gives *semantic* information about a va
 
 A more common form of Hungarian notation uses prefixes to give *type* information—for example, *dw* for **DWORD** and *w* for **WORD**.
 
-Note, the cpp core guildines discourage Hungarian notation, see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
-internally, the Windows team no longer uses it. It's use remains in many samples and documentation.
+Note, the cpp core guildines discourage prefix notation (e.g. Hungarian), see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
+internally, the Windows team no longer uses it. Its use remains in many samples and documentation.
 
 ## Next
 

--- a/desktop-src/LearnWin32/windows-coding-conventions.md
+++ b/desktop-src/LearnWin32/windows-coding-conventions.md
@@ -36,7 +36,7 @@ As you can see, there is a certain amount of redundancy in these typedefs. Some 
 
 ### Boolean Type
 
-**BOOL** is a type alias for **int**, distinct from C++ **bool** and other types that represent [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra). The header file WinDef.h also defines two values for use with **BOOL**.
+**BOOL** is a type alias for **int**, distinct from C++'s **bool**, and from other types that represent a [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra) value. The header file `WinDef.h` also defines two values for use with **BOOL**.
 
 ```C++
 #define FALSE    0 
@@ -70,7 +70,7 @@ if (result == TRUE) // Wrong!
 }
 ```
 
-Be aware that **BOOL** is an integer type and is not interchangeable with C++ **bool**.
+**BOOL** is an integer type, and is not interchangeable with C++'s **bool**.
 
 ### Pointer Types
 
@@ -82,7 +82,7 @@ LPRECT rect;  // The same
 PRECT  rect;  // Also the same.
 ```
 
-On 16bit architectures (16-bit Windows) there are 2 types of pointers, *P* for "pointer" and *LP* stands for "long pointer". Long pointers (also called *far pointers*) were needed to address memory ranges outside the current segment. The *LP* prefix was preserved to make it easier to port 16-bit code to 32-bit Windows. Today there is no distinction — a pointer is a pointer. Avoid using these prefixes or if you must use one use *P*.
+On 16-bit architectures (16-bit Windows) there are 2 types of pointers, *P* for "pointer" and *LP* stands for "long pointer". Long pointers (also called *far pointers*) were needed to address memory ranges outside of the current segment. The *LP* prefix has been preserved to make it easier to port 16-bit code to 32-bit Windows. Today there is no distinction, and these pointer types are all equivalent. Avoid using these prefixes; or if you must use one, then use *P*.
 
 ### Pointer Precision Types
 
@@ -104,13 +104,9 @@ In its original form, Hungarian notation gives *semantic* information about a va
 
 A more common form of Hungarian notation uses prefixes to give *type* information—for example, *dw* for **DWORD** and *w* for **WORD**.
 
-Note, the cpp core guildines discourage prefix notation (e.g. Hungarian), see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
-internally, the Windows team no longer uses it. Its use remains in many samples and documentation.
+> [!NOTE]
+> The [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines) discourage prefix notation (for example, Hungarian notation). See [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names). Internally, the Windows team no longer uses it. But its use remains in samples and documentation.
 
 ## Next
 
 [Working with Strings](working-with-strings.md)
-
- 
-
- 

--- a/desktop-src/LearnWin32/windows-coding-conventions.md
+++ b/desktop-src/LearnWin32/windows-coding-conventions.md
@@ -18,8 +18,6 @@ The Windows headers contain a lot of typedefs. Many of these are defined in the 
 
 ### Integer types
 
-
-
 | Data type     | Size    | Signed?  |
 |---------------|---------|----------|
 | **BYTE**      | 8 bits  | Unsigned |
@@ -34,57 +32,49 @@ The Windows headers contain a lot of typedefs. Many of these are defined in the 
 | **ULONGLONG** | 64 bits | Unsigned |
 | **WORD**      | 16 bits | Unsigned |
 
-
-
- 
-
 As you can see, there is a certain amount of redundancy in these typedefs. Some of this overlap is simply due to the history of the Windows APIs. The types listed here have fixed size, and the sizes are the same in both 32-bit and 64-applications. For example, the **DWORD** type is always 32 bits wide.
 
 ### Boolean Type
 
-**BOOL** is a typedef for an integer value that is used in a Boolean context. The header file WinDef.h also defines two values for use with **BOOL**.
-
+**BOOL** is a type alias for `int`, distinct from C++ **bool** and other types that represent [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra). The header file WinDef.h also defines two values for use with **BOOL**.
 
 ```C++
 #define FALSE    0 
 #define TRUE     1
 ```
 
-
-
 Despite this definition of **TRUE**, however, most functions that return a **BOOL** type can return any non-zero value to indicate Boolean truth. Therefore, you should always write this:
-
 
 ```C++
 // Right way.
-BOOL result = SomeFunctionThatReturnsBoolean();
-if (result) 
+if (SomeFunctionThatReturnsBoolean()) 
 { 
     ...
 }
+
+// or
+
+if (SomeFunctionThatReturnsBoolean() != FALSE)
+{ 
+    ...
+}
+
 ```
-
-
 
 and not this:
 
-
 ```C++
-// Wrong!
-if (result == TRUE) 
+if (result == TRUE) // Wrong!
 {
     ... 
 }
 ```
 
-
-
-Be aware that **BOOL** is an integer type and is not interchangeable with the C++ **bool** type.
+Be aware that **BOOL** is an integer type and is not interchangeable with C++ **bool**.
 
 ### Pointer Types
 
 Windows defines many data types of the form *pointer-to-X*. These usually have the prefix *P-* or *LP-* in the name. For example, **LPRECT** is a pointer to a [**RECT**](/previous-versions//dd162897(v=vs.85)), where **RECT** is a structure that describes a rectangle. The following variable declarations are equivalent.
-
 
 ```C++
 RECT*  rect;  // Pointer to a RECT structure.
@@ -92,9 +82,7 @@ LPRECT rect;  // The same
 PRECT  rect;  // Also the same.
 ```
 
-
-
-Historically, *P* stands for "pointer" and *LP* stands for "long pointer". Long pointers (also called *far pointers*) are a holdover from 16-bit Windows, when they were needed to address memory ranges outside the current segment. The *LP* prefix was preserved to make it easier to port 16-bit code to 32-bit Windows. Today there is no distinction — a pointer is a pointer.
+On 16bit architectures (16-bit Windows) there are 2 types of pointers, *P* for "pointer" and *LP* stands for "long pointer". Long pointers (also called *far pointers*) were needed to address memory ranges outside the current segment. The *LP* prefix was preserved to make it easier to port 16-bit code to 32-bit Windows. Today there is no distinction — a pointer is a pointer. Avoid using these prefixes or if you must use one use *P*.
 
 ### Pointer Precision Types
 
@@ -116,7 +104,8 @@ In its original form, Hungarian notation gives *semantic* information about a va
 
 A more common form of Hungarian notation uses prefixes to give *type* information—for example, *dw* for **DWORD** and *w* for **WORD**.
 
-If you search the Web for "Hungarian notation," you will find a lot of opinions about whether Hungarian notation is good or bad. Some programmers have an intense dislike for Hungarian notation. Others find it helpful. Regardless, many of the code examples on MSDN use Hungarian notation, but you don't need to memorize the prefixes to understand the code.
+Note, the cpp core guildines discourage practices like Hungarian notation, see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
+internally, the Windows team no longer uses it. It's use remains in many samples.
 
 ## Next
 

--- a/desktop-src/LearnWin32/windows-coding-conventions.md
+++ b/desktop-src/LearnWin32/windows-coding-conventions.md
@@ -36,7 +36,7 @@ As you can see, there is a certain amount of redundancy in these typedefs. Some 
 
 ### Boolean Type
 
-**BOOL** is a type alias for `int`, distinct from C++ **bool** and other types that represent [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra). The header file WinDef.h also defines two values for use with **BOOL**.
+**BOOL** is a type alias for **int**, distinct from C++ **bool** and other types that represent [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra). The header file WinDef.h also defines two values for use with **BOOL**.
 
 ```C++
 #define FALSE    0 
@@ -104,8 +104,8 @@ In its original form, Hungarian notation gives *semantic* information about a va
 
 A more common form of Hungarian notation uses prefixes to give *type* information—for example, *dw* for **DWORD** and *w* for **WORD**.
 
-Note, the cpp core guildines discourage practices like Hungarian notation, see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
-internally, the Windows team no longer uses it. It's use remains in many samples.
+Note, the cpp core guildines discourage Hungarian notation, see [NL.5: Avoid encoding type information in names](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#nl5-avoid-encoding-type-information-in-names), and
+internally, the Windows team no longer uses it. It's use remains in many samples and documentation.
 
 ## Next
 


### PR DESCRIPTION
update to match current best practice and make it clear Windows OS developers no longer uses Hungarian.