### PR TITLE
Update keyboard-input.md note include wchar.h

### DIFF
--- a/desktop-src/LearnWin32/keyboard-input.md
+++ b/desktop-src/LearnWin32/keyboard-input.md
@@ -105,6 +105,8 @@ Some CTRL key combinations are translated into ASCII control characters. For exa
 
 The following code displays the main keyboard messages in the debugger. Try playing with different keystroke combinations and see what messages are generated.
 
+> [!Note]  
+> Be sure to include wchar.h or else swprintf_s will be undefined.
 
 ```C++
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
swprintf_s is not provided by any of the includes covered through the walkthrough thus far, so when the user imports this code to their WindowsProc, errors will through that it's undefined. Including wchar.h fixes this issue.