### PR TITLE
Removing Deprecated Function

### DIFF
--- a/desktop-src/Direct2D/direct2d-quickstart.md
+++ b/desktop-src/Direct2D/direct2d-quickstart.md
@@ -234,9 +234,10 @@ DemoApp::~DemoApp()
             // obtain the system DPI and use it to scale the window size.
             FLOAT dpiX, dpiY;
 
-            // The factory returns the current system DPI. This is also the value it will use
-            // to create its own windows.
-            m_pDirect2dFactory->GetDesktopDpi(&dpiX, &dpiY);
+            // The following will return the current system DPI. This is the value it will use
+            // to create a window with the correct dimensions.
+            dpiX = (FLOAT) GetDpiForWindow (GetDesktopWindow ());
+            dpiY = dpiX;
 
 
             // Create the window.

--- a/desktop-src/Direct2D/direct2d-quickstart.md
+++ b/desktop-src/Direct2D/direct2d-quickstart.md
@@ -234,7 +234,7 @@ DemoApp::~DemoApp()
             // obtain the system DPI and use it to scale the window size.
             FLOAT dpiX, dpiY;
 
-            // The following will return the current system DPI. This is the value it will use
+            // The following will return the current system DPI. This is the value used
             // to create a window with the correct dimensions.
             dpiX = (FLOAT) GetDpiForWindow (GetDesktopWindow ());
             dpiY = dpiX;


### PR DESCRIPTION
A summary of my change(s):
- `ID2D1Factory::GetDesktopDpi()` is deprecated and the Visual Studio compiler will no longer compile new code using this function.
    - The compiler suggests using the [`GetDpiForWindow()`](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getdpiforwindow) function for desktop applications.

The following has been tested on Windows 11 using Visual Studio Community 2022 and shown to be working correctly.