### PR TITLE
[WIP] AMPPL: Document EKU evalation semantics

### DIFF
--- a/desktop-src/Services/protecting-anti-malware-services-.md
+++ b/desktop-src/Services/protecting-anti-malware-services-.md
@@ -42,8 +42,6 @@ For an anti-malware user-mode service to run as a protected service, the anti-ma
 > [!IMPORTANT]
 > In Windows 8.1, the certification chain either has to be a known root as determined by driver verification, or the root certificate must be included.
 
- 
-
 During the boot process, this resource section will be extracted from the ELAM driver to validate the certificate information and register the anti-malware service. The anti-malware service can also be registered during the anti-malware software installation process by calling a special API, as described later in this document.
 
 After the resource section is successfully extracted from the ELAM driver and the user-mode service is registered, the service is allowed to launch as protected service. After the service is launched as protected, other non-protected processes on the system won't be able to inject threads, and they wont' be allowed to write into the virtual memory of the protected process.
@@ -58,8 +56,6 @@ The user-mode service that needs to be launched as protected must be signed with
 
 > [!NOTE]  
 > SHA256 file/page hashes must be used, though certificates may continue to be SHA1.
-
- 
 
 ### Primary signature (recommended)
 
@@ -76,8 +72,6 @@ For more info about how to set up and install the Certificate Authority, see [Se
 > [!NOTE]  
 > For compatibility with Windows Vista or Windows XP (or Windows 7 without the SHA2 patch), you can use the "/as" switch when signing your binaries with [SignTool.exe](/windows/desktop/SecCrypto/signtool) with the SHA256 file/page hashes. This will add the signature as a secondary signature to the file. SHA1 sign the file first, since Windows XP, Windows Vista, and Windows 7 will only see the first signature.
 
- 
-
 ### DLL signing requirements
 
 As mentioned earlier, any non-Windows DLLs that get loaded into the protected service must be signed with the same certificate that was used to sign the anti-malware service.
@@ -92,7 +86,6 @@ Anti-malware vendors can include packages developed by other companies without u
 4. Use the [add catalog](/windows/desktop/api/Mscat/nf-mscat-cryptcatadminaddcatalog) function to include the catalog with the application.
 
 When code integrity comes across the packages without an appropriate signature, it will search for a catalog with an approved signature. It will find this catalog as long as these steps are followed and it is installed with the application.
-
 
 ## Resource file info
 
@@ -151,15 +144,11 @@ Note that the certificate chain must include the Code Signing EKU (1.3.6.1.5.5.7
 > [!NOTE]
 > If EKU information is included in certificate information for the ELAM driver, then the same EKU must be used when signing your binaries.
 
-
 > [!NOTE]
 > Windows code integrity's string representation of an OID in a EKU has a maximum length of 64 characters, including the zero termination character.
-
  
 > [!NOTE]
-> In case multiple EKUs are specified, then they are evaluated in (AND|OR)? manner.
-> AND manner: end-entity certificate must satisfy all EKUs specified in ELAM resource section for given entry,
-> OR manner: end-entity certificate must one of any EKUs specified in ELAM resource section for given entry
+> If you specify multiple EKUs, then they are evaluated with `AND` logic. The end-entity certificate must satisfy all EKUs specified in the ELAM resource section for the given entry.
 
 ### Count
 
@@ -179,7 +168,6 @@ During the installation, an anti-malware software installer can call the [**Inst
 
 Code example:
 
-
 ```C++
 HANDLE FileHandle = NULL;
 
@@ -198,8 +186,6 @@ if (InstallElamCertificateInfo(FileHandle) == FALSE)
     goto exitFunc;
 }
 ```
-
-
 
 ### Starting the service as protected
 
@@ -227,8 +213,6 @@ The installer can follow these steps to create, configure, and start the service
     }
     ```
 
-    
-
 4.  Call the [**StartService**](/windows/desktop/api/Winsvc/nf-winsvc-startservicea) API to start the service. When starting the service as protected, SCM checks with Code Integrity (CI) subsystem to validate the certificate information. After the certificate information is validated by CI, SCM launches the service as protected.
     1.  Note that this step fails if you haven’t registered the service by calling the [**InstallELAMCertificateInfo**](/windows/win32/api/sysinfoapi/nf-sysinfoapi-installelamcertificateinfo) API.
     2.  If the service has been configured to start automatically during the system startup phase, you can avoid this step and simply reboot the system. During a reboot, the system automatically registers the service (if the ELAM driver starts successfully) and starts the service in protected mode.
@@ -245,7 +229,6 @@ Notes:
 -   You need to have your service binaries signed using the /ac switch to include the cross-certificate to chain it up to a known CA. Self-signed cert without proper chaining to a known root CA will not work.
 
 Code example:
-
 
 ```C++
 DWORD ProtectionLevel = PROTECTION_LEVEL_SAME;
@@ -309,8 +292,6 @@ if (CreateProcessW(ApplicationName,
 }
 ```
 
-
-
 ## Updates and servicing
 
 After the anti-malware service is launched as protected, other non-protected processes (and even admins) aren't able to stop the service. In the case of updates to the service binaries, the anti-malware service needs to receive a callback from the installer to stop itself so that it can be serviced. After the service is stopped, the anti-malware installer can perform upgrades and then follow the steps described above in the [Registering the service](https://www.bing.com/search?q=Registering+the+service) and [Starting the service as protected](#starting-the-service-as-protected) sections to register the certificate and start the service as protected.
@@ -358,8 +339,6 @@ Set the value to **00000400** to break in the debugger when the signature valida
 > 1.  Processes that have UI or a GUI cannot be protected because of the way the kernel locks a process in memory and does not allow writes to it.
 > 2.  Prior to Windows 10, version 1703 (the Creators update), protected processes cannot use the TLS or SSL communication protocols due to limitations of certificate sharing between the Local Security Authority (LSA) and a protected process.
 
- 
-
 ## Resources
 
 For more info, see:
@@ -380,7 +359,4 @@ These Windows API functions are referenced in this article:
 -   [**SetServiceObjectSecurity**](/windows/desktop/api/winsvc/nf-winsvc-setserviceobjectsecurity)
 -   [**StartService**](/windows/desktop/api/Winsvc/nf-winsvc-startservicea)
 -   [**UpdateProcThreadAttribute**](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute)
-
- 
-
- 
+-   

--- a/desktop-src/Services/protecting-anti-malware-services-.md
+++ b/desktop-src/Services/protecting-anti-malware-services-.md
@@ -157,9 +157,9 @@ Note that the certificate chain must include the Code Signing EKU (1.3.6.1.5.5.7
 
  
 > [!NOTE]
-> In case multiple EKU's are specified, then they are evaluated in (AND|OR)? manner.
-> AND manner: end-entity certificate must satisfy all EKU's specified in ELAM resource section for given entry,
-> OR manner: end-entity certificate must one of any EKU's specified in ELAM resource section for given entry
+> In case multiple EKUs are specified, then they are evaluated in (AND|OR)? manner.
+> AND manner: end-entity certificate must satisfy all EKUs specified in ELAM resource section for given entry,
+> OR manner: end-entity certificate must one of any EKUs specified in ELAM resource section for given entry
 
 ### Count
 

--- a/desktop-src/Services/protecting-anti-malware-services-.md
+++ b/desktop-src/Services/protecting-anti-malware-services-.md
@@ -154,7 +154,12 @@ Note that the certificate chain must include the Code Signing EKU (1.3.6.1.5.5.7
 
 > [!NOTE]
 > Windows code integrity's string representation of an OID in a EKU has a maximum length of 64 characters, including the zero termination character.
+
  
+> [!NOTE]
+> In case multiple EKU's are specified, then they are evaluated in (AND|OR)? manner.
+> AND manner: end-entity certificate must satisfy all EKU's specified in ELAM resource section for given entry,
+> OR manner: end-entity certificate must one of any EKU's specified in ELAM resource section for given entry
 
 ### Count
 


### PR DESCRIPTION
Current documentation is not exactly specific how is the case with multiple EKU's evaluated.
There are two options

- AND semantics - when all EKUs must be present in end entity certificate
- OR semantics - when at least one EKU must be present in end entity certificate

Please check it with Windows Code Integrity team and document implemented and used one option.
