### PR TITLE
Improve documentation of functions in Delay-Loaded DLLs section

### DIFF
--- a/desktop-src/DevNotes/delayloadfailurehook.md
+++ b/desktop-src/DevNotes/delayloadfailurehook.md
@@ -64,6 +64,8 @@ The address of the callback function.
 
 | Requirement | Value |
 |--------------------|-----------------------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows 8<br/>                                             |
+| Minimum supported server<br/> | Windows Server 2012<br/>                                    |
 | Library<br/> | <dl> <dt>Kernel32.lib</dt> </dl> |
 | DLL<br/>     | <dl> <dt>Kernel32.dll</dt> </dl> |
 

--- a/desktop-src/DevNotes/delayloadfailurehook.md
+++ b/desktop-src/DevNotes/delayloadfailurehook.md
@@ -50,7 +50,7 @@ The name of the DLL.
 *pszProcName* \[in\]
 </dt> <dd>
 
-The name of the process.
+The name of the procedure.
 
 </dd> </dl>
 

--- a/desktop-src/DevNotes/resolvedelayloadedapi.md
+++ b/desktop-src/DevNotes/resolvedelayloadedapi.md
@@ -60,14 +60,14 @@ The descriptor for the module to be loaded.
 *FailureDllHook* \[in, optional\]
 </dt> <dd>
 
-The address of the failure hook. See [**DelayLoadFailureHook**](delayloadfailurehook.md).
+The address of the failure hook.
 
 </dd> <dt>
 
 *FailureSystemHook* \[in, optional\]
 </dt> <dd>
 
-The address of the system failure hook.
+The address of the system failure hook. See [**DelayLoadFailureHook**](delayloadfailurehook.md).
 
 </dd> <dt>
 
@@ -95,6 +95,8 @@ The address of the import, or the failure stub for it.
 
 | Requirement | Value |
 |--------------------|-----------------------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows 8<br/>                                             |
+| Minimum supported server<br/> | Windows Server 2012<br/>                                    |
 | Library<br/> | <dl> <dt>Kernel32.lib</dt> </dl> |
 | DLL<br/>     | <dl> <dt>Kernel32.dll</dt> </dl> |
 

--- a/desktop-src/DevNotes/resolvedelayloadsfromdll.md
+++ b/desktop-src/DevNotes/resolvedelayloadsfromdll.md
@@ -63,7 +63,15 @@ Reserved; must be 0.
 
 ## Return value
 
-The address of the delay-load descriptor, if it is found; otherwise, **NULL**.
+Returns an **NTSTATUS** or error code.
+
+| Return code | Description |
+|--------------|--------------|
+| STATUS_SUCCESS | The operation completed successfully |
+| STATUS_DLL_NOT_FOUND | The Target DLL could not be found |
+
+The forms and significance of **NTSTATUS** error codes are listed in the Ntstatus.h header file available in the WDK, and are described in the WDK documentation.
+
 
 ## Requirements
 
@@ -71,9 +79,10 @@ The address of the delay-load descriptor, if it is found; otherwise, **NULL**.
 
 | Requirement | Value |
 |--------------------|-----------------------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows 8<br/>                                             |
+| Minimum supported server<br/> | Windows Server 2012<br/>                                    |
 | Library<br/> | <dl> <dt>Kernel32.lib</dt> </dl> |
 | DLL<br/>     | <dl> <dt>Kernel32.dll</dt> </dl> |
-
 
 
 ## See also


### PR DESCRIPTION
ResolveDelayLoadsFromDLL had incorrect information in the "Returns" section.

ResolveDelayLoadedAPI referred to the DelayLoadFailureHook function in the documentation for the FailureDllHook, when in fact DelayLoadFailureHook should be passed as the FailureSystemHook parameter.  (I'm still not sure that's clear).

All 3 functions were lacking documentation of the minimum Windows version required.

This whole section could probably use more work.  I noticed the "See also" section links all go to a download of retired technical documentation of Visual Studio 2003, when I think they were intended to refer to https://docs.microsoft.com/en-us/cpp/build/reference/linker-support-for-delay-loaded-dlls?view=msvc-170 (I would have updated them but I don't know the preferred way to make a permanent link, as opposed to whatever happened last time).

Even after all of this, the documentation is unclear how you're supposed to actually hook these APIs up.  The "Linker support" article goes into great detail on how it *used* to work, before these APIs were present.  Now that the OS provides these APIs it should be much simpler.