### PR TITLE
Improve description of descriptor table layout

### DIFF
--- a/desktop-src/direct3d12/creating-a-root-signature.md
+++ b/desktop-src/direct3d12/creating-a-root-signature.md
@@ -53,7 +53,7 @@ The set of shader registers specified by the combination of `RangeType`, `NumDes
 
 ## Descriptor Table Layout
 
-The [**D3D12\_ROOT\_DESCRIPTOR\_TABLE**](/windows/desktop/api/d3d12/ns-d3d12-d3d12_root_descriptor_table) structure declares the layout of a descriptor table as a collection of descriptor ranges that appear one after the other in a descriptor heap. Samplers are not allowed in the same descriptor table as CBV/UAV/SRVs.
+The [**D3D12\_ROOT\_DESCRIPTOR\_TABLE**](/windows/desktop/api/d3d12/ns-d3d12-d3d12_root_descriptor_table) structure declares the layout of a descriptor table as a collection of descriptor ranges that start at a given offset of a descriptor heap. Samplers are not allowed in the same descriptor table as CBV/UAV/SRVs.
 
 This struct is used when the root signature slot type is set to `D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE`.
 


### PR DESCRIPTION
The current descriptor table layout description misleads the reader to think that the tables described must follow each other sequentially.  This is not the case.  The tables are start from a given offset within the heap but there ordering/positioning can vary.