### PR TITLE
Add links to open source version of SHMath

### DIFF
--- a/desktop-src/direct3d10/d3d10-d3dxshadd.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshadd.md
@@ -4,19 +4,25 @@ ms.assetid: dbfea12b-c110-42a7-84b6-0dff3d958032
 title: D3DXSHAdd function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHAdd
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHAdd function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHAdd**.
 
 Adds two spherical harmonic (SH) vectors; in other words, pOut\[i\] = pA\[i\] + pB\[i\].
 

--- a/desktop-src/direct3d10/d3d10-d3dxshdot.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshdot.md
@@ -4,19 +4,25 @@ ms.assetid: 30f0e858-4c31-4b25-9979-754d996a7d48
 title: D3DXSHDot function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHDot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHDot function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHDot**.
 
 Computes the dot product of two spherical harmonic (SH) vectors.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshevalconelight.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshevalconelight.md
@@ -4,19 +4,25 @@ ms.assetid: ad2b9c86-cf1a-426e-88e6-4c543519e002
 title: D3DXSHEvalConeLight function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalConeLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHEvalConeLight function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalConeLight**.
 
 Evaluates a light that is a cone of constant intensity and returns spectral spherical harmonic (SH) data.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshevaldirection.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshevaldirection.md
@@ -4,19 +4,25 @@ ms.assetid: c86973cc-c5b0-4358-b7eb-5c31f38b5b5a
 title: D3DXSHEvalDirection function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalDirection
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHEvalDirection function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalDirection**.
 
 Evaluates the spherical harmonic (SH) basis functions from an input direction vector.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshevaldirectionallight.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshevaldirectionallight.md
@@ -4,19 +4,25 @@ ms.assetid: b5c657f5-d291-4e53-908c-670b29a1888a
 title: D3DXSHEvalDirectionalLight function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalDirectionalLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHEvalDirectionalLight function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalDirectionalLight**.
 
 Evaluates a directional light and returns spectral spherical harmonic (SH) data.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshevalhemispherelight.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshevalhemispherelight.md
@@ -4,19 +4,25 @@ ms.assetid: 7523ff42-c81d-4857-a50d-7efa213214b8
 title: D3DXSHEvalHemisphereLight function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalHemisphereLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHEvalHemisphereLight function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalHemisphereLight**.
 
 Evaluates a light that is a linear interpolation between two colors over the sphere.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshevalsphericallight.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshevalsphericallight.md
@@ -4,19 +4,25 @@ ms.assetid: e2a2b998-285a-46ef-99fe-ccc923013e9a
 title: D3DXSHEvalSphericalLight function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalSphericalLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHEvalSphericalLight function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalSphericalLight**.
 
 Evaluates a spherical light and returns spectral spherical harmonic (SH) data.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshmultiply2.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshmultiply2.md
@@ -4,19 +4,25 @@ ms.assetid: 9e0942ce-e39d-4147-9472-cda8a97fd390
 title: D3DXSHMultiply2 function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply2
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHMultiply2 function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply2**.
 
 Computes the product of two spherical harmonics functions (*f* and *g*). Both functions are of order N = 2.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshmultiply3.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshmultiply3.md
@@ -4,19 +4,25 @@ ms.assetid: 2845f90f-c8a0-4ca9-b2f6-7491a2b4763b
 title: D3DXSHMultiply3 function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply3
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHMultiply3 function
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply3**.
 
 Computes the product of two spherical harmonics functions (*f* and *g*). Both functions are of order N = 3.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshmultiply4.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshmultiply4.md
@@ -4,19 +4,25 @@ ms.assetid: 05427a18-447e-45d7-a851-e580298c9a1f
 title: D3DXSHMultiply4 function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply4
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHMultiply4 function
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply4**.
 
 Computes the product of two spherical harmonics functions (*f* and *g*). Both functions are of order N = 4.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshmultiply5.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshmultiply5.md
@@ -4,19 +4,25 @@ ms.assetid: c72231a1-9db3-4701-b7ad-4509028ce508
 title: D3DXSHMultiply5 function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply5
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHMultiply5 function
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply5**.
 
 Computes the product of two spherical harmonics functions (f and g). Both functions are of order N = 5.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshmultiply6.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshmultiply6.md
@@ -4,19 +4,25 @@ ms.assetid: 3b68b238-c1ae-4ab8-89ed-bdf815463143
 title: D3DXSHMultiply6 function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply6
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHMultiply6 function
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply6**.
 
 Computes the product of two spherical harmonics functions (f and g). Both functions are of order N = 6.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshrotate.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshrotate.md
@@ -4,19 +4,25 @@ ms.assetid: 22ed379a-ce08-46df-9cc1-8d5fde87c179
 title: D3DXSHRotate function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHRotate
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHRotate function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHRotate**.
 
 Rotates the spherical harmonic (SH) vector by the given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshrotatez.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshrotatez.md
@@ -4,19 +4,25 @@ ms.assetid: 7c4bec55-4a4c-4f7e-8849-1cac373a2340
 title: D3DXSHRotateZ function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHRotateZ
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHRotateZ function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHRotateZ**.
 
 Rotates the spherical harmonic (SH) vector in the z-axis by the given angle.
 

--- a/desktop-src/direct3d10/d3d10-d3dxshscale.md
+++ b/desktop-src/direct3d10/d3d10-d3dxshscale.md
@@ -4,19 +4,25 @@ ms.assetid: e323d238-f635-4780-982d-8798ba178f31
 title: D3DXSHScale function (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHScale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSHScale function (D3DX10.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHScale**.
 
 Scales a spherical harmonic (SH) vector; in other words, pOut\[i\] = pA\[i\]\*Scale.
 

--- a/desktop-src/direct3d11/d3dx11shprojectcubemap.md
+++ b/desktop-src/direct3d11/d3dx11shprojectcubemap.md
@@ -19,15 +19,13 @@ ms.date: 05/31/2018
 
 # D3DX11SHProjectCubeMap function
 
-> [!Note]  
-> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated for Windows 8 and is not supported for Windows Store apps.
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
 
- 
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/master/SHMath) library function **SHProjectCubeMap**.
 
-> [!Note]  
-> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/master/SHMath) library, **SHProjectCubeMap**.
 
- 
 
 Projects a function represented in a cube map into spherical harmonics.
 
@@ -51,7 +49,7 @@ HRESULT D3DX11SHProjectCubeMap(
 
 <dl> <dt>
 
-*pContext* 
+*pContext*
 </dt> <dd>
 
 Type: **[**ID3D11DeviceContext**](/windows/desktop/api/D3D11/nn-d3d11-id3d11devicecontext)\***
@@ -60,7 +58,7 @@ A pointer to an [**ID3D11DeviceContext**](/windows/desktop/api/D3D11/nn-d3d11-id
 
 </dd> <dt>
 
-*Order* 
+*Order*
 </dt> <dd>
 
 Type: **[**UINT**](/windows/desktop/WinProg/windows-data-types)**
@@ -69,7 +67,7 @@ Order of the SH evaluation, generates Order^2 coefficients whose degree is Order
 
 </dd> <dt>
 
-*pCubeMap* 
+*pCubeMap*
 </dt> <dd>
 
 Type: **[**ID3D11Texture2D**](/windows/desktop/api/D3D11/nn-d3d11-id3d11texture2d)\***
@@ -78,7 +76,7 @@ A pointer to an [**ID3D11Texture2D**](/windows/desktop/api/D3D11/nn-d3d11-id3d11
 
 </dd> <dt>
 
-*pROut* 
+*pROut*
 </dt> <dd>
 
 Type: **[**FLOAT**](/windows/desktop/WinProg/windows-data-types)\***
@@ -87,7 +85,7 @@ Output SH vector for red.
 
 </dd> <dt>
 
-*pGOut* 
+*pGOut*
 </dt> <dd>
 
 Type: **[**FLOAT**](/windows/desktop/WinProg/windows-data-types)\***
@@ -96,7 +94,7 @@ Output SH vector for green.
 
 </dd> <dt>
 
-*pBOut* 
+*pBOut*
 </dt> <dd>
 
 Type: **[**FLOAT**](/windows/desktop/WinProg/windows-data-types)\***
@@ -128,6 +126,3 @@ The return value is one of the values listed in [Direct3D 11 Return Codes](d3d11
 
 [D3DX Functions](d3d11-graphics-reference-d3dx11-functions.md)
 </dt> </dl>
-
- 
-

--- a/desktop-src/direct3d9/d3dxshadd.md
+++ b/desktop-src/direct3d9/d3dxshadd.md
@@ -4,19 +4,25 @@ ms.assetid: 12775c90-ed9d-4931-a449-2571816dd079
 title: D3DXSHAdd function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHAdd
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHAdd function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHAdd**.
 
 Adds two spherical harmonic (SH) vectors; in other words, pOut\[i\] = pA\[i\] + pB\[i\].
 

--- a/desktop-src/direct3d9/d3dxshdot.md
+++ b/desktop-src/direct3d9/d3dxshdot.md
@@ -4,19 +4,25 @@ ms.assetid: 71b7480d-ddac-4b02-bca7-d9318823d03e
 title: D3DXSHDot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHDot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHDot function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHDot**.
 
 Computes the dot product of two spherical harmonic (SH) vectors.
 

--- a/desktop-src/direct3d9/d3dxshevalconelight.md
+++ b/desktop-src/direct3d9/d3dxshevalconelight.md
@@ -4,19 +4,25 @@ ms.assetid: 13088e3b-76ae-43ef-886e-686f1f18a31d
 title: D3DXSHEvalConeLight function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalConeLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHEvalConeLight function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalConeLight**.
 
 Evaluates a light that is a cone of constant intensity and returns spectral spherical harmonic (SH) data.
 

--- a/desktop-src/direct3d9/d3dxshevaldirection.md
+++ b/desktop-src/direct3d9/d3dxshevaldirection.md
@@ -4,19 +4,25 @@ ms.assetid: f30ba32c-d6b0-4e4e-b5cd-839ed7821855
 title: D3DXSHEvalDirection function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalDirection
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHEvalDirection function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalDirection**.
 
 Evaluates the spherical harmonic (SH) basis functions from an input direction vector.
 

--- a/desktop-src/direct3d9/d3dxshevaldirectionallight.md
+++ b/desktop-src/direct3d9/d3dxshevaldirectionallight.md
@@ -4,19 +4,25 @@ ms.assetid: 6e2e9b02-13bb-4cef-ae9d-343fbf64e5d7
 title: D3DXSHEvalDirectionalLight function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalDirectionalLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHEvalDirectionalLight function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalDirectionalLight**.
 
 Evaluates a [directional light](light-types.md) and returns spectral spherical harmonic (SH) data.
 

--- a/desktop-src/direct3d9/d3dxshevalhemispherelight.md
+++ b/desktop-src/direct3d9/d3dxshevalhemispherelight.md
@@ -4,19 +4,25 @@ ms.assetid: c5815f12-f706-40f6-bf5e-78a211cfbbea
 title: D3DXSHEvalHemisphereLight function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalHemisphereLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHEvalHemisphereLight function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalHemisphereLight**.
 
 Evaluates a light that is a linear interpolation between two colors over the sphere.
 

--- a/desktop-src/direct3d9/d3dxshevalsphericallight.md
+++ b/desktop-src/direct3d9/d3dxshevalsphericallight.md
@@ -4,14 +4,14 @@ ms.assetid: aa46c162-9c2d-49c0-925c-d0c06456f918
 title: D3DXSHEvalSphericalLight function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHEvalSphericalLight
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
@@ -19,6 +19,12 @@ api_location:
 # D3DXSHEvalSphericalLight function (D3dx9math.h)
 
 Evaluates a spherical light and returns spectral spherical harmonic (SH) data.
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHEvalSphericalLight**.
 
 ## Syntax
 

--- a/desktop-src/direct3d9/d3dxshmultiply2.md
+++ b/desktop-src/direct3d9/d3dxshmultiply2.md
@@ -4,22 +4,28 @@ ms.assetid: 632400a4-2ac9-438d-85f7-869101f350c8
 title: D3DXSHMultiply2 function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHMultiply2
 - D3DXSHMultiply3
 - D3DXSHMultiply4
 - D3DXSHMultiply5
 - D3DXSHMultiply6
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXSHMultiply2 function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHMultiply2**, **XMSHMultiply3**, **XMSHMultiply4**, **XMSHMultiply5**, or **XMSHMultiply6**.
 
 Computes the product of two functions represented using SH (f and g).
 

--- a/desktop-src/direct3d9/d3dxshrotate.md
+++ b/desktop-src/direct3d9/d3dxshrotate.md
@@ -4,19 +4,25 @@ ms.assetid: 9e319725-6cbb-441e-b996-ec2c6f66e5df
 title: D3DXSHRotate function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHRotate
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHRotate function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHRotate**.
 
 Rotates the spherical harmonic (SH) vector by the given matrix.
 

--- a/desktop-src/direct3d9/d3dxshrotatez.md
+++ b/desktop-src/direct3d9/d3dxshrotatez.md
@@ -4,19 +4,25 @@ ms.assetid: 1f471183-4c8e-4fa8-9a42-f6cc2bb1b0f2
 title: D3DXSHRotateZ function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHRotateZ
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHRotateZ function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHRotateZ**.
 
 Rotates the spherical harmonic (SH) vector in the z-axis by the given angle.
 

--- a/desktop-src/direct3d9/d3dxshscale.md
+++ b/desktop-src/direct3d9/d3dxshscale.md
@@ -4,19 +4,25 @@ ms.assetid: e7b08b55-e2e7-4f13-bbee-10b844d3ef91
 title: D3DXSHScale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSHScale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSHScale function (D3dx9math.h)
+
+> [!Note]
+> The D3DX (D3DX 9, D3DX 10, and D3DX 11) utility library is deprecated and is not supported for Windows Store apps.
+
+> [!Note]
+> Instead of using this function, we recommend that you use the [Spherical Harmonics Math](https://github.com/Microsoft/DirectXMath/tree/main/SHMath) library function **XMSHScale**.
 
 Scales a spherical harmonic (SH) vector; in other words, pOut\[i\] = pA\[i\]\*Scale.
 


### PR DESCRIPTION
Added link to each D3DX9 and D3DX10 sh math function to the open source replacement on GitHub.