### PR TITLE
Wrong link to DirectShow Samples

### DIFF
--- a/desktop-src/DirectShow/directshow-samples.md
+++ b/desktop-src/DirectShow/directshow-samples.md
@@ -1,21 +1,18 @@
 ---
-description: DirectShow Samples
+description: DirectShow samples
 ms.assetid: 4166d5ca-5e02-49f6-bcb1-d448f8175a0c
 title: DirectShow Samples
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# DirectShow Samples
+# DirectShow samples
 
-The DirectShow samples are included with the [Windows SDK](https://www.microsoft.com/en-us/download/details.aspx?id=8279). They are located under the path \[SDK Root\] \\Samples\\Multimedia\\DirectShow.
+The DirectShow samples are included with the [Microsoft Windows SDK for Windows 7](https://www.microsoft.com/download/details.aspx?id=8279). They are located under the path `\[SDK Root\] \\Samples\\Multimedia\\DirectShow`.
 
 The following table lists all of the DirectShow samples provided in the Windows SDK. For instructions on how to build the samples, refer to the documentation provided in the Windows SDK.
 
 If there is additional documentation for a sample, the first column of this table links to it.
-
-
-
 
 | Sample | Area | Description | Additional Dependencies | 
 |--------|------|-------------|-------------------------|
@@ -53,11 +50,6 @@ If there is additional documentation for a sample, the first column of this tabl
 | Watermark Sample | VMR-9 | Blends a static bitmap onto a video during playback, using the VMR-9. | 
 | <a href="windowless-sample.md">Windowless Sample</a> | VMR-9 | Demonstrates windowless mode in the VMR-9. | 
 
-
-
-
- 
-
 ## Additional Dependencies
 
 Some of the samples link to the DirectShow base class library. To build these samples, you must first build the base class library. For more information, see [DirectShow Base Classes](directshow-base-classes.md). The base class library is required for all of the sample filters.
@@ -68,15 +60,5 @@ Many of the DirectShow samples use a set of common headers and source files loca
 
 ## Related topics
 
-<dl> <dt>
-
-[Setting Up the Build Environment](setting-up-the-build-environment.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
+* [Setting Up the Build Environment](setting-up-the-build-environment.md)
+* 

--- a/desktop-src/DirectShow/directshow-samples.md
+++ b/desktop-src/DirectShow/directshow-samples.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # DirectShow Samples
 
-The DirectShow samples are included with the [Windows SDK](https://msdn.microsoft.com/windows/aa904949.aspx). They are located under the path \[SDK Root\] \\Samples\\Multimedia\\DirectShow.
+The DirectShow samples are included with the [Windows SDK](https://www.microsoft.com/en-us/download/details.aspx?id=8279). They are located under the path \[SDK Root\] \\Samples\\Multimedia\\DirectShow.
 
 The following table lists all of the DirectShow samples provided in the Windows SDK. For instructions on how to build the samples, refer to the documentation provided in the Windows SDK.
 


### PR DESCRIPTION
Users must install windows 7.1 SDK in order to get the DirectShow Samples.