### PR TITLE
Update -search-ifilter-registering-filters.md

### DIFF
--- a/desktop-src/search/-search-ifilter-registering-filters.md
+++ b/desktop-src/search/-search-ifilter-registering-filters.md
@@ -54,12 +54,11 @@ When you register a new filter handler, we recommend that you use a descriptive 
     HKEY_LOCAL_MACHINE
        Software
           Classes
-             .txt
-                CLSID
-                   {PersistentHandlerGUID}
-                      PersistentAddinsRegistered
-                         {89BCB740-6119-101A-BCB7-00DD010655AF}l
-                            (Default) = {FilterHandlerCLSID}
+             CLSID
+                {PersistentHandlerGUID}
+                   PersistentAddinsRegistered
+                      {89BCB740-6119-101A-BCB7-00DD010655AF}l
+                         (Default) = {FilterHandlerCLSID}
 ```
 
 2. Register your filter handler with the following keys and values:
@@ -68,13 +67,12 @@ When you register a new filter handler, we recommend that you use a descriptive 
     HKEY_LOCAL_MACHINE
        Software
           Classes
-             .txt
-                CLSID
-                   {FilterHandlerCLSID}
-                      (Default) = {DescriptiveFilterHandlerName}
-                      InprocServer32
-                         (Default) = DLL Install Path
-                         ThreadingModel = Both
+             CLSID
+                {FilterHandlerCLSID}
+                   (Default) = {DescriptiveFilterHandlerName}
+                   InprocServer32
+                      (Default) = DLL Install Path
+                      ThreadingModel = Both
 ```
 
 ### Obsolete Approach for Registering Filters Handlers


### PR DESCRIPTION
The registry hive tree in this document was inaccurate. An extra level was very likely left in error after copying and pasting. This correction accurately reflects the Windows registry hive that can be verified using **Registry Editor** app in Windows.