### PR TITLE
Update svc-cpp.md

### DIFF
--- a/desktop-src/Services/svc-cpp.md
+++ b/desktop-src/Services/svc-cpp.md
@@ -54,7 +54,7 @@ int __cdecl _tmain(int argc, TCHAR *argv[])
     if( lstrcmpi( argv[1], TEXT("install")) == 0 )
     {
         SvcInstall();
-        return;
+        return 0;
     }
 
     // TO_DO: Add any additional services for the process to this table.
@@ -89,7 +89,7 @@ VOID SvcInstall()
     SC_HANDLE schService;
     TCHAR szPath[MAX_PATH];
 
-    if( !GetModuleFileName( "", szPath, MAX_PATH ) )
+    if( !GetModuleFileName( NULL, szPath, MAX_PATH ) )
     {
         printf("Cannot install service (%d)\n", GetLastError());
         return;


### PR DESCRIPTION
It wouldn't compile without these changes

\Svc.cpp(41): error C2561: 'main': function must return a value
.\Svc.cpp(33): note: see declaration of 'main'

.\Svc.cpp(76): error C2664: 'DWORD GetModuleFileNameA(HMODULE,LPSTR,DWORD)': cannot convert argument 1 from 'const char [1]' to 'HMODULE'
.\Svc.cpp(76): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast