### PR TITLE
Clarification on the maximum value of VolumeLength

### DIFF
--- a/desktop-src/FileIO/exfat-specification.md
+++ b/desktop-src/FileIO/exfat-specification.md
@@ -529,11 +529,11 @@ The valid range of values for this field shall be:
 
 - At least 2<sup>20</sup>/ 2<sup>BytesPerSectorShift</sup>, which ensures the smallest volume is no less than 1MB
 
-- At most 2<sup>64</sup>- 1, the largest value this field can describe
+- At most 2<sup>64</sup>- 1, the largest value this field can describe.
 
-However, if the size of the Excess Space sub-region is 0, then the value
-of this field is ClusterHeapOffset + (2<sup>32</sup>- 11) \*
-2<sup>SectorsPerClusterShift</sup>.
+  However, if the size of the Excess Space sub-region is 0, then the largest value
+  of this field is ClusterHeapOffset + (2<sup>32</sup>- 11) \*
+  2<sup>SectorsPerClusterShift</sup>.
 
 #### 3.1.6 FatOffset Field
 


### PR DESCRIPTION
The original description of VolumeLength implied that if the size of ExcessSpace is 0, then the value of VolumeLength **must** be "ClusterHeapOffset + (2<sup>32</sup>- 11) *  2<sup>SectorsPerClusterShift</sup>"

This pull request tries to clarify that by changing two things: the indendation level of the clarification to match the "At most" field to clarify that these two points are related to each other and clearly stating that the **largest** value of the field is that expression.