### PR TITLE
CoreAudio: list audio endpoint properties in one place

### DIFF
--- a/desktop-src/CoreAudio/audio-endpoint-properties.md
+++ b/desktop-src/CoreAudio/audio-endpoint-properties.md
@@ -21,24 +21,19 @@ For information about **PROPVARIANT**, see the Windows SDK documentation.
 
 The following properties are specific to audio endpoint devices.
 
-
-
-| Property                                                                                                            | Description                                                                                                                                                   |
-|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**PKEY\_AudioEndpoint\_Association**](pkey-audioendpoint-association.md)                                          | Associates a kernel-streaming (KS) pin category with an audio endpoint device.                                                                                |
-| [**PKEY\_AudioEndpoint\_ControlPanelPageProvider**](pkey-audioendpoint-controlpanelpageprovider.md)                | Specifies the CLSID of the registered provider of the device-properties extension for the audio endpoint device.                                              |
-| [**PKEY\_AudioEndpoint\_Disable\_SysFx**](pkey-audioendpoint-disable-sysfx.md)                                     | Indicates whether system effects are enabled in the shared-mode stream that flows to or from the audio endpoint device.                                       |
-| [**PKEY\_AudioEndpoint\_FormFactor**](pkey-audioendpoint-formfactor.md)                                            | Indicates the physical attributes of the audio endpoint device.                                                                                               |
-| [**PKEY\_AudioEndpoint\_FullRangeSpeakers**](pkey-audioendpoint-fullrangespeakers.md)                              | Specifies the channel-configuration mask for the full-range speakers that are connected to the audio endpoint device.                                         |
-| [**PKEY\_AudioEndpoint\_GUID**](pkey-audioendpoint-guid.md)                                                        | Supplies the DirectSound device identifier that corresponds to the audio endpoint device.                                                                     |
-| [**PKEY\_AudioEndpoint\_PhysicalSpeakers**](pkey-audioendpoint-physicalspeakers.md)                                | Defines the physical speaker configuration for the audio endpoint device.                                                                                     |
-| [**PKEY\_AudioEngine\_DeviceFormat**](pkey-audioengine-deviceformat.md)                                            | Specifies the device format, which is the format that the audio engine uses for the shared-mode stream that flows to or from the audio endpoint device.       |
-| [**PKEY\_AudioEngine\_OEMFormat**](pkey-audioengine-oemformat.md)<br/>                                       | Specifies the default format of the device that is used for rendering or capturing a stream. The values are populated by the OEM in an .inf file. <br/> |
-| [**PKEY\_AudioEndpoint\_Supports\_EventDriven\_Mode**](pkey-audioendpoint-supports-eventdriven-mode.md)<br/> | Indicates whether the endpoint supports the event-driven mode. The values are populated by the OEM in an .inf file.<br/>                                |
-
-
-
- 
+| Property | Description |
+|----------|-------------|
+| [**PKEY\_AudioEndpoint\_Association**](pkey-audioendpoint-association.md) | Associates a kernel-streaming (KS) pin category with an audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_ControlPanelPageProvider**](pkey-audioendpoint-controlpanelpageprovider.md) | Specifies the CLSID of the registered provider of the device-properties extension for the audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_Disable\_SysFx**](pkey-audioendpoint-disable-sysfx.md) | Indicates whether system effects are enabled in the shared-mode stream that flows to or from the audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_FormFactor**](pkey-audioendpoint-formfactor.md) | Indicates the physical attributes of the audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_FullRangeSpeakers**](pkey-audioendpoint-fullrangespeakers.md) | Specifies the channel-configuration mask for the full-range speakers that are connected to the audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_GUID**](pkey-audioendpoint-guid.md) | Supplies the DirectSound device identifier that corresponds to the audio endpoint device. |
+| [**PKEY\_AudioEndpoint\_PhysicalSpeakers**](pkey-audioendpoint-physicalspeakers.md) | Defines the physical speaker configuration for the audio endpoint device. |
+| [**PKEY\_AudioEngine\_DeviceFormat**](pkey-audioengine-deviceformat.md) | Specifies the device format, which is the format that the audio engine uses for the shared-mode stream that flows to or from the audio endpoint device. |
+| [**PKEY\_AudioEngine\_OEMFormat**](pkey-audioengine-oemformat.md) | Specifies the default format of the device that is used for rendering or capturing a stream. The values are populated by the OEM in an .inf file. |
+| [**PKEY\_AudioEndpoint\_Supports\_EventDriven\_Mode**](pkey-audioendpoint-supports-eventdriven-mode.md) | Indicates whether the endpoint supports the event-driven mode. The values are populated by the OEM in an .inf file. |
+| [**PKEY\_AudioEndpoint\_JackSubType**](pkey-audioendpoint-jacksubtype.md) | Contains an output category GUID for an audio endpoint device. |
 
 The core audio APIs support additional properties that do not apply exclusively to audio endpoint devices. For more information about these additional properties, see [Device Properties](device-properties.md).
 

--- a/desktop-src/CoreAudio/core-audio-properties.md
+++ b/desktop-src/CoreAudio/core-audio-properties.md
@@ -12,47 +12,16 @@ This programming reference for the Core Audio SDK includes the following propert
 
 ## Audio Endpoint Properties
 
-Core Audio SDK includes several properties of [audio endpoint devices](audio-endpoint-devices.md). For more information, see [Audio Endpoint Properties](audio-endpoint-properties.md).
+Core Audio SDK includes several properties of [audio endpoint devices](audio-endpoint-devices.md).
 
-The following properties are defined in Mmdeviceapi.h in Windows Vista and later.
-
-
-
-| Property                                                                                                            | Description                                                                                                                                                   |
-|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**PKEY\_AudioEndpoint\_Association**](pkey-audioendpoint-association.md)                                          | Associates a kernel-streaming (KS) pin category with an audio endpoint device.                                                                                |
-| [**PKEY\_AudioEndpoint\_ControlPanelPageProvider**](pkey-audioendpoint-controlpanelpageprovider.md)                | Specifies the CLSID of the registered provider of the device-properties extension for the audio endpoint device.                                              |
-| [**PKEY\_AudioEndpoint\_Disable\_SysFx**](pkey-audioendpoint-disable-sysfx.md)                                     | Indicates whether system effects are enabled in the shared-mode stream that flows to or from the audio endpoint device.                                       |
-| [**PKEY\_AudioEndpoint\_FormFactor**](pkey-audioendpoint-formfactor.md)                                            | Indicates the physical attributes of the audio endpoint device.                                                                                               |
-| [**PKEY\_AudioEndpoint\_FullRangeSpeakers**](pkey-audioendpoint-fullrangespeakers.md)                              | Specifies the channel-configuration mask for the full-range speakers that are connected to the audio endpoint device.                                         |
-| [**PKEY\_AudioEndpoint\_GUID**](pkey-audioendpoint-guid.md)                                                        | Supplies the DirectSound device identifier that corresponds to the audio endpoint device.                                                                     |
-| [**PKEY\_AudioEndpoint\_PhysicalSpeakers**](pkey-audioendpoint-physicalspeakers.md)                                | Defines the physical speaker configuration for the audio endpoint device.                                                                                     |
-| [**PKEY\_AudioEngine\_DeviceFormat**](pkey-audioengine-deviceformat.md)                                            | Specifies the device format, which is the format that the audio engine uses for the shared-mode stream that flows to or from the audio endpoint device.       |
-| [**PKEY\_AudioEngine\_OEMFormat**](pkey-audioengine-oemformat.md)<br/>                                       | Specifies the default format of the device that is used for rendering or capturing a stream. The values are populated by the OEM in an .inf file. <br/> |
-| [**PKEY\_AudioEndpoint\_Supports\_EventDriven\_Mode**](pkey-audioendpoint-supports-eventdriven-mode.md)<br/> | Indicates whether the endpoint supports the event-driven mode. The values are populated by the OEM in an .inf file.<br/>                                |
-| [**PKEY\_AudioEndpoint\_JackSubType**](pkey-audioendpoint-jacksubtype.md)<br/>                               | Contains an output category GUID for an audio endpoint device. <br/>                                                                                    |
-
-
-
+For more information, see [Audio Endpoint Properties](audio-endpoint-properties.md).
  
 
 ## Device Properties
 
-Core Audio SDK includes several device properties of [audio endpoint devices](audio-endpoint-devices.md). For more information, see [Device Properties](device-properties.md).
+Core Audio SDK includes several device properties of [audio endpoint devices](audio-endpoint-devices.md).
 
-The following properties are defined in Functiondiscoverykeys\_devpkey.h in Windows Vista and later.
-
-
-
-| Property                                                                         | Description                                                                                                                                                                                       |
-|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**PKEY\_DeviceInterface\_FriendlyName**](pkey-deviceinterface-friendlyname.md) | The friendly name of the audio adapter to which the endpoint device is attached (for example, "XYZ Audio Adapter").                                                                               |
-| [**PKEY\_Device\_DeviceDesc**](pkey-device-devicedesc.md)                       | The device description of the endpoint device (for example, "Speakers").                                                                                                                          |
-| [**PKEY\_Device\_FriendlyName**](pkey-device-friendlyname.md)                   | The friendly name of the endpoint device (for example, "Speakers (XYZ Audio Adapter)").                                                                                                           |
-| **PKEY\_Device\_ContainerId**                                                    | Stores the container identifier of the PnP device that implements the audio endpoint. For more information about this property, see "Device Property Reference" in the Windows WDK documentation. |
-
-
-
+For more information, see [Device Properties](device-properties.md).
  
 
 ## Related topics

--- a/desktop-src/CoreAudio/device-properties.md
+++ b/desktop-src/CoreAudio/device-properties.md
@@ -8,32 +8,27 @@ ms.date: 05/31/2018
 
 # Device Properties (Core Audio APIs)
 
-During the process of enumerating [audio endpoint devices](audio-endpoint-devices.md), a client application can interrogate the endpoint objects for their device properties. The device properties are exposed in MMDevice API's implementation of the **IPropertyStore** interface. Given a reference to the [**IMMDevice**](/windows/desktop/api/Mmdeviceapi/nn-mmdeviceapi-immdevice) interface of an endpoint object, a client can obtain a reference to the endpoint object's property store by calling the [**IMMDevice::OpenPropertyStore**](/windows/desktop/api/Mmdeviceapi/nf-mmdeviceapi-immdevice-openpropertystore) method.
+During the process of enumerating [audio endpoint devices](audio-endpoint-devices.md), a client application can interrogate the endpoint objects for their device properties. The device properties are exposed in MMDevice API's implementation of the [**IPropertyStore**](/windows/win32/api/propsys/nn-propsys-ipropertystore) interface. Given a reference to the [**IMMDevice**](/windows/desktop/api/Mmdeviceapi/nn-mmdeviceapi-immdevice) interface of an endpoint object, a client can obtain a reference to the endpoint object's property store by calling the [**IMMDevice::OpenPropertyStore**](/windows/desktop/api/Mmdeviceapi/nf-mmdeviceapi-immdevice-openpropertystore) method.
 
-The property-store object exposes an **IPropertyStore** interface. The two primary methods in this interface are **IPropertyStore::GetValue**, which gets a device property value, and **IPropertyStore::SetValue**, which sets a device property value. For more information about **IPropertyStore**, see the Windows SDK documentation.
+Clients can read these properties, but should not set them. Property values are stored as **PROPVARIANT** structures.
 
-The MMDevice API's implementation of the property store is different from the standard shell property store object. To change a property value, the client application must call the **IPropertyStore::SetValue** method. During this call, the new values are set and written in the registry. Therefore, the application does not need to call the **IPropertyStore::Commit** method after the **SetValue** call. The handle to the registry is closed only when the client releases the interface pointer.
+The endpoint manager sets the basic device properties for endpoints. The endpoint manager is the Windows component that is responsible for detecting the presence of audio endpoint devices.
 
-Typically, third-party client applications call the **GetValue** method but not the **SetValue** method. The endpoint manager sets the basic device properties for endpoints. The endpoint manager is the Windows Vista component that is responsible for detecting the presence of audio endpoint devices.
+Each **PKEY\_Xxx** property identifier in the following list is a constant of type **PROPERTYKEY** that is defined in header file **Functiondiscoverykeys\_devpkey.h**. All audio endpoint devices have these device properties.
 
-Each PKEY\_Xxx property identifier in the following list is a constant of type **PROPERTYKEY** that is defined in header file Functiondiscoverykeys\_devpkey.h. All audio endpoint devices have these three device properties.
+| Property | Description |
+|----------|-------------|
+| [**PKEY\_DeviceInterface\_FriendlyName**](pkey-deviceinterface-friendlyname.md) | The friendly name of the audio adapter to which the endpoint device is attached (for example, "XYZ Audio Adapter"). |
+| [**PKEY\_Device\_DeviceDesc**](pkey-device-devicedesc.md) | The device description of the endpoint device (for example, "Speakers"). |
+| [**PKEY\_Device\_FriendlyName**](pkey-device-friendlyname.md) | The friendly name of the endpoint device (for example, "Speakers (XYZ Audio Adapter)"). |
+| **PKEY\_Device\_InstanceId** | Stores the audio endpoint [device instance identifier](/windows-hardware/drivers/install/device-instance-ids). The value can also be aquired via [**IMMDevice::GetId**](nf-mmdeviceapi-immdevice-getid.md) method. For more information about this property, see [Endpoint ID Strings](endpoint-id-strings.md) and [DEVPKEY_Device_InstanceId](/windows-hardware/drivers/install/devpkey-device-instanceid). |
+| **PKEY\_Device\_ContainerId** | Stores the [container identifier](/windows-hardware/drivers/install/container-ids) of the PnP device that implements the audio endpoint. For more information about this property, see [DEVPKEY_Device_ContainerId](/windows-hardware/drivers/install/devpkey-device-containerid). |
 
+Some audio endpoint devices might have additional properties that do not appear in the preceding list. For more information about additional properties, see [Audio Endpoint Properties](audio-endpoint-properties.md).
 
-
-| Property                                                                         | Description                                                                                                                                                                                                                                                                       |
-|----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**PKEY\_DeviceInterface\_FriendlyName**](pkey-deviceinterface-friendlyname.md) | The friendly name of the audio adapter to which the endpoint device is attached (for example, "XYZ Audio Adapter"). **PROPVARIANT** member **vt** is set to VT\_LPWSTR and member **pwszVal** points to a null-terminated, wide-character string that contains the friendly name. |
-| [**PKEY\_Device\_DeviceDesc**](pkey-device-devicedesc.md)                       | The device description of the endpoint device (for example, "Speakers"). **PROPVARIANT** member **vt** is set to VT\_LPWSTR and member **pwszVal** points to a null-terminated, wide-character string that contains the device description.                                       |
-| [**PKEY\_Device\_FriendlyName**](pkey-device-friendlyname.md)                   | The friendly name of the endpoint device (for example, "Speakers (XYZ Audio Adapter)"). **PROPVARIANT** member **vt** is set to VT\_LPWSTR and member **pwszVal** points to a null-terminated, wide-character string that contains the friendly name.                             |
-
-
-
- 
-
-Some audio endpoint devices might have additional properties that do not appear in the preceding list. For more information about additional properties, see [Audio Endpoint Properties](audio-endpoint-properties.md). For more information about **PROPERTYKEY**, see the Windows SDK documentation.
+For more information about **PROPERTYKEY**, see the [Windows Property System documentation](/windows/win32/api/wtypes/ns-wtypes-propertykey).
 
 The following code example prints the display names of all audio-rendering endpoint devices in the system:
-
 
 ```C++
 //-----------------------------------------------------------


### PR DESCRIPTION
Clarify what is endpoint device instanceid and containerid.