### PR TITLE
Fixed typo

### DIFF
--- a/desktop-src/direct3dhlsl/sv-innercoverage.md
+++ b/desktop-src/direct3dhlsl/sv-innercoverage.md
@@ -16,7 +16,7 @@ ms.date: 05/31/2018
 
 # SV\_InnerCoverage
 
-SV\_InputCoverage represents underestimated conservative rasterization information (i.e. whether a pixel is guaranteed-to-be-fully covered).
+SV\_InnerCoverage represents underestimated conservative rasterization information (i.e. whether a pixel is guaranteed-to-be-fully covered).
 
 ## Type
 


### PR DESCRIPTION
SV\_InnerCoverage is the SV that represents understimated conservative rasterization, not SV\_InputCoverage (I don't think SV_InputCoverage exists, I guess it was confused with SV_Coverage as input, or confused with SGV InputCoverage).