### PR TITLE
Slight correction to the value of XM_1DIV2PI

### DIFF
--- a/desktop-src/dxmath/ovw-xnamath-reference-constants.md
+++ b/desktop-src/dxmath/ovw-xnamath-reference-constants.md
@@ -42,7 +42,7 @@ The following constants are provided by the DirectXMath Library.
 </tr>
 <tr class="odd">
 <td>XM_1DIV2PI<br/></td>
-<td>An optimal representation of 2/π.<br/></td>
+<td>An optimal representation of 1/2π.<br/></td>
 </tr>
 <tr class="even">
 <td>XM_PIDIV2<br/></td>


### PR DESCRIPTION
XM_1DIV2PI is defined in the header as: `XM_CONST float XM_1DIV2PI   = 0.159154943f;`, which looks more like 1/2pi rather than 2/pi, which would be 0.6366...