### PR TITLE
Fix behavior description

### DIFF
--- a/desktop-src/Controls/lvn-endlabeledit.md
+++ b/desktop-src/Controls/lvn-endlabeledit.md
@@ -38,7 +38,7 @@ LVN_ENDLABELEDIT
 *lParam* 
 </dt> <dd>
 
-Pointer to an [**NMLVDISPINFO**](/windows/win32/api/commctrl/ns-commctrl-nmlvdispinfoa) structure. The **item** member of this structure is an [**LVITEM**](/windows/win32/api/commctrl/ns-commctrl-lvitema) structure whose **iItem** member identifies the item being edited. The **pszText** member of **item** contains a valid value when the LVN\_ENDLABELEDIT notification code is sent, regardless of whether the LVIF\_TEXT flag is set in the **mask** member of the **LVITEM** structure. If the user cancels editing, the **pszText** member of the **LVITEM** structure is **NULL**; otherwise, **pszText** is the address of the edited text.
+Pointer to an [**NMLVDISPINFO**](/windows/win32/api/commctrl/ns-commctrl-nmlvdispinfoa) structure. The **item** member of this structure is an [**LVITEM**](/windows/win32/api/commctrl/ns-commctrl-lvitema) structure whose **iItem** member identifies the item being edited. The **pszText** member of **item** contains a valid value when the LVN\_ENDLABELEDIT notification code is sent, regardless of whether the LVIF\_TEXT flag is set in the **mask** member of the **LVITEM** structure. If the user cancels editing or doesn't change the text and presses *Enter* key, the **pszText** member of the **LVITEM** structure is **NULL**; otherwise, **pszText** is the address of the edited text.
 
 </dd> </dl>
 


### PR DESCRIPTION
Fix behavior description when user doesn't change the text and presses Enter key.
In this case pszText is NULL as well.