### PR TITLE
max value of each 6 digit is 720885, not 720896.

### DIFF
--- a/desktop-src/SecProv/protectkeywithnumericalpassword-win32-encryptablevolume.md
+++ b/desktop-src/SecProv/protectkeywithnumericalpassword-win32-encryptablevolume.md
@@ -56,7 +56,7 @@ Type: **string**
 
 A string that specifies the specially formatted 48-digit numerical password.
 
-The numerical password must contain 48 digits. These digits can be divided into 8 groups of 6 digits, with the last digit in each group indicating a checksum value for the group. Each group of 6 digits must be divisible by 11 and must be less than 720896. Assuming a group of six digits is labeled as x1, x2, x3, x4, x5, and x6, the checksum x6 digit is calculated as –x1+x2–x3+x4–x5 mod 11.
+The numerical password must contain 48 digits. These digits can be divided into 8 groups of 6 digits, with the last digit in each group indicating a checksum value for the group. Each group of 6 digits must be divisible by 11 and must be 720885 or less. Assuming a group of six digits is labeled as x1, x2, x3, x4, x5, and x6, the checksum x6 digit is calculated as –x1+x2–x3+x4–x5 mod 11.
 
 The groups of digits can optionally be separated by a space or hyphen. Therefore, "xxxxxx-xxxxxx-xxxxxx-xxxxxx-xxxxxx-xxxxxx-xxxxxx-xxxxxx" or "xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx xxxxxx" may also contain valid numerical passwords.
 


### PR DESCRIPTION
> Each group of 6 digits must be divisible by 11 and must be less than 720896.
This '720896' came from '65536 * 11'.

But 'unsigned short' range is 0-65535 and https://docs.microsoft.com/en-us/windows/win32/secprov/unlockwithnumericalpassword-win32-encryptablevolume also says ""less than"" 65536 (= 65535).

So correct max value is '65535 * 11' = 720885.