### PR TITLE
Add links to DirectXMatrixStack.h for DirectXMath

### DIFF
--- a/desktop-src/direct3d10/d3d10-d3dxcreatematrixstack.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcreatematrixstack.md
@@ -4,19 +4,22 @@ ms.assetid: df0f3564-0226-44b8-b22b-4dd27905c44c
 title: D3DXCreateMatrixStack function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXCreateMatrixStack
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXCreateMatrixStack function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Create a matrix stack.
 

--- a/desktop-src/direct3d10/d3d10-id3dxmatrixstack.md
+++ b/desktop-src/direct3d10/d3d10-id3dxmatrixstack.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMatrixStack interface
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Applications use the methods of the ID3DXMATRIXStack interface to manipulate a matrix stack.
 

--- a/desktop-src/direct3d10/d3d10-id3dxmatrixstack.md
+++ b/desktop-src/direct3d10/d3d10-id3dxmatrixstack.md
@@ -4,19 +4,22 @@ ms.assetid: 6c76f9e0-5f59-4cf3-b34a-2475536af6c7
 title: ID3DXMatrixStack interface (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMatrixStack
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMatrixStack interface
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Applications use the methods of the ID3DXMATRIXStack interface to manipulate a matrix stack.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-gettop.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-gettop.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::GetTop method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Retrieves the current matrix at the top of the stack.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-gettop.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-gettop.md
@@ -4,19 +4,22 @@ ms.assetid: cf379742-3e7d-4309-a7af-b97348428682
 title: ID3DXMATRIXStack::GetTop method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.GetTop
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::GetTop method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Retrieves the current matrix at the top of the stack.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-loadidentity.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-loadidentity.md
@@ -4,19 +4,22 @@ ms.assetid: 324b49c2-3aca-4bbb-90f3-62f3ffb2fa45
 title: ID3DXMATRIXStack::LoadIdentity method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.LoadIdentity
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::LoadIdentity method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads identity in the current matrix.
 
@@ -67,7 +70,3 @@ The identity matrix is a matrix in which all coefficients are 0.0 except the \[1
  
 
  
-
-
-
-

--- a/desktop-src/direct3d10/id3dxmatrixstack-loadidentity.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-loadidentity.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::LoadIdentity method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads identity in the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-loadmatrix.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-loadmatrix.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::LoadMatrix method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads the given matrix into the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-loadmatrix.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-loadmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: b898f344-db90-48e0-b457-0eb8d7b31dca
 title: ID3DXMATRIXStack::LoadMatrix method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.LoadMatrix
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::LoadMatrix method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads the given matrix into the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-multmatrix.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-multmatrix.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::MultMatrix method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the given matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-multmatrix.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-multmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: 72388919-e474-4433-b219-41e2d312848e
 title: ID3DXMATRIXStack::MultMatrix method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.MultMatrix
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::MultMatrix method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the given matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-multmatrixlocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-multmatrixlocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::MultMatrixLocal method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the given matrix and the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-multmatrixlocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-multmatrixlocal.md
@@ -4,19 +4,22 @@ ms.assetid: 4d374a7b-99e0-4313-970d-b0e7cf3e97ce
 title: ID3DXMATRIXStack::MultMatrixLocal method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.MultMatrixLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::MultMatrixLocal method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the given matrix and the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-pop.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-pop.md
@@ -4,19 +4,22 @@ ms.assetid: f4e4ff5d-a7a1-4f87-9b7e-53b9d044ba51
 title: ID3DXMATRIXStack::Pop method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Pop
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::Pop method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Removes the current matrix from the top of the stack.
 
@@ -67,7 +70,3 @@ Note that this method decrements the count of items on the stack by 1, effective
  
 
  
-
-
-
-

--- a/desktop-src/direct3d10/id3dxmatrixstack-pop.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-pop.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Pop method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Removes the current matrix from the top of the stack.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-push.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-push.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Push method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Adds a matrix to the stack.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-push.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-push.md
@@ -4,19 +4,22 @@ ms.assetid: 8660047f-64bc-4b34-8270-3087412db942
 title: ID3DXMATRIXStack::Push method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Push
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::Push method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Adds a matrix to the stack.
 
@@ -67,7 +70,3 @@ This method increments the count of items on the stack by 1, duplicating the cur
  
 
  
-
-
-
-

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateaxis.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateaxis.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateAxis method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateaxis.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateaxis.md
@@ -4,19 +4,22 @@ ms.assetid: 7c842bf6-2d13-422e-8136-0506a76ce9fe
 title: ID3DXMATRIXStack::RotateAxis method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateAxis
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::RotateAxis method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateaxislocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateaxislocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateAxisLocal method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateaxislocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateaxislocal.md
@@ -4,19 +4,22 @@ ms.assetid: 90837762-9bfe-4065-94b3-1ca61184a78e
 title: ID3DXMATRIXStack::RotateAxisLocal method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateAxisLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::RotateAxisLocal method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchroll.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: 35e237f6-40f2-4001-adb0-f489d61f64e7
 title: ID3DXMATRIXStack::RotateYawPitchRoll method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateYawPitchRoll
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::RotateYawPitchRoll method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchroll.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchroll.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateYawPitchRoll method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchrolllocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchrolllocal.md
@@ -4,19 +4,22 @@ ms.assetid: da023816-5176-460d-ab6b-909b89cc46cd
 title: ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateYawPitchRollLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchrolllocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-rotateyawpitchrolllocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-scale.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-scale.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Scale method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the world coordinate origin.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-scale.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-scale.md
@@ -4,19 +4,22 @@ ms.assetid: d0f4b341-b3b6-42e4-84df-78f203c3728e
 title: ID3DXMATRIXStack::Scale method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Scale
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::Scale method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the world coordinate origin.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-scalelocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-scalelocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::ScaleLocal method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the object origin.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-scalelocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-scalelocal.md
@@ -4,19 +4,22 @@ ms.assetid: 748fce3a-a33c-4975-bbf0-dd3167a036f1
 title: ID3DXMATRIXStack::ScaleLocal method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.ScaleLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::ScaleLocal method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the object origin.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-translate.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-translate.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Translate method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the computed translation matrix determined by the given factors (x, y, and z).
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-translate.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-translate.md
@@ -4,19 +4,22 @@ ms.assetid: d6e347a5-bb66-451d-b66e-49ea8eff70b3
 title: ID3DXMATRIXStack::Translate method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Translate
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::Translate method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the computed translation matrix determined by the given factors (x, y, and z).
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-translatelocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-translatelocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::TranslateLocal method (D3DX10.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the computed translation matrix determined by the given factors (x, y, and z) and the current matrix.
 

--- a/desktop-src/direct3d10/id3dxmatrixstack-translatelocal.md
+++ b/desktop-src/direct3d10/id3dxmatrixstack-translatelocal.md
@@ -4,19 +4,22 @@ ms.assetid: 96399801-dd80-4e9a-a5c3-c5d41eb9368a
 title: ID3DXMATRIXStack::TranslateLocal method (D3DX10.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.TranslateLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # ID3DXMATRIXStack::TranslateLocal method (D3DX10.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the computed translation matrix determined by the given factors (x, y, and z) and the current matrix.
 

--- a/desktop-src/direct3d9/d3dxcreatematrixstack.md
+++ b/desktop-src/direct3d9/d3dxcreatematrixstack.md
@@ -4,19 +4,22 @@ ms.assetid: bb067b38-efc6-4ed8-9eef-14b3cc70660f
 title: D3DXCreateMatrixStack function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXCreateMatrixStack
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXCreateMatrixStack function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Creates an instance of the [**ID3DXMATRIXStack**](id3dxmatrixstack.md) interface.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--gettop.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--gettop.md
@@ -4,19 +4,22 @@ ms.assetid: 0e20af0a-a332-4cb5-bf87-2ec75aa170ab
 title: ID3DXMATRIXStack::GetTop method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.GetTop
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::GetTop method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Retrieves the current matrix at the top of the stack.
 
@@ -72,7 +75,3 @@ Note that this method does not remove the current matrix from the top of the sta
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--gettop.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--gettop.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::GetTop method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Retrieves the current matrix at the top of the stack.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--loadidentity.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--loadidentity.md
@@ -4,19 +4,22 @@ ms.assetid: e314a51f-4016-4819-a95d-d91864a54b2e
 title: ID3DXMATRIXStack::LoadIdentity method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.LoadIdentity
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::LoadIdentity method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads identity in the current matrix.
 
@@ -67,7 +70,3 @@ The identity matrix is a matrix in which all coefficients are 0.0 except the \[1
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--loadidentity.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--loadidentity.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::LoadIdentity method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads identity in the current matrix.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--loadmatrix.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--loadmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: c4c5ac50-238f-4b41-8ea9-7e48ffd03fc5
 title: ID3DXMATRIXStack::LoadMatrix method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.LoadMatrix
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::LoadMatrix method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads the given matrix into the current matrix.
 
@@ -78,7 +81,3 @@ Note that this method does not add an item to the stack; rather, it replaces the
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--loadmatrix.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--loadmatrix.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::LoadMatrix method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Loads the given matrix into the current matrix.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--multmatrix.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--multmatrix.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::MultMatrix method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the given matrix.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--multmatrix.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--multmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: a673ce82-6fed-4a3f-8c37-d0db11195f06
 title: ID3DXMATRIXStack::MultMatrix method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.MultMatrix
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::MultMatrix method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the given matrix.
 
@@ -87,7 +90,3 @@ This method does not add an item to the stack, it replaces the current matrix wi
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--multmatrixlocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--multmatrixlocal.md
@@ -4,19 +4,22 @@ ms.assetid: 6f909b38-821c-4173-aba9-fd4392f70551
 title: ID3DXMATRIXStack::MultMatrixLocal method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.MultMatrixLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::MultMatrixLocal method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the given matrix and the current matrix.
 
@@ -87,7 +90,3 @@ This method does not add an item to the stack, it replaces the current matrix wi
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--multmatrixlocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--multmatrixlocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::MultMatrixLocal method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the given matrix and the current matrix.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--pop.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--pop.md
@@ -4,19 +4,22 @@ ms.assetid: 4c542012-058a-4818-8ec4-27e7d3357ca3
 title: ID3DXMATRIXStack::Pop method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Pop
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::Pop method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Removes the current matrix from the top of the stack.
 
@@ -70,7 +73,3 @@ Note that this method decrements the count of items on the stack by 1, effective
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--pop.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--pop.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Pop method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Removes the current matrix from the top of the stack.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--push.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--push.md
@@ -4,19 +4,22 @@ ms.assetid: 99bc636d-f1fd-4ace-a649-6a1a952927e0
 title: ID3DXMATRIXStack::Push method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Push
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::Push method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Adds a matrix to the stack.
 
@@ -70,7 +73,3 @@ This method increments the count of items on the stack by 1, duplicating the cur
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/id3dxmatrixstack--push.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--push.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Push method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Adds a matrix to the stack.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateaxis.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateaxis.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateAxis method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateaxis.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateaxis.md
@@ -4,19 +4,22 @@ ms.assetid: b7ae5195-a2af-429f-9a0d-51cd7e955362
 title: ID3DXMATRIXStack::RotateAxis method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateAxis
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::RotateAxis method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateaxislocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateaxislocal.md
@@ -4,19 +4,22 @@ ms.assetid: c7ef11e9-f4c4-4801-8f25-190066baeb52
 title: ID3DXMATRIXStack::RotateAxisLocal method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateAxisLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::RotateAxisLocal method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateaxislocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateaxislocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateAxisLocal method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchroll.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: 25a7eff4-a575-4ddb-85eb-ef3fa2d6ae3b
 title: ID3DXMATRIXStack::RotateYawPitchRoll method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateYawPitchRoll
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::RotateYawPitchRoll method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchroll.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchroll.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateYawPitchRoll method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to world coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchrolllocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchrolllocal.md
@@ -4,19 +4,22 @@ ms.assetid: c69f5ea7-5d14-4187-9405-1ceff8230185
 title: ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.RotateYawPitchRollLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchrolllocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--rotateyawpitchrolllocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::RotateYawPitchRollLocal method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Rotates (relative to the object's local coordinate space) around an arbitrary axis.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--scale.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--scale.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Scale method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the world coordinate origin.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--scale.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--scale.md
@@ -4,19 +4,22 @@ ms.assetid: 6c4ef625-736e-41a0-8a79-4d71e8685754
 title: ID3DXMATRIXStack::Scale method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Scale
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::Scale method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the world coordinate origin.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--scalelocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--scalelocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::ScaleLocal method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the object origin.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--scalelocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--scalelocal.md
@@ -4,19 +4,22 @@ ms.assetid: fe71da67-c8c9-4c78-9055-9bc3cadc0780
 title: ID3DXMATRIXStack::ScaleLocal method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.ScaleLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::ScaleLocal method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Scale the current matrix about the object origin.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--translate.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--translate.md
@@ -4,19 +4,22 @@ ms.assetid: e0ac72a2-9970-433e-9026-aa79edc8261c
 title: ID3DXMATRIXStack::Translate method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.Translate
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::Translate method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the computed translation matrix determined by the given factors (x, y, and z).
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--translate.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--translate.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::Translate method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the current matrix and the computed translation matrix determined by the given factors (x, y, and z).
 

--- a/desktop-src/direct3d9/id3dxmatrixstack--translatelocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--translatelocal.md
@@ -4,19 +4,22 @@ ms.assetid: d4752a6c-2114-4016-a69f-dcc561d2c76b
 title: ID3DXMATRIXStack::TranslateLocal method (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack.TranslateLocal
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack::TranslateLocal method (D3dx9math.h)
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the computed translation matrix determined by the given factors (x, y, and z) and the current matrix.
 
@@ -76,7 +79,7 @@ This method left-multiplies the current matrix with the computed translation mat
 
 
 ```
-    
+
 D3DXMATRIX tmp;
 D3DXMatrixTranslation( &tmp, x, y, z );
 m_stack[m_currentPos] = tmp * m_stack[m_currentPos];

--- a/desktop-src/direct3d9/id3dxmatrixstack--translatelocal.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack--translatelocal.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack::TranslateLocal method (D3dx9math.h)
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Determines the product of the computed translation matrix determined by the given factors (x, y, and z) and the current matrix.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack.md
@@ -19,7 +19,7 @@ api_location:
 # ID3DXMATRIXStack interface
 
 > [!Note]
-> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Applications use the methods of the ID3DXMATRIXStack interface to manipulate a matrix stack.
 

--- a/desktop-src/direct3d9/id3dxmatrixstack.md
+++ b/desktop-src/direct3d9/id3dxmatrixstack.md
@@ -4,19 +4,22 @@ ms.assetid: 4d382d39-a9da-4a3b-b7b6-d6890357d467
 title: ID3DXMATRIXStack interface (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - ID3DXMATRIXStack
-api_type: 
+api_type:
 - COM
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # ID3DXMATRIXStack interface
+
+> [!Note]
+> The math functions of the D3DX utility library are deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
 
 Applications use the methods of the ID3DXMATRIXStack interface to manipulate a matrix stack.
 

--- a/desktop-src/direct3d9/matrix-stacks.md
+++ b/desktop-src/direct3d9/matrix-stacks.md
@@ -8,6 +8,9 @@ ms.date: 05/31/2018
 
 # Matrix Stacks (Direct3D 9)
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead along with this header from [GitHub](https://github.com/microsoft/DirectXMath/tree/main/MatrixStack).
+
 The D3DX utility library provides the [**ID3DXMATRIXStack**](id3dxmatrixstack.md) interface. It supplies a mechanism to enable matrices to be pushed onto and popped off of a matrix stack. Implementing a matrix stack is an efficient way to track matrices while traversing a transform hierarchy.
 
 The D3DX utility library uses a matrix stack to store transformations as matrices. The various methods of the [**ID3DXMATRIXStack**](id3dxmatrixstack.md) interface deal with the current matrix, or the matrix located on top of the stack. You can clear the current matrix with the [**ID3DXMATRIXStack::LoadIdentity**](id3dxmatrixstack--loadidentity.md) method. To explicitly specify a certain matrix to load as the current transformation matrix, use the [**ID3DXMATRIXStack::LoadMatrix**](id3dxmatrixstack--loadmatrix.md) method. Then you can call either the [**ID3DXMATRIXStack::MultMatrix**](id3dxmatrixstack--multmatrix.md) method or the [**ID3DXMATRIXStack::MultMatrixLocal**](id3dxmatrixstack--multmatrixlocal.md) method to multiply the current matrix by the specified matrix.
@@ -87,6 +90,3 @@ For more information about the specific methods that you can perform on a D3DX m
  
 
  
-
-
-


### PR DESCRIPTION
Added link to each D3DX9 and D3DX10 matrix stack methods to point the open source replacement on DirectXMath GitHub.