### PR TITLE
Add links to DirectXMath for D3DXMath functions

### DIFF
--- a/desktop-src/direct3d10/d3d10-d3dxboxboundprobe.md
+++ b/desktop-src/direct3d10/d3d10-d3dxboxboundprobe.md
@@ -4,19 +4,22 @@ ms.assetid: d3cdcf89-461b-44b0-b5d0-ca2e3869a5ad
 title: D3DXBoxBoundProbe function (D3DX10math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXBoxBoundProbe
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXBoxBoundProbe function (D3DX10math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines whether a ray intersects the volume of a box's bounding box.
 

--- a/desktop-src/direct3d10/d3d10-d3dxcolor.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcolor.md
@@ -4,18 +4,21 @@ ms.assetid: bb5e36c8-4f24-41b5-84e7-3034e497721d
 title: D3DXCOLOR structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXCOLOR
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXCOLOR structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes color values.
 

--- a/desktop-src/direct3d10/d3d10-d3dxcoloradjustcontrast.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcoloradjustcontrast.md
@@ -4,19 +4,22 @@ ms.assetid: c111d3c7-19c6-4a6b-af0d-a9e1bc0bb7d9
 title: D3DXColorAdjustContrast function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorAdjustContrast
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXColorAdjustContrast function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adjusts the contrast value of a color.
 

--- a/desktop-src/direct3d10/d3d10-d3dxcoloradjustsaturation.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcoloradjustsaturation.md
@@ -4,19 +4,22 @@ ms.assetid: a7ca64b4-2198-4116-8e9f-79d6c922fd09
 title: D3DXColorAdjustSaturation function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorAdjustSaturation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXColorAdjustSaturation function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adjusts the saturation value of a color.
 

--- a/desktop-src/direct3d10/d3d10-d3dxcomputeboundingbox.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcomputeboundingbox.md
@@ -4,19 +4,22 @@ ms.assetid: 1b8f328c-2fe1-462e-b464-c8dd9dc03e67
 title: D3DXComputeBoundingBox function (D3DX10math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXComputeBoundingBox
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXComputeBoundingBox function (D3DX10math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a coordinate-axis oriented bounding box.
 

--- a/desktop-src/direct3d10/d3d10-d3dxcomputeboundingsphere.md
+++ b/desktop-src/direct3d10/d3d10-d3dxcomputeboundingsphere.md
@@ -4,19 +4,22 @@ ms.assetid: 54f486d2-45e9-4fc1-90a3-97488ed4d900
 title: D3DXComputeBoundingSphere function (D3DX10math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXComputeBoundingSphere
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXComputeBoundingSphere function (D3DX10math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a bounding sphere for the mesh.
 

--- a/desktop-src/direct3d10/d3d10-d3dxfloat16.md
+++ b/desktop-src/direct3d10/d3d10-d3dxfloat16.md
@@ -4,20 +4,23 @@ ms.assetid: 2aaca07b-66eb-4845-9d22-692be02234ac
 title: D3DXFLOAT16 structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFLOAT16
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXFLOAT16 structure (D3DX10Math.h)
 
-Describes a 16-bit floating point vector.
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
+
+Describes a 16-bit floating point value.
 
 ## Syntax
 

--- a/desktop-src/direct3d10/d3d10-d3dxfloat16to32array.md
+++ b/desktop-src/direct3d10/d3d10-d3dxfloat16to32array.md
@@ -4,19 +4,22 @@ ms.assetid: cf07a21d-9ea3-4fbe-ab8f-564e2bbb8d60
 title: D3DXFloat16To32Array function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFloat16To32Array
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXFloat16To32Array function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts an array of 16-bit floats to 32-bit floats.
 

--- a/desktop-src/direct3d10/d3d10-d3dxfloat32to16array.md
+++ b/desktop-src/direct3d10/d3d10-d3dxfloat32to16array.md
@@ -4,19 +4,22 @@ ms.assetid: 2114cf25-cc83-4c4a-9db5-ecc0f8ff1e85
 title: D3DXFloat32To16Array function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFloat32To16Array
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXFloat32To16Array function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts an array of 32-bit floats to 16-bit floats.
 

--- a/desktop-src/direct3d10/d3d10-d3dxfresnelterm.md
+++ b/desktop-src/direct3d10/d3d10-d3dxfresnelterm.md
@@ -4,19 +4,22 @@ ms.assetid: eaa2e5ea-9b6f-4216-8b48-7be74501124d
 title: D3DXFresnelTerm function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFresnelTerm
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXFresnelTerm function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculate the Fresnel term.
 

--- a/desktop-src/direct3d10/d3d10-d3dxintersecttri.md
+++ b/desktop-src/direct3d10/d3d10-d3dxintersecttri.md
@@ -4,19 +4,22 @@ ms.assetid: 819f2543-8046-47c9-93b8-7d888264786f
 title: D3DXIntersectTri function (D3DX10math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXIntersectTri
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXIntersectTri function (D3DX10math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes the intersection of a ray and a triangle.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrix.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrix.md
@@ -4,18 +4,21 @@ ms.assetid: c354d28b-bb08-41c5-bb59-90a912181f0f
 title: D3DXMATRIX structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMATRIX
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXMATRIX structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 A 4x4 matrix that contains methods and operator overloads.
 
@@ -107,7 +110,7 @@ public:
 #else //!__cplusplus
 typedef struct _D3DMATRIX D3DXMATRIX, *LPD3DXMATRIX;
 #endif //!__cplusplus
-        
+
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixa16.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixa16.md
@@ -4,18 +4,21 @@ ms.assetid: d9e9c1cc-7555-4011-a4b4-8cce20404841
 title: D3DXMATRIXA16 structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMATRIXA16
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXMATRIXA16 structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 A 4x4, 16-byte-aligned matrix that contains methods and operator overloads.
 
@@ -87,7 +90,7 @@ typedef struct _D3DXMATRIXA16 : public D3DXMATRIX
 } _D3DXMATRIXA16;
 
 typedef D3DX_ALIGN16 _D3DXMATRIXA16 D3DXMATRIXA16, *LPD3DXMATRIXA16;
-        
+
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixaffinetransformation.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixaffinetransformation.md
@@ -4,19 +4,22 @@ ms.assetid: 36044272-a8ce-47db-8f52-30dc680f8174
 title: D3DXMatrixAffineTransformation function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixAffineTransformation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixAffineTransformation function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 3D affine transformation matrix. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixaffinetransformation2d.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixaffinetransformation2d.md
@@ -4,19 +4,22 @@ ms.assetid: f46a307c-4566-42c8-8def-fb189116144e
 title: D3DXMatrixAffineTransformation2D function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixAffineTransformation2D
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixAffineTransformation2D function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 2D affine transformation matrix in the x-y plane. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixdecompose.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixdecompose.md
@@ -4,19 +4,22 @@ ms.assetid: 3694769f-56e7-4983-924e-021c129462a2
 title: D3DXMatrixDecompose function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixDecompose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixDecompose function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Breaks down a general 3D transformation matrix into its scalar, rotational, and translational components.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixdeterminant.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixdeterminant.md
@@ -4,19 +4,22 @@ ms.assetid: b0155c91-1554-42ef-b219-c6cdd2a905b5
 title: D3DXMatrixDeterminant function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixDeterminant
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixDeterminant function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the determinant of a matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixinverse.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixinverse.md
@@ -4,19 +4,22 @@ ms.assetid: 928a201b-814d-41cc-bfab-d2f8a12addeb
 title: D3DXMatrixInverse function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixInverse
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixInverse function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the inverse of a matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixlookatlh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixlookatlh.md
@@ -4,19 +4,22 @@ ms.assetid: 06888a97-66ef-447f-be8b-ea458ce16b4b
 title: D3DXMatrixLookAtLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixLookAtLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixLookAtLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed, look-at matrix.
 
@@ -91,7 +94,7 @@ This function uses the following formula to compute the returned matrix.
 zaxis = normal(At - Eye)
 xaxis = normal(cross(Up, zaxis))
 yaxis = cross(zaxis, xaxis)
-    
+
  xaxis.x           yaxis.x           zaxis.x          0
  xaxis.y           yaxis.y           zaxis.y          0
  xaxis.z           yaxis.z           zaxis.z          0

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixlookatrh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixlookatrh.md
@@ -4,19 +4,22 @@ ms.assetid: 98c8932f-f179-42ed-a361-a89065b71876
 title: D3DXMatrixLookAtRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixLookAtRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixLookAtRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed, look-at matrix.
 
@@ -91,7 +94,7 @@ This function uses the following formula to compute the returned matrix.
 zaxis = normal(Eye - At)
 xaxis = normal(cross(Up, zaxis))
 yaxis = cross(zaxis, xaxis)
-    
+
  -xaxis.x           yaxis.x           -zaxis.x          0
  -xaxis.y           yaxis.y           -zaxis.y          0
  -xaxis.z           yaxis.z           -zaxis.z          0

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixmultiply.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixmultiply.md
@@ -4,19 +4,22 @@ ms.assetid: d15cd680-0e19-4353-9eee-73933663960e
 title: D3DXMatrixMultiply function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixMultiply
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixMultiply function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the product of two matrices.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixmultiplytranspose.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixmultiplytranspose.md
@@ -4,19 +4,22 @@ ms.assetid: 3db4138c-407c-47b5-b8b9-04af8771e98e
 title: D3DXMatrixMultiplyTranspose function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixMultiplyTranspose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixMultiplyTranspose function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the transposed product of two matrices.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixortholh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixortholh.md
@@ -4,19 +4,22 @@ ms.assetid: 67bec4a3-2126-4f5a-9301-97faa6dc6e84
 title: D3DXMatrixOrthoLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixOrthoLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixorthooffcenterlh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixorthooffcenterlh.md
@@ -4,19 +4,22 @@ ms.assetid: 84175c08-5a0b-4183-afe2-8aecafd73897
 title: D3DXMatrixOrthoOffCenterLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoOffCenterLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixOrthoOffCenterLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, left-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixorthooffcenterrh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixorthooffcenterrh.md
@@ -4,19 +4,22 @@ ms.assetid: 01d4d61e-de7b-4431-a168-68a50b1d6021
 title: D3DXMatrixOrthoOffCenterRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoOffCenterRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixOrthoOffCenterRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, right-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixorthorh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixorthorh.md
@@ -4,19 +4,22 @@ ms.assetid: e6673ff4-06a2-4a16-b72e-5ca69ddf2438
 title: D3DXMatrixOrthoRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixOrthoRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivefovlh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivefovlh.md
@@ -4,19 +4,22 @@ ms.assetid: 35ee12d6-0a58-4b00-ac8f-82f82215f02e
 title: D3DXMatrixPerspectiveFovLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveFovLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveFovLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed perspective projection matrix based on a field of view.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivefovrh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivefovrh.md
@@ -4,19 +4,22 @@ ms.assetid: a75e6666-e6c0-4a54-bc88-835fa012542f
 title: D3DXMatrixPerspectiveFovRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveFovRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveFovRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed perspective projection matrix based on a field of view.
 
@@ -104,7 +107,7 @@ xScale     0          0              0
 0          0      zn*zf/(zn-zf)      0
 where:
 yScale = cot(fovY/2)
-    
+
 xScale = yScale / aspect ratio
 ```
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivelh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectivelh.md
@@ -4,19 +4,22 @@ ms.assetid: 5fd8da67-ff12-42fa-b915-b50fa2680b32
 title: D3DXMatrixPerspectiveLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed perspective projection matrix
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiveoffcenterlh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiveoffcenterlh.md
@@ -4,19 +4,22 @@ ms.assetid: 73616fcc-1799-4e65-92b9-2d8f500c326e
 title: D3DXMatrixPerspectiveOffCenterLH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveOffCenterLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveOffCenterLH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, left-handed perspective projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiveoffcenterrh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiveoffcenterrh.md
@@ -4,19 +4,22 @@ ms.assetid: 51509bfc-2f49-4ba7-8918-3c44d857d4b2
 title: D3DXMatrixPerspectiveOffCenterRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveOffCenterRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveOffCenterRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, right-handed perspective projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiverh.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixperspectiverh.md
@@ -4,19 +4,22 @@ ms.assetid: 324c8a21-24ef-4b3a-aac1-a753e26076d4
 title: D3DXMatrixPerspectiveRH function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixPerspectiveRH function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed perspective projection matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixreflect.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixreflect.md
@@ -4,19 +4,22 @@ ms.assetid: bd2c5905-780e-4fac-a848-d7dbcfc390c6
 title: D3DXMatrixReflect function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixReflect
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixReflect function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that reflects the coordinate system about a plane.
 
@@ -71,7 +74,7 @@ This function uses the following formula to compute the returned matrix.
 
 ```
 P = normalize(Plane);
-    
+
 -2 * P.a * P.a + 1  -2 * P.b * P.a      -2 * P.c * P.a        0
 -2 * P.a * P.b      -2 * P.b * P.b + 1  -2 * P.c * P.b        0
 -2 * P.a * P.c      -2 * P.b * P.c      -2 * P.c * P.c + 1    0

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationaxis.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationaxis.md
@@ -4,19 +4,22 @@ ms.assetid: dc4b8b3f-e1d2-475f-9dcb-622ada9fae6b
 title: D3DXMatrixRotationAxis function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationAxis
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationAxis function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around an arbitrary axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationquaternion.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationquaternion.md
@@ -4,19 +4,22 @@ ms.assetid: dcbf8696-b959-4475-a250-6094dd5fe358
 title: D3DXMatrixRotationQuaternion function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationQuaternion
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationQuaternion function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a rotation matrix from a quaternion.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationx.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationx.md
@@ -4,19 +4,22 @@ ms.assetid: 895079bf-b807-4bfd-9222-a7c1251d7d1e
 title: D3DXMatrixRotationX function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationX
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationX function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the x-axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationy.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationy.md
@@ -4,19 +4,22 @@ ms.assetid: b58def9b-29dc-4c7d-89a3-188ef9b9f94f
 title: D3DXMatrixRotationY function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationY
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationY function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the y-axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationyawpitchroll.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: a3ef2b57-275f-484a-88fc-aaa5e470717c
 title: D3DXMatrixRotationYawPitchRoll function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationYawPitchRoll
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationYawPitchRoll function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix with a specified yaw, pitch, and roll.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixrotationz.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixrotationz.md
@@ -4,19 +4,22 @@ ms.assetid: a168ea24-0cec-4e1b-a128-e9dadedf190b
 title: D3DXMatrixRotationZ function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationZ
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixRotationZ function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the z-axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixscaling.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixscaling.md
@@ -4,19 +4,22 @@ ms.assetid: 1804bf41-26de-4be1-ad62-7a871d7408e6
 title: D3DXMatrixScaling function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixScaling
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixScaling function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that scales along the x-axis, the y-axis, and the z-axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixshadow.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixshadow.md
@@ -4,19 +4,22 @@ ms.assetid: 83c9e7d6-fc6c-48e7-bbf2-6aa10868351d
 title: D3DXMatrixShadow function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixShadow
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixShadow function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that flattens geometry into a plane.
 
@@ -83,7 +86,7 @@ This function uses the following formula to compute the returned matrix.
 P = normalize(Plane);
 L = Light;
 d = dot(P, L)
-    
+
 P.a * L.x + d  P.a * L.y      P.a * L.z      P.a * L.w  
 P.b * L.x      P.b * L.y + d  P.b * L.z      P.b * L.w  
 P.c * L.x      P.c * L.y      P.c * L.z + d  P.c * L.w  

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixtransformation.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixtransformation.md
@@ -4,19 +4,22 @@ ms.assetid: 99c75ce9-3683-4753-b635-760eb8aaf46e
 title: D3DXMatrixTransformation function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTransformation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixTransformation function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a transformation matrix. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixtransformation2d.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixtransformation2d.md
@@ -4,19 +4,22 @@ ms.assetid: 5b894c3b-a532-458a-bcbc-48fcd5c73c34
 title: D3DXMatrixTransformation2D function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTransformation2D
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixTransformation2D function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 2D transformation matrix that represents transformations in the xy plane. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixtranslation.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixtranslation.md
@@ -4,19 +4,22 @@ ms.assetid: a3565a06-22af-4ded-8835-da4c7ae81805
 title: D3DXMatrixTranslation function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTranslation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixTranslation function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Create a translation matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxmatrixtranspose.md
+++ b/desktop-src/direct3d10/d3d10-d3dxmatrixtranspose.md
@@ -4,19 +4,22 @@ ms.assetid: 934b17cc-39c4-425c-839b-69e080f0efd7
 title: D3DXMatrixTranspose function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTranspose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXMatrixTranspose function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the matrix transpose of a matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplane.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplane.md
@@ -4,18 +4,21 @@ ms.assetid: c6da7343-a4f3-4cac-855b-14bd70c0d3c2
 title: D3DXPLANE structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPLANE
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXPLANE structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a plane.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplanefrompointnormal.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplanefrompointnormal.md
@@ -4,19 +4,22 @@ ms.assetid: 93c644d2-ab8c-47a1-9a3b-8b9c6a13178b
 title: D3DXPlaneFromPointNormal function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneFromPointNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneFromPointNormal function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Constructs a plane from a point and a normal.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplanefrompoints.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplanefrompoints.md
@@ -4,19 +4,22 @@ ms.assetid: 0e77af1b-cedf-482c-8398-10becb398a2c
 title: D3DXPlaneFromPoints function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneFromPoints
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneFromPoints function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Constructs a plane from three points.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplaneintersectline.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplaneintersectline.md
@@ -4,19 +4,22 @@ ms.assetid: aea1c4e1-f8c0-46df-bb33-2b517396d69e
 title: D3DXPlaneIntersectLine function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneIntersectLine
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneIntersectLine function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Finds the intersection between a plane and a line.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplanenormalize.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplanenormalize.md
@@ -4,19 +4,22 @@ ms.assetid: 52ae36a7-e37b-457a-9832-e62900a85bde
 title: D3DXPlaneNormalize function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneNormalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneNormalize function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Normalizes the plane coefficients so that the plane normal has unit length.
 

--- a/desktop-src/direct3d10/d3d10-d3dxplanetransform.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplanetransform.md
@@ -4,19 +4,22 @@ ms.assetid: ded06eac-4086-47e8-bc55-c37959afc22d
 title: D3DXPlaneTransform function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneTransform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneTransform function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a plane by a matrix. The input matrix is the inverse transpose of the actual transformation.
 
@@ -83,7 +86,7 @@ D3DXPLANE   plane(0,1,1,0);
 D3DXPlaneNormalize(&plane, &plane);
 
 D3DXMATRIX  matrix;
-D3DXMatrixScaling(&matrix, 1.0f,2.0f,3.0f); 
+D3DXMatrixScaling(&matrix, 1.0f,2.0f,3.0f);
 D3DXMatrixInverse(&matrix, NULL, &matrix);
 D3DXMatrixTranspose(&matrix, &matrix);
 D3DXPlaneTransform(&planeNew, &plane, &matrix);

--- a/desktop-src/direct3d10/d3d10-d3dxplanetransformarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxplanetransformarray.md
@@ -4,19 +4,22 @@ ms.assetid: 9529b06a-0575-4115-8d35-fc35a7bfb0bd
 title: D3DXPlaneTransformArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneTransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXPlaneTransformArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array of planes by a matrix. The vectors that describe each plane must be normalized.
 
@@ -117,10 +120,10 @@ for(int i = 0; i < ARRAYSIZE; i++)
 }
 
 D3DXMATRIX  matrix;
-D3DXMatrixScaling( &matrix, 1.0f, 2.0f, 3.0f ); 
+D3DXMatrixScaling( &matrix, 1.0f, 2.0f, 3.0f );
 D3DXMatrixInverse( &matrix, NULL, &matrix );
 D3DXMatrixTranspose( &matrix, &matrix );
-D3DXPlaneTransformArray( &planeNew, sizeof (D3DXPLANE), &plane, 
+D3DXPlaneTransformArray( &planeNew, sizeof (D3DXPLANE), &plane,
                          sizeof (D3DXPLANE), &matrix, ARRAYSIZE );
 ```
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternion.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternion.md
@@ -4,18 +4,21 @@ ms.assetid: e6cb45b2-3132-4315-b02d-a3dfc444f8cc
 title: D3DXQUATERNION structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQUATERNION
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXQUATERNION structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a quaternion.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionbarycentric.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionbarycentric.md
@@ -4,19 +4,22 @@ ms.assetid: 0a8d8d5a-f486-4457-86e9-27e76eaf1bc4
 title: D3DXQuaternionBaryCentric function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionBaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionBaryCentric function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a quaternion in barycentric coordinates.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionexp.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionexp.md
@@ -4,19 +4,22 @@ ms.assetid: bd70c432-ac61-4c38-b10b-3b103e49ead8
 title: D3DXQuaternionExp function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionExp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionExp function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the exponential.
 
@@ -67,8 +70,8 @@ This method converts a pure quaternion to a unit quaternion. D3DXQuaternionExp e
 
 ```
 Given a pure quaternion defined by:
-q = (0, theta * v); 
-    
+q = (0, theta * v);
+
 This method calculates the exponential result.
 exp(Q) = (cos(theta), sin(theta) * v)
 ```

--- a/desktop-src/direct3d10/d3d10-d3dxquaternioninverse.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternioninverse.md
@@ -4,19 +4,22 @@ ms.assetid: 8e1bba91-8895-43a2-805b-1368050f8e82
 title: D3DXQuaternionInverse function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionInverse
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionInverse function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Conjugates and renormalizes a quaternion.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionln.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionln.md
@@ -4,19 +4,22 @@ ms.assetid: 576cf676-bb42-45ec-8e45-4612a7cdb167
 title: D3DXQuaternionLn function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionLn
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionLn function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the natural logarithm.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionmultiply.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionmultiply.md
@@ -4,19 +4,22 @@ ms.assetid: f549e383-9c39-47a9-84e4-82365bdf1155
 title: D3DXQuaternionMultiply function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionMultiply
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionMultiply function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Multiplies two quaternions.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionnormalize.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionnormalize.md
@@ -4,19 +4,22 @@ ms.assetid: 6735a632-64d7-4bc1-b63e-d0cd27f5a29b
 title: D3DXQuaternionNormalize function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionNormalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionNormalize function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a unit length quaternion.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionrotationaxis.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionrotationaxis.md
@@ -4,19 +4,22 @@ ms.assetid: 9673ef89-458f-4a25-960e-8f03179e78ba
 title: D3DXQuaternionRotationAxis function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationAxis
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionRotationAxis function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Rotates a quaternion about an arbitrary axis.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionrotationmatrix.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionrotationmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: 316bf3e0-32ff-4e5e-b771-99f7eea2e27c
 title: D3DXQuaternionRotationMatrix function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationMatrix
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionRotationMatrix function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a quaternion from a rotation matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionrotationyawpitchroll.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionrotationyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: c929d9d4-b9cb-4de6-86c1-26fec3617846
 title: D3DXQuaternionRotationYawPitchRoll function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationYawPitchRoll
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionRotationYawPitchRoll function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a quaternion with the given yaw, pitch, and roll.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionslerp.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionslerp.md
@@ -4,19 +4,22 @@ ms.assetid: 487e1df1-bf20-49cb-ad14-61fcf1300904
 title: D3DXQuaternionSlerp function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSlerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionSlerp function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Interpolates between two quaternions, using spherical linear interpolation.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionsquad.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionsquad.md
@@ -4,19 +4,22 @@ ms.assetid: ba953731-4372-4b32-942b-23abfe479704
 title: D3DXQuaternionSquad function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSquad
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionSquad function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Interpolates between quaternions, using spherical quadrangle interpolation.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaternionsquadsetup.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaternionsquadsetup.md
@@ -4,19 +4,22 @@ ms.assetid: c66227bd-8cc1-4173-9dc2-5aab9d57301e
 title: D3DXQuaternionSquadSetup function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSquadSetup
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionSquadSetup function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Sets up control points for spherical quadrangle interpolation.
 

--- a/desktop-src/direct3d10/d3d10-d3dxquaterniontoaxisangle.md
+++ b/desktop-src/direct3d10/d3d10-d3dxquaterniontoaxisangle.md
@@ -4,19 +4,22 @@ ms.assetid: 1e81b88b-071d-46f1-b640-c70d063a14d1
 title: D3DXQuaternionToAxisAngle function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionToAxisAngle
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXQuaternionToAxisAngle function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a quaternion's axis and angle of rotation.
 

--- a/desktop-src/direct3d10/d3d10-d3dxsphereboundprobe.md
+++ b/desktop-src/direct3d10/d3d10-d3dxsphereboundprobe.md
@@ -4,19 +4,22 @@ ms.assetid: 5984a1a6-d36c-4a05-8c74-0ece7443356c
 title: D3DXSphereBoundProbe function (D3DX10math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSphereBoundProbe
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXSphereBoundProbe function (D3DX10math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines if a ray intersects the volume of a sphere's bounding box.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2barycentric.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2barycentric.md
@@ -4,19 +4,22 @@ ms.assetid: 8eceb2c0-26a0-4a7f-9830-85327dcb31ab
 title: D3DXVec2BaryCentric function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2BaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2BaryCentric function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 2D vectors.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2catmullrom.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2catmullrom.md
@@ -4,19 +4,22 @@ ms.assetid: 8ec1abfa-0fa9-486a-b86d-bbb8f1d63849
 title: D3DXVec2CatmullRom function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2CatmullRom
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2CatmullRom function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 2D vectors.
 
@@ -106,10 +109,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2hermite.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2hermite.md
@@ -4,19 +4,22 @@ ms.assetid: 2d6ff836-a1a7-4cd0-aea3-4fe344f4e211
 title: D3DXVec2Hermite function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Hermite
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2Hermite function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 2D vectors.
 
@@ -130,9 +133,9 @@ Plug in the solutions for A,B,C and D to generate Q(s).
 
 
 ```
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2normalize.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2normalize.md
@@ -4,19 +4,22 @@ ms.assetid: fac4f269-2778-4500-af9e-23a0112543b0
 title: D3DXVec2Normalize function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Normalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2Normalize function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 2D vector.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transform.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transform.md
@@ -4,19 +4,22 @@ ms.assetid: 4b57eb7f-fae9-48ac-a806-510da75d25a6
 title: D3DXVec2Transform function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Transform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2Transform function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 2D vector by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transformarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transformarray.md
@@ -4,19 +4,22 @@ ms.assetid: 66c8909c-6c20-4b32-9546-fcf2d0e824fa
 title: D3DXVec2TransformArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2TransformArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 1) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transformcoord.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transformcoord.md
@@ -4,19 +4,22 @@ ms.assetid: bb24204f-0c8e-4dc5-bcae-12e3033d1a39
 title: D3DXVec2TransformCoord function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformCoord
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2TransformCoord function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 2D vector by a given matrix, projecting the result back into w = 1.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transformcoordarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transformcoordarray.md
@@ -4,19 +4,22 @@ ms.assetid: dba68678-2ab4-4f64-9975-5e9f2a20f66a
 title: D3DXVec2TransformCoordArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformCoordArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2TransformCoordArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 1) by a given matrix, and projects the result back into w = 1.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transformnormal.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transformnormal.md
@@ -4,19 +4,22 @@ ms.assetid: fc238bb1-155f-4018-9c92-16352726920d
 title: D3DXVec2TransformNormal function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2TransformNormal function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms the 2D vector normal by the given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec2transformnormalarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec2transformnormalarray.md
@@ -4,19 +4,22 @@ ms.assetid: a53f998a-f2a5-4e4b-bc1c-c1f46284d78b
 title: D3DXVec2TransformNormalArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformNormalArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - D3DX10.lib
 - D3DX10.dll
 ---
 
 # D3DXVec2TransformNormalArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 0) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3barycentric.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3barycentric.md
@@ -4,18 +4,21 @@ ms.assetid: 572e151d-8044-480e-92b2-3f973d92d03e
 title: D3DXVec3BaryCentric function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3BaryCentric
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3BaryCentric function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 3D vectors.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3catmullrom.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3catmullrom.md
@@ -4,18 +4,21 @@ ms.assetid: 324bd4b5-b0df-4dd3-b370-3c365c9f2db1
 title: D3DXVec3CatmullRom function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3CatmullRom
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3CatmullRom function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 3D vectors.
 
@@ -105,10 +108,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3hermite.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3hermite.md
@@ -4,18 +4,21 @@ ms.assetid: d2212299-0478-48a6-b303-60c212528058
 title: D3DXVec3Hermite function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Hermite
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3Hermite function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 3D vectors.
 
@@ -129,9 +132,9 @@ Plug in the solutions for A,B,C and D to generate Q(s).
 
 
 ```
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3normalize.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3normalize.md
@@ -4,18 +4,21 @@ ms.assetid: 420321a2-0c3b-419c-9620-acf184e7b4f0
 title: D3DXVec3Normalize function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Normalize
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3Normalize function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 3D vector.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3project.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3project.md
@@ -4,18 +4,21 @@ ms.assetid: 6fc59788-c3f7-4f47-a345-9108105e820e
 title: D3DXVec3Project function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Project
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3Project function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects a 3D vector from object space into screen space.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3projectarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3projectarray.md
@@ -4,18 +4,21 @@ ms.assetid: 33f0f65a-c027-4a31-83a7-f5f6b2a2f72f
 title: D3DXVec3ProjectArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3ProjectArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3ProjectArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects an array (x, y, z, 0) from object space into screen space.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transform.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transform.md
@@ -4,18 +4,21 @@ ms.assetid: 88b26d94-2550-4126-bf91-b06391ec5c75
 title: D3DXVec3Transform function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Transform
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3Transform function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms vector (x, y, z, 1) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transformarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transformarray.md
@@ -4,18 +4,21 @@ ms.assetid: f64c55df-ea93-4c93-be89-eee650e6ecf0
 title: D3DXVec3TransformArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3TransformArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 1) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transformcoord.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transformcoord.md
@@ -4,18 +4,21 @@ ms.assetid: e138fdc0-6999-45ab-8bcf-54f53bd9b1bf
 title: D3DXVec3TransformCoord function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformCoord
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3TransformCoord function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 3D vector by a given matrix, projecting the result back into w = 1.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transformcoordarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transformcoordarray.md
@@ -4,18 +4,21 @@ ms.assetid: 259a885d-89be-4fea-a579-dac3dd76878f
 title: D3DXVec3TransformCoordArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformCoordArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3TransformCoordArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 1) by a given matrix, and projects the result back into w = 1.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transformnormal.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transformnormal.md
@@ -4,18 +4,21 @@ ms.assetid: 8068b80f-6222-4f23-8b1c-2ff5592fa898
 title: D3DXVec3TransformNormal function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformNormal
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3TransformNormal function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms the 3D vector normal by the given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3transformnormalarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3transformnormalarray.md
@@ -4,18 +4,21 @@ ms.assetid: 7f0a41ce-bd3a-4e35-9a5d-8178a4e7bd44
 title: D3DXVec3TransformNormalArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformNormalArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3TransformNormalArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 0) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3unproject.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3unproject.md
@@ -4,18 +4,21 @@ ms.assetid: c96d732d-0594-42b4-bc54-458a313f153e
 title: D3DXVec3Unproject function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Unproject
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3Unproject function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects a vector from screen space into object space.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec3unprojectarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec3unprojectarray.md
@@ -4,18 +4,21 @@ ms.assetid: 02db5b32-7fa3-4cde-bd63-0d8b3dfc31e7
 title: D3DXVec3UnprojectArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3UnprojectArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec3UnprojectArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects an array (x, y, z, 0) from screen space into object space.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4barycentric.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4barycentric.md
@@ -4,18 +4,21 @@ ms.assetid: 44406135-3270-4f2e-bb53-29affb2510f2
 title: D3DXVec4BaryCentric function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4BaryCentric
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4BaryCentric function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 4D vectors.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4catmullrom.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4catmullrom.md
@@ -4,18 +4,21 @@ ms.assetid: e3a10989-e25e-46fa-b72e-bade936cacf1
 title: D3DXVec4CatmullRom function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4CatmullRom
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4CatmullRom function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 4D vectors.
 
@@ -105,10 +108,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4cross.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4cross.md
@@ -4,18 +4,21 @@ ms.assetid: 4f728fbd-cf5a-4d2e-ba4f-487616d83f6d
 title: D3DXVec4Cross function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Cross
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4Cross function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the cross-product in four dimensions.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4hermite.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4hermite.md
@@ -4,18 +4,21 @@ ms.assetid: 8fddcd47-8c8a-4e14-86db-07dd44ec5767
 title: D3DXVec4Hermite function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Hermite
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4Hermite function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 4D vectors.
 
@@ -129,9 +132,9 @@ Plug in the solutions for A,B,C and D to generate Q(s).
 
 
 ```
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4normalize.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4normalize.md
@@ -4,18 +4,21 @@ ms.assetid: ed3c48cf-4985-4ef3-b733-f8532e3ff6b5
 title: D3DXVec4Normalize function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Normalize
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4Normalize function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 4D vector.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4transform.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4transform.md
@@ -4,18 +4,21 @@ ms.assetid: ccbf33bc-1f94-4cf8-b048-220d54516e00
 title: D3DXVec4Transform function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Transform
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4Transform function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 4D vector by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvec4transformarray.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvec4transformarray.md
@@ -4,18 +4,21 @@ ms.assetid: afd5cccb-e22f-4726-a84e-9eac1c1c277f
 title: D3DXVec4TransformArray function (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4TransformArray
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVec4TransformArray function (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, w) by a given matrix.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector2-16f.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector2-16f.md
@@ -4,18 +4,21 @@ ms.assetid: b410d2e1-a006-4563-928a-c9000f73c224
 title: D3DXVECTOR2_16F structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR2_16F
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR2\_16F structure
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a two-component vector including operator overloads and type casts. Same as a [**D3DXVECTOR2**](d3d10-d3dxvector2.md), but it uses 16-bit floating point values for x, y, and z.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector2.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector2.md
@@ -4,18 +4,21 @@ ms.assetid: 5b7b4847-b994-48c6-ae3c-e48ee1716ddd
 title: D3DXVECTOR2 structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR2
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR2 structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a two-component vector including operator overloads and type casts.
 
@@ -104,7 +107,7 @@ public:
 #endif //__cplusplus
     FLOAT x, y;
 } D3DXVECTOR2, *LPD3DXVECTOR2;
-        
+
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector3-16f.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector3-16f.md
@@ -4,18 +4,21 @@ ms.assetid: b21676f1-5cff-4eef-bd60-5c09882283dc
 title: D3DXVECTOR3_16F structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR3_16F
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR3\_16F structure
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Same as a [**D3DXVECTOR3**](d3d10-d3dxvector3.md), but it uses 16-bit floating point values for x, y, and z.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector3.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector3.md
@@ -4,18 +4,21 @@ ms.assetid: d170cd26-d705-4a31-82b3-f9ea070b6ca4
 title: D3DXVECTOR3 structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR3
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR3 structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a three-component vector including operator overloads and type casts.
 
@@ -117,7 +120,7 @@ public:
 #else //!__cplusplus
 typedef struct _D3DVECTOR D3DXVECTOR3, *LPD3DXVECTOR3;
 #endif //!__cplusplus
-        
+
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector4-16f.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector4-16f.md
@@ -4,18 +4,21 @@ ms.assetid: 2db5fb3e-ffe0-4bcf-8894-a8bc7eefaf82
 title: D3DXVECTOR4_16F structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR4_16F
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR4\_16F structure
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Same as a [**D3DXVECTOR4**](d3d10-d3dxvector4.md), but it uses 16-bit floating point values for x, y, and z.
 

--- a/desktop-src/direct3d10/d3d10-d3dxvector4.md
+++ b/desktop-src/direct3d10/d3d10-d3dxvector4.md
@@ -4,18 +4,21 @@ ms.assetid: c6348346-f317-48ed-a369-e39fdb4dc1d6
 title: D3DXVECTOR4 structure (D3DX10Math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR4
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - D3DX10Math.h
 ---
 
 # D3DXVECTOR4 structure (D3DX10Math.h)
+
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a four-component vector including operator overloads and type casts.
 
@@ -128,7 +131,7 @@ public:
 #endif //__cplusplus
     FLOAT x, y, z, w;
 } D3DXVECTOR4, *LPD3DXVECTOR4;
-        
+
 ```
 
 

--- a/desktop-src/direct3d10/d3d10-graphics-reference-d3dx10-functions-math.md
+++ b/desktop-src/direct3d10/d3d10-graphics-reference-d3dx10-functions-math.md
@@ -8,8 +8,8 @@ ms.date: 05/31/2018
 
 # Math Functions (Direct3D 10 Graphics)
 
-> [!Note]  
-> The math functions of the D3DX utility library are deprecated for Windows 8. We recommend that you use [DirectXMath](../dxmath/directxmath-portal.md) instead.
+> [!Note]
+> The D3DX10 utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
  
 

--- a/desktop-src/direct3d9/d3dxcolor-extensions.md
+++ b/desktop-src/direct3d9/d3dxcolor-extensions.md
@@ -4,18 +4,21 @@ ms.assetid: 89780c6f-c78b-4ebe-876a-6dbc37b598ef
 title: D3DXCOLOR Extensions (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXCOLOR
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXCOLOR Extensions
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Supplies the following operator overloads and type casts for [**D3DXCOLOR**](d3dxcolor.md) structures.
 

--- a/desktop-src/direct3d9/d3dxcolor.md
+++ b/desktop-src/direct3d9/d3dxcolor.md
@@ -4,18 +4,21 @@ ms.assetid: 53d3176a-f727-498e-8bea-0e30e0a1c66e
 title: D3DXCOLOR structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXCOLOR
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXCOLOR structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes color values.
 

--- a/desktop-src/direct3d9/d3dxcoloradd.md
+++ b/desktop-src/direct3d9/d3dxcoloradd.md
@@ -4,19 +4,22 @@ ms.assetid: 7743392d-4676-4408-93e9-f92d4bf02411
 title: D3DXColorAdd function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorAdd
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorAdd function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adds two color values together to create a new color value.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in pOut. In this w
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxcoloradjustcontrast.md
+++ b/desktop-src/direct3d9/d3dxcoloradjustcontrast.md
@@ -4,19 +4,22 @@ ms.assetid: be49c9c7-b625-4cbc-bd63-1d5766ae2dbb
 title: D3DXColorAdjustContrast function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorAdjustContrast
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorAdjustContrast function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adjusts the contrast value of a color.
 

--- a/desktop-src/direct3d9/d3dxcoloradjustsaturation.md
+++ b/desktop-src/direct3d9/d3dxcoloradjustsaturation.md
@@ -4,19 +4,22 @@ ms.assetid: 1f66c3b4-2f02-4993-80c6-c484180c2459
 title: D3DXColorAdjustSaturation function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorAdjustSaturation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorAdjustSaturation function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adjusts the saturation value of a color.
 
@@ -83,7 +86,7 @@ This function interpolates the red, green, and blue color components of a [**D3D
     // Approximate values for each component's contribution to luminance.
     // Based upon the NTSC standard described in ITU-R Recommendation BT.709.
     FLOAT grey = pC->r * 0.2125f + pC->g * 0.7154f + pC->b * 0.0721f;
-    
+
     pOut->r = grey + s * (pC->r - grey);
 ```
 

--- a/desktop-src/direct3d9/d3dxcolorlerp.md
+++ b/desktop-src/direct3d9/d3dxcolorlerp.md
@@ -4,19 +4,22 @@ ms.assetid: bf7bf2f4-5fb5-44d3-a7e5-7998640d7d49
 title: D3DXColorLerp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorLerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorLerp function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Uses linear interpolation to create a color value.
 
@@ -88,7 +91,7 @@ This function interpolates the red, green, blue, and alpha components of a [**D3
 
 
 ```
-   
+
 pOut->r = pC1->r + s * (pC2->r - pC1->r);
 ```
 

--- a/desktop-src/direct3d9/d3dxcolormodulate.md
+++ b/desktop-src/direct3d9/d3dxcolormodulate.md
@@ -4,19 +4,22 @@ ms.assetid: deff70c7-2359-48b2-ab40-8c418acf5a07
 title: D3DXColorModulate function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorModulate
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorModulate function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Blends two colors.
 
@@ -113,7 +116,3 @@ pOut->r = pC1->r * pC2->r;
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxcolornegative.md
+++ b/desktop-src/direct3d9/d3dxcolornegative.md
@@ -4,19 +4,22 @@ ms.assetid: 74143126-93f8-49fa-abe3-fd730b644d87
 title: D3DXColorNegative function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorNegative
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorNegative function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Creates the negative color value of a color value.
 
@@ -105,7 +108,3 @@ pOut->r = 1.0f - pC->r;
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxcolorscale.md
+++ b/desktop-src/direct3d9/d3dxcolorscale.md
@@ -4,19 +4,22 @@ ms.assetid: 35e8adee-7ce5-4db5-8276-f0e408748e78
 title: D3DXColorScale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorScale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorScale function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Scales a color value.
 

--- a/desktop-src/direct3d9/d3dxcolorsubtract.md
+++ b/desktop-src/direct3d9/d3dxcolorsubtract.md
@@ -4,19 +4,22 @@ ms.assetid: c21f8402-c1c2-4909-896f-2872ef518537
 title: D3DXColorSubtract function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXColorSubtract
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXColorSubtract function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Subtracts two color values to create a new color value.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the pOut parame
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxcomputeboundingbox.md
+++ b/desktop-src/direct3d9/d3dxcomputeboundingbox.md
@@ -4,19 +4,22 @@ ms.assetid: 74e1b84e-1264-49eb-9172-7842af7e25e0
 title: D3DXComputeBoundingBox function (D3DX9Mesh.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXComputeBoundingBox
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXComputeBoundingBox function (D3DX9Mesh.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a coordinate-axis oriented bounding box.
 

--- a/desktop-src/direct3d9/d3dxcomputeboundingsphere.md
+++ b/desktop-src/direct3d9/d3dxcomputeboundingsphere.md
@@ -4,19 +4,22 @@ ms.assetid: efa1365b-fe3a-4165-a3cb-bc1cd2ba03c0
 title: D3DXComputeBoundingSphere function (D3DX9Mesh.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXComputeBoundingSphere
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXComputeBoundingSphere function (D3DX9Mesh.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a bounding sphere for the mesh.
 

--- a/desktop-src/direct3d9/d3dxfloat16-extensions.md
+++ b/desktop-src/direct3d9/d3dxfloat16-extensions.md
@@ -4,18 +4,21 @@ ms.assetid: d287efb5-d15e-46dc-924d-012e1a108efc
 title: D3DXFLOAT16 Extensions (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFLOAT16
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXFLOAT16 Extensions
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Supplies operator overloads and type casts for [**D3DXFLOAT16**](d3dxfloat16.md) structures.
 
@@ -71,7 +74,3 @@ Operator overloads and type casts for this structure are implemented in d3dx9mat
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxfloat16.md
+++ b/desktop-src/direct3d9/d3dxfloat16.md
@@ -4,18 +4,21 @@ ms.assetid: f823a327-f07a-44e9-b58a-7865e11e80eb
 title: D3DXFLOAT16 structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFLOAT16
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXFLOAT16 structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a 16-bit floating point vector.
 

--- a/desktop-src/direct3d9/d3dxfloat16to32array.md
+++ b/desktop-src/direct3d9/d3dxfloat16to32array.md
@@ -4,19 +4,22 @@ ms.assetid: cabb2888-76e4-403b-99ab-f7d62478bf43
 title: D3DXFloat16To32Array function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFloat16To32Array
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXFloat16To32Array function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts an array of 16-bit floats to 32-bit floats.
 

--- a/desktop-src/direct3d9/d3dxfloat32to16array.md
+++ b/desktop-src/direct3d9/d3dxfloat32to16array.md
@@ -4,19 +4,22 @@ ms.assetid: 00f7ae77-d2b5-4244-8fe9-6fea475700b7
 title: D3DXFloat32To16Array function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXFloat32To16Array
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXFloat32To16Array function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts an array of 32-bit floats to 16-bit floats.
 

--- a/desktop-src/direct3d9/d3dxmatrix-extensions.md
+++ b/desktop-src/direct3d9/d3dxmatrix-extensions.md
@@ -8,6 +8,8 @@ ms.date: 05/31/2018
 
 # D3DXMATRIX Extensions
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 
 | Type              | Extension                          |
@@ -30,6 +32,3 @@ The content for this page has been consolidated with the [**D3DXMATRIX**](d3dxma
  
 
  
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrix.md
+++ b/desktop-src/direct3d9/d3dxmatrix.md
@@ -4,18 +4,21 @@ ms.assetid: 0911088b-50cf-4c4a-996e-351386fc359b
 title: D3DXMATRIX structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMATRIX
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXMATRIX structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 A 4x4 matrix that contains methods and operator overloads.
 

--- a/desktop-src/direct3d9/d3dxmatrixa16.md
+++ b/desktop-src/direct3d9/d3dxmatrixa16.md
@@ -4,18 +4,21 @@ ms.assetid: c7082fe5-f98b-4ab7-b8c2-7cdbab4848ad
 title: D3DXMATRIXA16 structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMATRIXA16
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXMATRIXA16 structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 A 4x4, 16-byte-aligned matrix that contains methods and operator overloads.
 
@@ -87,7 +90,7 @@ typedef struct _D3DXMATRIXA16 : public D3DXMATRIX
 } _D3DXMATRIXA16;
 
 typedef D3DX_ALIGN16 _D3DXMATRIXA16 D3DXMATRIXA16, *LPD3DXMATRIXA16;
-        
+
 ```
 
 

--- a/desktop-src/direct3d9/d3dxmatrixaffinetransformation.md
+++ b/desktop-src/direct3d9/d3dxmatrixaffinetransformation.md
@@ -4,19 +4,22 @@ ms.assetid: 54eac78f-57be-4a24-8dfb-0b519e97d6ca
 title: D3DXMatrixAffineTransformation function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixAffineTransformation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixAffineTransformation function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 3D affine transformation matrix. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d9/d3dxmatrixaffinetransformation2d.md
+++ b/desktop-src/direct3d9/d3dxmatrixaffinetransformation2d.md
@@ -4,19 +4,22 @@ ms.assetid: 335de919-ae4d-405d-b6bb-ca6bdc2d568a
 title: D3DXMatrixAffineTransformation2D function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixAffineTransformation2D
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixAffineTransformation2D function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 2D affine transformation matrix in the xy plane. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d9/d3dxmatrixdecompose.md
+++ b/desktop-src/direct3d9/d3dxmatrixdecompose.md
@@ -4,19 +4,22 @@ ms.assetid: 73d3c248-1254-444e-9fd8-4f144424ddb7
 title: D3DXMatrixDecompose function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixDecompose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixDecompose function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Breaks down a general 3D transformation matrix into its scalar, rotational, and translational components.
 
@@ -101,7 +104,3 @@ If the function succeeds, the return value is S\_OK. If the function fails, the 
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixdeterminant.md
+++ b/desktop-src/direct3d9/d3dxmatrixdeterminant.md
@@ -4,19 +4,22 @@ ms.assetid: 711ba616-4c90-41d1-b9d5-0893b3e47284
 title: D3DXMatrixDeterminant function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixDeterminant
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixDeterminant function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the determinant of a matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixidentity.md
+++ b/desktop-src/direct3d9/d3dxmatrixidentity.md
@@ -4,19 +4,22 @@ ms.assetid: 0dd6d4fb-284c-4d01-9a85-63aa08e71723
 title: D3DXMatrixIdentity function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixIdentity
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixIdentity function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Creates an identity matrix.
 
@@ -80,7 +83,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixinverse.md
+++ b/desktop-src/direct3d9/d3dxmatrixinverse.md
@@ -4,19 +4,22 @@ ms.assetid: b8cad5c5-caa5-4426-b045-1770f8806b6b
 title: D3DXMatrixInverse function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixInverse
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixInverse function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the inverse of a matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixisidentity.md
+++ b/desktop-src/direct3d9/d3dxmatrixisidentity.md
@@ -4,19 +4,22 @@ ms.assetid: 00f72d08-5d4b-4310-8167-e6b6371d24fd
 title: D3DXMatrixIsIdentity function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixIsIdentity
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixIsIdentity function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines if a matrix is an identity matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixlookatlh.md
+++ b/desktop-src/direct3d9/d3dxmatrixlookatlh.md
@@ -4,19 +4,22 @@ ms.assetid: bf34d3d8-725d-4fc1-b4c8-6c98f9dac329
 title: D3DXMatrixLookAtLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixLookAtLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixLookAtLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed, look-at matrix.
 
@@ -91,7 +94,7 @@ This function uses the following formula to compute the returned matrix.
 zaxis = normal(At - Eye)
 xaxis = normal(cross(Up, zaxis))
 yaxis = cross(zaxis, xaxis)
-    
+
  xaxis.x           yaxis.x           zaxis.x          0
  xaxis.y           yaxis.y           zaxis.y          0
  xaxis.z           yaxis.z           zaxis.z          0
@@ -124,7 +127,3 @@ yaxis = cross(zaxis, xaxis)
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixlookatrh.md
+++ b/desktop-src/direct3d9/d3dxmatrixlookatrh.md
@@ -4,19 +4,22 @@ ms.assetid: 10198bb9-a77e-4482-be6e-cc5f76eff30b
 title: D3DXMatrixLookAtRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixLookAtRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixLookAtRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed, look-at matrix.
 
@@ -91,7 +94,7 @@ This function uses the following formula to compute the returned matrix.
 zaxis = normal(Eye - At)
 xaxis = normal(cross(Up, zaxis))
 yaxis = cross(zaxis, xaxis)
-    
+
  xaxis.x            yaxis.x            zaxis.x           0
  xaxis.y            yaxis.y            zaxis.y           0
  xaxis.z            yaxis.z            zaxis.z           0
@@ -124,7 +127,3 @@ yaxis = cross(zaxis, xaxis)
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixmultiply.md
+++ b/desktop-src/direct3d9/d3dxmatrixmultiply.md
@@ -4,19 +4,22 @@ ms.assetid: 160c801a-6589-4a0d-8e90-7e7a99fbd5f7
 title: D3DXMatrixMultiply function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixMultiply
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixMultiply function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the product of two matrices.
 
@@ -100,7 +103,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixmultiplytranspose.md
+++ b/desktop-src/direct3d9/d3dxmatrixmultiplytranspose.md
@@ -4,19 +4,22 @@ ms.assetid: 43927500-9413-41a4-a6ee-974d85dd1054
 title: D3DXMatrixMultiplyTranspose function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixMultiplyTranspose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixMultiplyTranspose function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the transposed product of two matrices.
 
@@ -105,7 +108,3 @@ This function is useful to set matrices as constants for vertex and pixel shader
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixortholh.md
+++ b/desktop-src/direct3d9/d3dxmatrixortholh.md
@@ -4,19 +4,22 @@ ms.assetid: e42151bd-2302-491b-a211-7d5a4b8e437f
 title: D3DXMatrixOrthoLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixOrthoLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixorthooffcenterlh.md
+++ b/desktop-src/direct3d9/d3dxmatrixorthooffcenterlh.md
@@ -4,19 +4,22 @@ ms.assetid: e4f087e5-63d9-49ca-9d8e-3a25070e1a51
 title: D3DXMatrixOrthoOffCenterLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoOffCenterLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixOrthoOffCenterLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, left-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixorthooffcenterrh.md
+++ b/desktop-src/direct3d9/d3dxmatrixorthooffcenterrh.md
@@ -4,19 +4,22 @@ ms.assetid: d6171e28-b138-4ccf-9f12-fb977a30aca1
 title: D3DXMatrixOrthoOffCenterRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoOffCenterRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixOrthoOffCenterRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, right-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixorthorh.md
+++ b/desktop-src/direct3d9/d3dxmatrixorthorh.md
@@ -4,19 +4,22 @@ ms.assetid: 6b9b50d5-0307-4fc7-a28d-8f42d2a21bf0
 title: D3DXMatrixOrthoRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixOrthoRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixOrthoRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed orthographic projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectivefovlh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectivefovlh.md
@@ -4,19 +4,22 @@ ms.assetid: 90328798-f124-4b61-90a9-971946066b02
 title: D3DXMatrixPerspectiveFovLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveFovLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveFovLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed perspective projection matrix based on a field of view.
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectivefovrh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectivefovrh.md
@@ -4,19 +4,22 @@ ms.assetid: 3f4bc5d8-90af-4fdc-bc0c-931407cd7a9b
 title: D3DXMatrixPerspectiveFovRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveFovRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveFovRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed perspective projection matrix based on a field of view.
 
@@ -106,7 +109,7 @@ xScale     0          0              0
 0        0        zn*zf/(zn-zf)      0
 where:
 yScale = cot(fovY/2)
-    
+
 xScale = yScale / aspect ratio
 ```
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectivelh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectivelh.md
@@ -4,19 +4,22 @@ ms.assetid: 07bbbca8-ad1e-4177-97d4-601b33179b47
 title: D3DXMatrixPerspectiveLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a left-handed perspective projection matrix
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectiveoffcenterlh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectiveoffcenterlh.md
@@ -4,19 +4,22 @@ ms.assetid: de2732dd-a4f2-47bc-9509-de16f1ca85c2
 title: D3DXMatrixPerspectiveOffCenterLH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveOffCenterLH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveOffCenterLH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, left-handed perspective projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectiveoffcenterrh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectiveoffcenterrh.md
@@ -4,19 +4,22 @@ ms.assetid: e6826e46-fc80-41fa-b0d8-45b6797df76f
 title: D3DXMatrixPerspectiveOffCenterRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveOffCenterRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveOffCenterRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a customized, right-handed perspective projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixperspectiverh.md
+++ b/desktop-src/direct3d9/d3dxmatrixperspectiverh.md
@@ -4,19 +4,22 @@ ms.assetid: dd9b041b-922b-43df-a6e9-46c97204338a
 title: D3DXMatrixPerspectiveRH function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixPerspectiveRH
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixPerspectiveRH function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a right-handed perspective projection matrix.
 

--- a/desktop-src/direct3d9/d3dxmatrixreflect.md
+++ b/desktop-src/direct3d9/d3dxmatrixreflect.md
@@ -4,19 +4,22 @@ ms.assetid: f6dc3834-42f2-4ad0-8098-8c5e25e10d58
 title: D3DXMatrixReflect function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixReflect
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixReflect function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that reflects the coordinate system about a plane.
 
@@ -71,7 +74,7 @@ This function uses the following formula to compute the returned matrix.
 
 ```
 P = normalize(Plane);
-    
+
 -2 * P.a * P.a + 1  -2 * P.b * P.a      -2 * P.c * P.a        0
 -2 * P.a * P.b      -2 * P.b * P.b + 1  -2 * P.c * P.b        0
 -2 * P.a * P.c      -2 * P.b * P.c      -2 * P.c * P.c + 1    0
@@ -101,7 +104,3 @@ P = normalize(Plane);
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixrotationaxis.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationaxis.md
@@ -4,19 +4,22 @@ ms.assetid: 368c8f64-7709-4200-94d3-3dbc92a960c1
 title: D3DXMatrixRotationAxis function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationAxis
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationAxis function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around an arbitrary axis.
 

--- a/desktop-src/direct3d9/d3dxmatrixrotationquaternion.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationquaternion.md
@@ -4,19 +4,22 @@ ms.assetid: e590058c-772b-4eef-aab0-a12bb04c299a
 title: D3DXMatrixRotationQuaternion function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationQuaternion
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationQuaternion function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a rotation matrix from a quaternion.
 
@@ -102,7 +105,3 @@ For information about how to calculate quaternion values from a direction vector
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixrotationx.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationx.md
@@ -4,19 +4,22 @@ ms.assetid: 45a2668d-787f-4354-882a-94a72edaa543
 title: D3DXMatrixRotationX function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationX
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationX function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the x-axis.
 

--- a/desktop-src/direct3d9/d3dxmatrixrotationy.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationy.md
@@ -4,19 +4,22 @@ ms.assetid: 80449e5d-f9bb-48c0-a787-a5e5a9d1c9a3
 title: D3DXMatrixRotationY function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationY
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationY function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the y-axis.
 

--- a/desktop-src/direct3d9/d3dxmatrixrotationyawpitchroll.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: efaab508-34ed-4373-a8d0-3bc459d75f39
 title: D3DXMatrixRotationYawPitchRoll function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationYawPitchRoll
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationYawPitchRoll function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix with a specified yaw, pitch, and roll.
 

--- a/desktop-src/direct3d9/d3dxmatrixrotationz.md
+++ b/desktop-src/direct3d9/d3dxmatrixrotationz.md
@@ -4,19 +4,22 @@ ms.assetid: 73db43e6-3831-4867-8eda-80127b61e169
 title: D3DXMatrixRotationZ function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixRotationZ
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixRotationZ function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that rotates around the z-axis.
 

--- a/desktop-src/direct3d9/d3dxmatrixscaling.md
+++ b/desktop-src/direct3d9/d3dxmatrixscaling.md
@@ -4,19 +4,22 @@ ms.assetid: f51baa4e-0aec-4de8-b746-24cb52f318d6
 title: D3DXMatrixScaling function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixScaling
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixScaling function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that scales along the x-axis, the y-axis, and the z-axis.
 

--- a/desktop-src/direct3d9/d3dxmatrixshadow.md
+++ b/desktop-src/direct3d9/d3dxmatrixshadow.md
@@ -4,19 +4,22 @@ ms.assetid: 8f283ff9-c879-476c-8057-f4fe77a7a9e7
 title: D3DXMatrixShadow function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixShadow
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixShadow function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix that flattens geometry into a plane.
 
@@ -83,7 +86,7 @@ This function uses the following formula to compute the returned matrix.
 P = normalize(Plane);
 L = Light;
 d = -dot(P, L)
-    
+
 P.a * L.x + d  P.a * L.y      P.a * L.z      P.a * L.w  
 P.b * L.x      P.b * L.y + d  P.b * L.z      P.b * L.w  
 P.c * L.x      P.c * L.y      P.c * L.z + d  P.c * L.w  
@@ -115,7 +118,3 @@ If the light's w-component is 0, the ray from the origin to the light represents
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixtransformation.md
+++ b/desktop-src/direct3d9/d3dxmatrixtransformation.md
@@ -4,19 +4,22 @@ ms.assetid: 39042fc6-f489-4e44-ad3f-858ca395575d
 title: D3DXMatrixTransformation function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTransformation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixTransformation function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a transformation matrix. **NULL** arguments are treated as identity transformations.
 
@@ -163,7 +166,3 @@ For 2D transformations, use [**D3DXMatrixTransformation2D**](d3dxmatrixtransform
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxmatrixtransformation2d.md
+++ b/desktop-src/direct3d9/d3dxmatrixtransformation2d.md
@@ -4,19 +4,22 @@ ms.assetid: 671d3d67-b474-4fc1-9913-d21f05d66d9a
 title: D3DXMatrixTransformation2D function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTransformation2D
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixTransformation2D function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a 2D transformation matrix that represents transformations in the xy plane. **NULL** arguments are treated as identity transformations.
 

--- a/desktop-src/direct3d9/d3dxmatrixtranslation.md
+++ b/desktop-src/direct3d9/d3dxmatrixtranslation.md
@@ -4,19 +4,22 @@ ms.assetid: 1cb713d5-b994-4496-a506-89451be09fb2
 title: D3DXMatrixTranslation function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTranslation
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixTranslation function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a matrix using the specified offsets.
 

--- a/desktop-src/direct3d9/d3dxmatrixtranspose.md
+++ b/desktop-src/direct3d9/d3dxmatrixtranspose.md
@@ -4,19 +4,22 @@ ms.assetid: 0ba9682f-3dd6-48b2-82b1-6e34e8ce5452
 title: D3DXMatrixTranspose function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXMatrixTranspose
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXMatrixTranspose function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the matrix transpose of a matrix.
 
@@ -85,7 +88,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplane-extensions.md
+++ b/desktop-src/direct3d9/d3dxplane-extensions.md
@@ -4,18 +4,21 @@ ms.assetid: 05f80b68-fb2b-4fd7-94e9-e5b40968c4aa
 title: D3DXPLANE Extensions (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPLANE
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXPLANE Extensions
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Supplies the following operator overloads and type casts for [**D3DXPLANE**](d3dxplane.md) structures.
 
@@ -83,7 +86,3 @@ Operator overloads and type casts for this structure are implemented in d3dx9mat
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplane.md
+++ b/desktop-src/direct3d9/d3dxplane.md
@@ -4,18 +4,21 @@ ms.assetid: ffca4650-9788-4559-8f6b-a4e5db29ce55
 title: D3DXPLANE structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPLANE
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXPLANE structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a plane.
 

--- a/desktop-src/direct3d9/d3dxplanedot.md
+++ b/desktop-src/direct3d9/d3dxplanedot.md
@@ -4,19 +4,22 @@ ms.assetid: e6232ca8-52cc-472d-8bdb-4f8dfc520d4f
 title: D3DXPlaneDot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneDot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneDot function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes the dot product of a plane and a 4D vector.
 

--- a/desktop-src/direct3d9/d3dxplanedotcoord.md
+++ b/desktop-src/direct3d9/d3dxplanedotcoord.md
@@ -4,19 +4,22 @@ ms.assetid: 634de6bc-b631-493d-a7a6-292a3c3253d6
 title: D3DXPlaneDotCoord function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneDotCoord
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneDotCoord function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes the dot product of a plane and a 3D vector. The w parameter of the vector is assumed to be 1.
 

--- a/desktop-src/direct3d9/d3dxplanedotnormal.md
+++ b/desktop-src/direct3d9/d3dxplanedotnormal.md
@@ -4,19 +4,22 @@ ms.assetid: 7aba1e94-6531-4c07-83b0-6100805e8bbd
 title: D3DXPlaneDotNormal function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneDotNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneDotNormal function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes the dot product of a plane and a 3D vector. The w parameter of the vector is assumed to be 0.
 

--- a/desktop-src/direct3d9/d3dxplanefrompointnormal.md
+++ b/desktop-src/direct3d9/d3dxplanefrompointnormal.md
@@ -4,19 +4,22 @@ ms.assetid: af396bbb-09b7-492f-a25f-9c950da7e605
 title: D3DXPlaneFromPointNormal function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneFromPointNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneFromPointNormal function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Constructs a plane from a point and a normal.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplanefrompoints.md
+++ b/desktop-src/direct3d9/d3dxplanefrompoints.md
@@ -4,19 +4,22 @@ ms.assetid: 13d5ce6b-0046-441b-b826-f34f4fe16979
 title: D3DXPlaneFromPoints function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneFromPoints
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneFromPoints function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Constructs a plane from three points.
 
@@ -108,7 +111,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplaneintersectline.md
+++ b/desktop-src/direct3d9/d3dxplaneintersectline.md
@@ -4,19 +4,22 @@ ms.assetid: 2723cd3e-fdc3-4aab-a089-0089e5b14e3e
 title: D3DXPlaneIntersectLine function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneIntersectLine
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneIntersectLine function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Finds the intersection between a plane and a line.
 
@@ -107,7 +110,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplanenormalize.md
+++ b/desktop-src/direct3d9/d3dxplanenormalize.md
@@ -4,19 +4,22 @@ ms.assetid: 9c595986-e1f8-4153-ba23-1fa6e583a050
 title: D3DXPlaneNormalize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneNormalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneNormalize function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Normalizes the plane coefficients so that the plane normal has unit length.
 
@@ -87,7 +90,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplanescale.md
+++ b/desktop-src/direct3d9/d3dxplanescale.md
@@ -4,19 +4,22 @@ ms.assetid: 3a0454ef-2821-472f-b7a4-5e49bb5f556e
 title: D3DXPlaneScale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneScale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneScale function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Scale the plane with the given scaling factor.
 

--- a/desktop-src/direct3d9/d3dxplanetransform.md
+++ b/desktop-src/direct3d9/d3dxplanetransform.md
@@ -4,19 +4,22 @@ ms.assetid: 3581b397-cbd8-4aed-80dd-1841f331a367
 title: D3DXPlaneTransform function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneTransform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneTransform function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a plane by a matrix. The input matrix is the inverse transpose of the actual transformation.
 
@@ -83,7 +86,7 @@ D3DXPLANE   plane(0,1,1,0);
 D3DXPlaneNormalize(&plane, &plane);
 
 D3DXMATRIX  matrix;
-D3DXMatrixScaling(&matrix, 1.0f,2.0f,3.0f); 
+D3DXMatrixScaling(&matrix, 1.0f,2.0f,3.0f);
 D3DXMatrixInverse(&matrix, NULL, &matrix);
 D3DXMatrixTranspose(&matrix, &matrix);
 D3DXPlaneTransform(&planeNew, &plane, &matrix);
@@ -134,7 +137,3 @@ The parameter pM contains the inverse transpose of the transformation matrix. Th
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxplanetransformarray.md
+++ b/desktop-src/direct3d9/d3dxplanetransformarray.md
@@ -4,19 +4,22 @@ ms.assetid: e82e830b-efbb-4bdc-b370-7bfa4326a669
 title: D3DXPlaneTransformArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXPlaneTransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXPlaneTransformArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array of planes by a matrix. The vectors that describe each plane must be normalized.
 
@@ -117,10 +120,10 @@ for(int i = 0; i < ARRAYSIZE; i++)
 }
 
 D3DXMATRIX  matrix;
-D3DXMatrixScaling( &matrix, 1.0f, 2.0f, 3.0f ); 
+D3DXMatrixScaling( &matrix, 1.0f, 2.0f, 3.0f );
 D3DXMatrixInverse( &matrix, NULL, &matrix );
 D3DXMatrixTranspose( &matrix, &matrix );
-D3DXPlaneTransformArray( &planeNew, sizeof (D3DXPLANE), &plane, 
+D3DXPlaneTransformArray( &planeNew, sizeof (D3DXPLANE), &plane,
                          sizeof (D3DXPLANE), &matrix, ARRAYSIZE );
 ```
 

--- a/desktop-src/direct3d9/d3dxquaternion-extensions.md
+++ b/desktop-src/direct3d9/d3dxquaternion-extensions.md
@@ -4,18 +4,21 @@ ms.assetid: a49975a4-a9a7-4183-91b3-3d56f70747ef
 title: D3DXQUATERNION Extensions (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQUATERNION
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXQUATERNION Extensions
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Supplies the following operator overloads and type casts for [**D3DXQUATERNION**](d3dxquaternion.md) structures.
 
@@ -90,7 +93,3 @@ Operator overloads and type casts for this structure are implemented in d3dx9mat
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternion.md
+++ b/desktop-src/direct3d9/d3dxquaternion.md
@@ -4,18 +4,21 @@ ms.assetid: 3d88ed17-5b0a-46d5-8fe6-d66e1fa26c13
 title: D3DXQUATERNION structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQUATERNION
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXQUATERNION structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a quaternion.
 

--- a/desktop-src/direct3d9/d3dxquaternionbarycentric.md
+++ b/desktop-src/direct3d9/d3dxquaternionbarycentric.md
@@ -4,19 +4,22 @@ ms.assetid: 8fcd2e16-1bf1-4e18-afc9-17c92f2bbac5
 title: D3DXQuaternionBaryCentric function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionBaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionBaryCentric function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a quaternion in barycentric coordinates.
 

--- a/desktop-src/direct3d9/d3dxquaternionconjugate.md
+++ b/desktop-src/direct3d9/d3dxquaternionconjugate.md
@@ -4,19 +4,22 @@ ms.assetid: f690fdd8-7805-4fc1-9064-4f249d5f7c4f
 title: D3DXQuaternionConjugate function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionConjugate
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionConjugate function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the conjugate of a quaternion.
 
@@ -92,7 +95,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaterniondot.md
+++ b/desktop-src/direct3d9/d3dxquaterniondot.md
@@ -4,19 +4,22 @@ ms.assetid: 2ed9aca9-0526-4b92-bd66-b09dcf4f474a
 title: D3DXQuaternionDot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionDot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionDot function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the dot product of two quaternions.
 

--- a/desktop-src/direct3d9/d3dxquaternionexp.md
+++ b/desktop-src/direct3d9/d3dxquaternionexp.md
@@ -4,19 +4,22 @@ ms.assetid: 648aeaf1-ead3-4b21-819f-cd2a70881a13
 title: D3DXQuaternionExp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionExp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionExp function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the exponential.
 
@@ -67,8 +70,8 @@ This method converts a pure quaternion to a unit quaternion. **D3DXQuaternionExp
 
 ```
 Given a pure quaternion defined by:
-q = (0, theta * v); 
-    
+q = (0, theta * v);
+
 This method calculates the exponential result.
 exp(Q) = (cos(theta), sin(theta) * v)
 ```
@@ -110,7 +113,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionidentity.md
+++ b/desktop-src/direct3d9/d3dxquaternionidentity.md
@@ -4,19 +4,22 @@ ms.assetid: 8088897b-5755-4ea0-afef-bd49d1921f5c
 title: D3DXQuaternionIdentity function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionIdentity
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionIdentity function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the identity quaternion.
 
@@ -82,7 +85,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternioninverse.md
+++ b/desktop-src/direct3d9/d3dxquaternioninverse.md
@@ -4,19 +4,22 @@ ms.assetid: 25407a60-f7c0-4063-8d1d-2d6d03bdb217
 title: D3DXQuaternionInverse function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionInverse
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionInverse function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Conjugates and renormalizes a quaternion.
 
@@ -102,7 +105,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionisidentity.md
+++ b/desktop-src/direct3d9/d3dxquaternionisidentity.md
@@ -4,19 +4,22 @@ ms.assetid: 1cd39e1b-9b68-434d-b7b0-3ec6cddb8757
 title: D3DXQuaternionIsIdentity function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionIsIdentity
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionIsIdentity function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines if a quaternion is an identity quaternion.
 

--- a/desktop-src/direct3d9/d3dxquaternionlength.md
+++ b/desktop-src/direct3d9/d3dxquaternionlength.md
@@ -4,19 +4,22 @@ ms.assetid: daa835c2-2370-4427-a4ca-eddfb43d5c67
 title: D3DXQuaternionLength function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionLength
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionLength function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the length of a quaternion.
 

--- a/desktop-src/direct3d9/d3dxquaternionlengthsq.md
+++ b/desktop-src/direct3d9/d3dxquaternionlengthsq.md
@@ -4,19 +4,22 @@ ms.assetid: 358d2a2b-7baf-4ae9-9b92-7a7f01ca843b
 title: D3DXQuaternionLengthSq function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionLengthSq
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionLengthSq function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the square of the length of a quaternion.
 

--- a/desktop-src/direct3d9/d3dxquaternionln.md
+++ b/desktop-src/direct3d9/d3dxquaternionln.md
@@ -4,19 +4,22 @@ ms.assetid: 73ca7d13-1e20-48fc-b0ed-0d3127d094a7
 title: D3DXQuaternionLn function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionLn
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionLn function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Calculates the natural logarithm.
 
@@ -104,7 +107,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionmultiply.md
+++ b/desktop-src/direct3d9/d3dxquaternionmultiply.md
@@ -4,19 +4,22 @@ ms.assetid: 11072fc9-dae8-4f63-b07d-b709eed381df
 title: D3DXQuaternionMultiply function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionMultiply
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionMultiply function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Multiplies two quaternions.
 
@@ -114,7 +117,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionnormalize.md
+++ b/desktop-src/direct3d9/d3dxquaternionnormalize.md
@@ -4,19 +4,22 @@ ms.assetid: 31f56c2b-96b0-4110-a5b9-ce09983779b6
 title: D3DXQuaternionNormalize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionNormalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionNormalize function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a unit length quaternion.
 
@@ -88,7 +91,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionrotationaxis.md
+++ b/desktop-src/direct3d9/d3dxquaternionrotationaxis.md
@@ -4,19 +4,22 @@ ms.assetid: 9ff0fe2c-54d6-482c-84e1-f38e3c57d8dd
 title: D3DXQuaternionRotationAxis function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationAxis
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionRotationAxis function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Rotates a quaternion about an arbitrary axis.
 

--- a/desktop-src/direct3d9/d3dxquaternionrotationmatrix.md
+++ b/desktop-src/direct3d9/d3dxquaternionrotationmatrix.md
@@ -4,19 +4,22 @@ ms.assetid: 4fafb1aa-5d6f-46e6-84b1-e0bac22952d2
 title: D3DXQuaternionRotationMatrix function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationMatrix
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionRotationMatrix function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a quaternion from a rotation matrix.
 
@@ -93,7 +96,3 @@ Use [**D3DXQuaternionNormalize**](d3dxquaternionnormalize.md) for any quaternion
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaternionrotationyawpitchroll.md
+++ b/desktop-src/direct3d9/d3dxquaternionrotationyawpitchroll.md
@@ -4,19 +4,22 @@ ms.assetid: be4a3bd5-114b-4652-8e0a-e51338317c16
 title: D3DXQuaternionRotationYawPitchRoll function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionRotationYawPitchRoll
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionRotationYawPitchRoll function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Builds a quaternion with the given yaw, pitch, and roll.
 

--- a/desktop-src/direct3d9/d3dxquaternionslerp.md
+++ b/desktop-src/direct3d9/d3dxquaternionslerp.md
@@ -4,19 +4,22 @@ ms.assetid: 94a989c8-fa6b-4852-9aa3-e55ad814ffd7
 title: D3DXQuaternionSlerp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSlerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionSlerp function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Interpolates between two quaternions, using spherical linear interpolation.
 

--- a/desktop-src/direct3d9/d3dxquaternionsquad.md
+++ b/desktop-src/direct3d9/d3dxquaternionsquad.md
@@ -4,19 +4,22 @@ ms.assetid: afce9afb-64cc-4059-90f5-7ed1aca9b3cb
 title: D3DXQuaternionSquad function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSquad
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionSquad function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Interpolates between quaternions, using spherical quadrangle interpolation.
 

--- a/desktop-src/direct3d9/d3dxquaternionsquadsetup.md
+++ b/desktop-src/direct3d9/d3dxquaternionsquadsetup.md
@@ -4,19 +4,22 @@ ms.assetid: f800d457-8546-49a1-800e-e5c27af96710
 title: D3DXQuaternionSquadSetup function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionSquadSetup
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionSquadSetup function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Sets up control points for spherical quadrangle interpolation.
 
@@ -199,7 +202,3 @@ D3DXQuaternionSquad(&Qt, &Q1, &A, &B, &C, time);
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxquaterniontoaxisangle.md
+++ b/desktop-src/direct3d9/d3dxquaterniontoaxisangle.md
@@ -4,19 +4,22 @@ ms.assetid: 6efd0a68-7641-403e-8ae2-c715b705b36e
 title: D3DXQuaternionToAxisAngle function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXQuaternionToAxisAngle
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXQuaternionToAxisAngle function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Computes a quaternion's axis and angle of rotation.
 

--- a/desktop-src/direct3d9/d3dxsphereboundprobe.md
+++ b/desktop-src/direct3d9/d3dxsphereboundprobe.md
@@ -4,19 +4,22 @@ ms.assetid: fa2e9ecf-7905-4a62-ba48-774bd522525a
 title: D3DXSphereBoundProbe function (D3DX9Mesh.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXSphereBoundProbe
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXSphereBoundProbe function (D3DX9Mesh.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines if a ray intersects the volume of a sphere's bounding box.
 

--- a/desktop-src/direct3d9/d3dxtodegree.md
+++ b/desktop-src/direct3d9/d3dxtodegree.md
@@ -4,18 +4,21 @@ ms.assetid: 1b19af39-ca23-4364-9121-f532d7fed099
 title: D3DXToDegree (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXToDegree
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXToDegree
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts radians into degrees.
 
@@ -65,7 +68,3 @@ The macro returns the radian value in degrees.
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxtoradian.md
+++ b/desktop-src/direct3d9/d3dxtoradian.md
@@ -4,18 +4,21 @@ ms.assetid: 450806bd-db2f-47be-ae80-c261088b1bb8
 title: D3DXToRadian (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXToRadian
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXToRadian
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Converts degrees into radians.
 
@@ -65,7 +68,3 @@ The macro returns the degree value in radians.
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2add.md
+++ b/desktop-src/direct3d9/d3dxvec2add.md
@@ -4,19 +4,22 @@ ms.assetid: 82b2fdf6-1b1f-4768-8c0b-ac8faa77d7ed
 title: D3DXVec2Add function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Add
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Add function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adds two 2D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2barycentric.md
+++ b/desktop-src/direct3d9/d3dxvec2barycentric.md
@@ -4,19 +4,22 @@ ms.assetid: afbffe6d-d786-4d65-b737-ae201613d1ac
 title: D3DXVec2BaryCentric function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2BaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2BaryCentric function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 2D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec2catmullrom.md
+++ b/desktop-src/direct3d9/d3dxvec2catmullrom.md
@@ -4,19 +4,22 @@ ms.assetid: dacda32d-b4c4-4d8b-9d20-9a4bb1d3ce6c
 title: D3DXVec2CatmullRom function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2CatmullRom
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2CatmullRom function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 2D vectors.
 
@@ -106,10 +109,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d9/d3dxvec2ccw.md
+++ b/desktop-src/direct3d9/d3dxvec2ccw.md
@@ -4,19 +4,22 @@ ms.assetid: daec19f2-cd0f-4a68-affc-9a42bda8912c
 title: D3DXVec2CCW function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2CCW
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2CCW function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the z-component by taking the cross product of two 2D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec2dot.md
+++ b/desktop-src/direct3d9/d3dxvec2dot.md
@@ -4,19 +4,22 @@ ms.assetid: ae77ff29-44be-4b67-9c63-aaffa4fe8d59
 title: D3DXVec2Dot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Dot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Dot function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the dot product of two 2D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec2hermite.md
+++ b/desktop-src/direct3d9/d3dxvec2hermite.md
@@ -4,19 +4,22 @@ ms.assetid: 30eb9490-bc01-4449-adfb-1c552e8ad3e7
 title: D3DXVec2Hermite function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Hermite
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Hermite function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 2D vectors.
 
@@ -126,9 +129,9 @@ A + B = v2 - v1 - t1 (substituting for C and D)
 Plug in the solutions for A,B,C and D to generate Q(s).
 
 ``` syntax
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d9/d3dxvec2length.md
+++ b/desktop-src/direct3d9/d3dxvec2length.md
@@ -4,19 +4,22 @@ ms.assetid: 376fd2ca-c89d-41e7-a15c-a79d7281d010
 title: D3DXVec2Length function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Length
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Length function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the length of a 2D vector.
 

--- a/desktop-src/direct3d9/d3dxvec2lengthsq.md
+++ b/desktop-src/direct3d9/d3dxvec2lengthsq.md
@@ -4,19 +4,22 @@ ms.assetid: 0ecc40bb-7613-463a-a8a0-5e184feb441f
 title: D3DXVec2LengthSq function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2LengthSq
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2LengthSq function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the square of the length of a 2D vector.
 

--- a/desktop-src/direct3d9/d3dxvec2lerp.md
+++ b/desktop-src/direct3d9/d3dxvec2lerp.md
@@ -4,19 +4,22 @@ ms.assetid: f8e9e6be-9696-4a4a-a6c8-c021985decaa
 title: D3DXVec2Lerp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Lerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Lerp function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a linear interpolation between two 2D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec2maximize.md
+++ b/desktop-src/direct3d9/d3dxvec2maximize.md
@@ -4,19 +4,22 @@ ms.assetid: 5eb5141b-d611-4c6b-a3e3-c7ad8f223657
 title: D3DXVec2Maximize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Maximize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Maximize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 2D vector that is made up of the largest components of two 2D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2minimize.md
+++ b/desktop-src/direct3d9/d3dxvec2minimize.md
@@ -4,19 +4,22 @@ ms.assetid: 6944523e-33dd-456e-9cc2-17760d76c548
 title: D3DXVec2Minimize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Minimize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Minimize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 2D vector that is made up of the smallest components of two 2D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2normalize.md
+++ b/desktop-src/direct3d9/d3dxvec2normalize.md
@@ -4,19 +4,22 @@ ms.assetid: 2796a5d1-cb1c-4093-87f2-a2ad43279d91
 title: D3DXVec2Normalize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Normalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Normalize function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 2D vector.
 
@@ -85,7 +88,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2scale.md
+++ b/desktop-src/direct3d9/d3dxvec2scale.md
@@ -4,19 +4,22 @@ ms.assetid: 1887bc48-3766-42d7-840b-1e29d78db4ce
 title: D3DXVec2Scale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Scale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Scale function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Scales a 2D vector.
 

--- a/desktop-src/direct3d9/d3dxvec2subtract.md
+++ b/desktop-src/direct3d9/d3dxvec2subtract.md
@@ -4,19 +4,22 @@ ms.assetid: e5a693e9-b143-41d5-923d-3f3f71461a42
 title: D3DXVec2Subtract function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Subtract
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Subtract function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Subtracts two 2D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2transform.md
+++ b/desktop-src/direct3d9/d3dxvec2transform.md
@@ -4,19 +4,22 @@ ms.assetid: ccde9e34-2d99-4112-a8ed-3820d018b547
 title: D3DXVec2Transform function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2Transform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2Transform function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 2D vector by a given matrix.
 
@@ -103,7 +106,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2transformarray.md
+++ b/desktop-src/direct3d9/d3dxvec2transformarray.md
@@ -4,19 +4,22 @@ ms.assetid: ba8c1983-bd65-4249-9451-69d813e4a3a4
 title: D3DXVec2TransformArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2TransformArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 1) by a given matrix.
 

--- a/desktop-src/direct3d9/d3dxvec2transformcoord.md
+++ b/desktop-src/direct3d9/d3dxvec2transformcoord.md
@@ -4,19 +4,22 @@ ms.assetid: 0c0efdf8-77df-4f4a-86ce-89e11555f4dc
 title: D3DXVec2TransformCoord function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformCoord
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2TransformCoord function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 2D vector by a given matrix, projecting the result back into w = 1.
 
@@ -103,7 +106,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2transformcoordarray.md
+++ b/desktop-src/direct3d9/d3dxvec2transformcoordarray.md
@@ -4,19 +4,22 @@ ms.assetid: 23c88bed-344b-4b3a-bb92-e50cbe96daf9
 title: D3DXVec2TransformCoordArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformCoordArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2TransformCoordArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 1) by a given matrix, and projects the result back into w = 1.
 

--- a/desktop-src/direct3d9/d3dxvec2transformnormal.md
+++ b/desktop-src/direct3d9/d3dxvec2transformnormal.md
@@ -4,19 +4,22 @@ ms.assetid: aa9adf6d-5aae-4acf-bbd9-f5c14d90470e
 title: D3DXVec2TransformNormal function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2TransformNormal function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms the 2D vector normal by the given matrix.
 
@@ -105,7 +108,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec2transformnormalarray.md
+++ b/desktop-src/direct3d9/d3dxvec2transformnormalarray.md
@@ -4,19 +4,22 @@ ms.assetid: 9f5d8fdc-f3e1-41dc-be4e-9ffc6be1947f
 title: D3DXVec2TransformNormalArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec2TransformNormalArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec2TransformNormalArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 0) by a given matrix.
 

--- a/desktop-src/direct3d9/d3dxvec3add.md
+++ b/desktop-src/direct3d9/d3dxvec3add.md
@@ -4,19 +4,22 @@ ms.assetid: 2979e291-786b-4bc9-b584-421f08db949a
 title: D3DXVec3Add function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Add
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Add function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adds two 3D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3barycentric.md
+++ b/desktop-src/direct3d9/d3dxvec3barycentric.md
@@ -4,19 +4,22 @@ ms.assetid: ecbabc76-9936-4f31-adec-1ec807984787
 title: D3DXVec3BaryCentric function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3BaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3BaryCentric function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 3D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec3catmullrom.md
+++ b/desktop-src/direct3d9/d3dxvec3catmullrom.md
@@ -4,19 +4,22 @@ ms.assetid: 779f067c-ac46-4fde-9e18-e31b1504b490
 title: D3DXVec3CatmullRom function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3CatmullRom
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3CatmullRom function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 3D vectors.
 
@@ -106,10 +109,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d9/d3dxvec3cross.md
+++ b/desktop-src/direct3d9/d3dxvec3cross.md
@@ -4,19 +4,22 @@ ms.assetid: c9623f35-c8fc-4fbe-87b6-0e5bb8ebd5e8
 title: D3DXVec3Cross function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Cross
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Cross function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the cross-product of two 3D vectors.
 
@@ -77,11 +80,11 @@ This function determines the cross-product with the following code.
 
 ```
 D3DXVECTOR3 v;
-    
+
 v.x = pV1->y * pV2->z - pV1->z * pV2->y;
 v.y = pV1->z * pV2->x - pV1->x * pV2->z;
 v.z = pV1->x * pV2->y - pV1->y * pV2->x;
-    
+
 *pOut = v;
 ```
 
@@ -113,7 +116,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3dot.md
+++ b/desktop-src/direct3d9/d3dxvec3dot.md
@@ -4,19 +4,22 @@ ms.assetid: 61aa7751-cc06-4673-929b-d7c1e691e395
 title: D3DXVec3Dot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Dot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Dot function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the dot product of two 3D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec3hermite.md
+++ b/desktop-src/direct3d9/d3dxvec3hermite.md
@@ -4,19 +4,22 @@ ms.assetid: d45b1179-0e11-4f58-8d50-432236cb88ca
 title: D3DXVec3Hermite function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Hermite
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Hermite function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 3D vectors.
 
@@ -126,9 +129,9 @@ A + B = v2 - v1 - t1 (substituting for C and D)
 Plug in the solutions for A,B,C and D to generate Q(s).
 
 ``` syntax
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d9/d3dxvec3length.md
+++ b/desktop-src/direct3d9/d3dxvec3length.md
@@ -4,19 +4,22 @@ ms.assetid: 78da506c-3169-48e9-934c-cc09271a10d4
 title: D3DXVec3Length function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Length
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Length function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the length of a 3D vector.
 

--- a/desktop-src/direct3d9/d3dxvec3lengthsq.md
+++ b/desktop-src/direct3d9/d3dxvec3lengthsq.md
@@ -4,19 +4,22 @@ ms.assetid: 25dc50cc-542b-4989-a858-9b37603393a0
 title: D3DXVec3LengthSq function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3LengthSq
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3LengthSq function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the square of the length of a 3D vector.
 

--- a/desktop-src/direct3d9/d3dxvec3lerp.md
+++ b/desktop-src/direct3d9/d3dxvec3lerp.md
@@ -4,19 +4,22 @@ ms.assetid: f3f06f1b-8824-47f0-b2ed-c212fa4c3225
 title: D3DXVec3Lerp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Lerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Lerp function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a linear interpolation between two 3D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec3maximize.md
+++ b/desktop-src/direct3d9/d3dxvec3maximize.md
@@ -4,19 +4,22 @@ ms.assetid: 8d3a5310-bee9-4dbd-bef3-8a0e1586f365
 title: D3DXVec3Maximize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Maximize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Maximize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 3D vector that is made up of the largest components of two 3D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3minimize.md
+++ b/desktop-src/direct3d9/d3dxvec3minimize.md
@@ -4,19 +4,22 @@ ms.assetid: f38164a5-d016-4a8a-a7fe-d7eb0a681107
 title: D3DXVec3Minimize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Minimize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Minimize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 3D vector that is made up of the smallest components of two 3D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3normalize.md
+++ b/desktop-src/direct3d9/d3dxvec3normalize.md
@@ -4,19 +4,22 @@ ms.assetid: 7bb8302e-8af2-4328-9b46-bc9f5a009f56
 title: D3DXVec3Normalize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Normalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Normalize function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 3D vector.
 
@@ -85,7 +88,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3project.md
+++ b/desktop-src/direct3d9/d3dxvec3project.md
@@ -4,19 +4,22 @@ ms.assetid: b012771d-052f-4bf9-b39c-387d8a63fa59
 title: D3DXVec3Project function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Project
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Project function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects a 3D vector from object space into screen space.
 
@@ -128,7 +131,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3projectarray.md
+++ b/desktop-src/direct3d9/d3dxvec3projectarray.md
@@ -4,19 +4,22 @@ ms.assetid: cf022741-0bae-4c22-872f-bd94c3721aff
 title: D3DXVec3ProjectArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3ProjectArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3ProjectArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects an array (x, y, z, 0) from object space into screen space.
 

--- a/desktop-src/direct3d9/d3dxvec3scale.md
+++ b/desktop-src/direct3d9/d3dxvec3scale.md
@@ -4,19 +4,22 @@ ms.assetid: b2483d6e-56e4-4557-a603-d59c0767774d
 title: D3DXVec3Scale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Scale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Scale function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Scales a 3D vector.
 

--- a/desktop-src/direct3d9/d3dxvec3subtract.md
+++ b/desktop-src/direct3d9/d3dxvec3subtract.md
@@ -4,19 +4,22 @@ ms.assetid: 09e2cede-a0a3-4a5e-a7e1-e7a98cdc433b
 title: D3DXVec3Subtract function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Subtract
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Subtract function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Subtracts two 3D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3transform.md
+++ b/desktop-src/direct3d9/d3dxvec3transform.md
@@ -4,19 +4,22 @@ ms.assetid: 5b290c4c-22f1-4086-8e5e-f995757ef193
 title: D3DXVec3Transform function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Transform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Transform function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms vector (x, y, z, 1) by a given matrix.
 
@@ -97,7 +100,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3transformarray.md
+++ b/desktop-src/direct3d9/d3dxvec3transformarray.md
@@ -4,19 +4,22 @@ ms.assetid: fd7ab674-5e42-4265-afad-ae5a00dabcdb
 title: D3DXVec3TransformArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3TransformArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 1) by a given matrix.
 

--- a/desktop-src/direct3d9/d3dxvec3transformcoord.md
+++ b/desktop-src/direct3d9/d3dxvec3transformcoord.md
@@ -4,19 +4,22 @@ ms.assetid: 4075b067-1e64-46c9-be73-5fa765c9cb9d
 title: D3DXVec3TransformCoord function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformCoord
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3TransformCoord function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 3D vector by a given matrix, projecting the result back into w = 1.
 
@@ -103,7 +106,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3transformcoordarray.md
+++ b/desktop-src/direct3d9/d3dxvec3transformcoordarray.md
@@ -4,19 +4,22 @@ ms.assetid: f1595861-d8cb-4787-8078-b9ba6f76507e
 title: D3DXVec3TransformCoordArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformCoordArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3TransformCoordArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 1) by a given matrix, and projects the result back into w = 1.
 

--- a/desktop-src/direct3d9/d3dxvec3transformnormal.md
+++ b/desktop-src/direct3d9/d3dxvec3transformnormal.md
@@ -4,19 +4,22 @@ ms.assetid: aa9531e1-b77a-4aad-8d59-2677908cb978
 title: D3DXVec3TransformNormal function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformNormal
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3TransformNormal function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms the 3D vector normal by the given matrix.
 
@@ -99,7 +102,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3transformnormalarray.md
+++ b/desktop-src/direct3d9/d3dxvec3transformnormalarray.md
@@ -4,19 +4,22 @@ ms.assetid: c12fad52-d541-483f-a919-e6031aa4f761
 title: D3DXVec3TransformNormalArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3TransformNormalArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3TransformNormalArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, z, 0) by a given matrix.
 

--- a/desktop-src/direct3d9/d3dxvec3unproject.md
+++ b/desktop-src/direct3d9/d3dxvec3unproject.md
@@ -4,19 +4,22 @@ ms.assetid: 9fd69cae-1d9c-4fae-9e15-8eb9950b4850
 title: D3DXVec3Unproject function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3Unproject
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3Unproject function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects a vector from screen space into object space.
 
@@ -128,7 +131,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec3unprojectarray.md
+++ b/desktop-src/direct3d9/d3dxvec3unprojectarray.md
@@ -4,19 +4,22 @@ ms.assetid: fef2a76c-c2fe-48c5-a1bb-6669bcc76b9b
 title: D3DXVec3UnprojectArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec3UnprojectArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec3UnprojectArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Projects an array (x, y, z, 0) from screen space into object space.
 

--- a/desktop-src/direct3d9/d3dxvec4add.md
+++ b/desktop-src/direct3d9/d3dxvec4add.md
@@ -4,19 +4,22 @@ ms.assetid: da807dc0-6a31-4315-a32d-a42062c22199
 title: D3DXVec4Add function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Add
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Add function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Adds two 4D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4barycentric.md
+++ b/desktop-src/direct3d9/d3dxvec4barycentric.md
@@ -4,19 +4,22 @@ ms.assetid: 80d73232-76bf-4f40-add2-dd1bdcc5cd98
 title: D3DXVec4BaryCentric function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4BaryCentric
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4BaryCentric function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a point in Barycentric coordinates, using the specified 4D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec4catmullrom.md
+++ b/desktop-src/direct3d9/d3dxvec4catmullrom.md
@@ -4,19 +4,22 @@ ms.assetid: 24c26e70-b02c-4621-8b7e-db16f99dddb5
 title: D3DXVec4CatmullRom function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4CatmullRom
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4CatmullRom function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Catmull-Rom interpolation, using the specified 4D vectors.
 
@@ -106,10 +109,10 @@ Given four points (p1, p2, p3, p4), find a function Q(s) such that:
 
 
 ```
-Q(s) is a cubic function. 
-Q(s) interpolates between p2 and p3 as s ranges from 0 to 1. 
-Q(s) is parallel to the line joining p1 to p3 when s is 0. 
-Q(s) is parallel to the line joining p2 to p4 when s is 1. 
+Q(s) is a cubic function.
+Q(s) interpolates between p2 and p3 as s ranges from 0 to 1.
+Q(s) is parallel to the line joining p1 to p3 when s is 0.
+Q(s) is parallel to the line joining p2 to p4 when s is 1.
 ```
 
 

--- a/desktop-src/direct3d9/d3dxvec4cross.md
+++ b/desktop-src/direct3d9/d3dxvec4cross.md
@@ -4,19 +4,22 @@ ms.assetid: 10b965c9-7ed7-450c-86a0-114f068c888f
 title: D3DXVec4Cross function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Cross
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Cross function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the cross-product in four dimensions.
 
@@ -108,7 +111,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4dot.md
+++ b/desktop-src/direct3d9/d3dxvec4dot.md
@@ -4,19 +4,22 @@ ms.assetid: 565dede8-6cc8-4313-9480-2f252cac94f2
 title: D3DXVec4Dot function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Dot
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Dot function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Determines the dot product of two 4D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec4hermite.md
+++ b/desktop-src/direct3d9/d3dxvec4hermite.md
@@ -4,19 +4,22 @@ ms.assetid: 687d4dcf-ee75-4dda-b6d2-5ba0b5281a64
 title: D3DXVec4Hermite function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Hermite
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Hermite function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a Hermite spline interpolation, using the specified 4D vectors.
 
@@ -119,9 +122,9 @@ These properties are used to solve for A, B, C, D.
 Plug in the solutions for A,B,C and D to generate Q(s).
 
 ``` syntax
-A = 2v1 - 2v2 + t2 + t1 
+A = 2v1 - 2v2 + t2 + t1
 B = 3v2 - 3v1 - 2t1 - t2
-C = t1 
+C = t1
 D = v1
 ```
 

--- a/desktop-src/direct3d9/d3dxvec4length.md
+++ b/desktop-src/direct3d9/d3dxvec4length.md
@@ -4,19 +4,22 @@ ms.assetid: cb332160-3e3d-41b9-bfb0-e3b743d2eafd
 title: D3DXVec4Length function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Length
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Length function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the length of a 4D vector.
 

--- a/desktop-src/direct3d9/d3dxvec4lengthsq.md
+++ b/desktop-src/direct3d9/d3dxvec4lengthsq.md
@@ -4,19 +4,22 @@ ms.assetid: 73091179-4acb-408b-8c91-766052999f26
 title: D3DXVec4LengthSq function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4LengthSq
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4LengthSq function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the square of the length of a 4D vector.
 

--- a/desktop-src/direct3d9/d3dxvec4lerp.md
+++ b/desktop-src/direct3d9/d3dxvec4lerp.md
@@ -4,19 +4,22 @@ ms.assetid: a068a626-17cd-4df9-8f41-9b417bfda1d1
 title: D3DXVec4Lerp function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Lerp
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Lerp function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Performs a linear interpolation between two 4D vectors.
 

--- a/desktop-src/direct3d9/d3dxvec4maximize.md
+++ b/desktop-src/direct3d9/d3dxvec4maximize.md
@@ -4,19 +4,22 @@ ms.assetid: a08ceba0-938c-42af-8f32-b1fd8c12d926
 title: D3DXVec4Maximize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Maximize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Maximize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 4D vector that is made up of the largest components of two 4D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4minimize.md
+++ b/desktop-src/direct3d9/d3dxvec4minimize.md
@@ -4,19 +4,22 @@ ms.assetid: ae3819a3-a5b6-47c2-b789-3e3f07db9f03
 title: D3DXVec4Minimize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Minimize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Minimize function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns a 4D vector that is made up of the smallest components of two 4D vectors.
 
@@ -98,7 +101,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4normalize.md
+++ b/desktop-src/direct3d9/d3dxvec4normalize.md
@@ -4,19 +4,22 @@ ms.assetid: e12d5dc7-b26f-41dd-b89d-1df9ba23077a
 title: D3DXVec4Normalize function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Normalize
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Normalize function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Returns the normalized version of a 4D vector.
 
@@ -85,7 +88,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4scale.md
+++ b/desktop-src/direct3d9/d3dxvec4scale.md
@@ -4,19 +4,22 @@ ms.assetid: b185a9b9-f768-4b50-aa6c-667c71eac39a
 title: D3DXVec4Scale function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Scale
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Scale function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Scales a 4D vector.
 

--- a/desktop-src/direct3d9/d3dxvec4subtract.md
+++ b/desktop-src/direct3d9/d3dxvec4subtract.md
@@ -4,19 +4,22 @@ ms.assetid: 3bc55b38-818e-40eb-859e-495ee28fc4ae
 title: D3DXVec4Subtract function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Subtract
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Subtract function
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Subtracts two 4D vectors.
 
@@ -101,7 +104,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4transform.md
+++ b/desktop-src/direct3d9/d3dxvec4transform.md
@@ -4,19 +4,22 @@ ms.assetid: de93f138-7cf8-43cc-8255-c053c799aea8
 title: D3DXVec4Transform function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4Transform
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4Transform function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms a 4D vector by a given matrix.
 
@@ -95,7 +98,3 @@ The return value for this function is the same value returned in the *pOut* para
  
 
  
-
-
-
-

--- a/desktop-src/direct3d9/d3dxvec4transformarray.md
+++ b/desktop-src/direct3d9/d3dxvec4transformarray.md
@@ -4,19 +4,22 @@ ms.assetid: 11d69f65-2aef-46f4-b274-e173a11382a8
 title: D3DXVec4TransformArray function (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVec4TransformArray
-api_type: 
+api_type:
 - LibDef
-api_location: 
+api_location:
 - d3dx9.lib
 - d3dx9.dll
 ---
 
 # D3DXVec4TransformArray function (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Transforms an array (x, y, 0, 1) by a given matrix.
 

--- a/desktop-src/direct3d9/d3dxvector2-extensions.md
+++ b/desktop-src/direct3d9/d3dxvector2-extensions.md
@@ -8,6 +8,9 @@ ms.date: 05/31/2018
 
 # D3DXVECTOR2 Extensions
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
+
 The content from this page has been moved to the [**D3DXVECTOR2**](d3dxvector2.md) page.
 
 ## Related topics
@@ -20,6 +23,3 @@ The content from this page has been moved to the [**D3DXVECTOR2**](d3dxvector2.m
  
 
  
-
-
-

--- a/desktop-src/direct3d9/d3dxvector2.md
+++ b/desktop-src/direct3d9/d3dxvector2.md
@@ -4,18 +4,21 @@ ms.assetid: e61ec1c8-00b5-491f-8fb1-be97218f6c68
 title: D3DXVECTOR2 structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR2
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXVECTOR2 structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a two-component vector including operator overloads and type casts.
 
@@ -127,7 +130,7 @@ public:
     D3DXFLOAT16 x, y;
 
 } D3DXVECTOR2_16F, *LPD3DXVECTOR2_16F;
-        
+
 ```
 
 

--- a/desktop-src/direct3d9/d3dxvector3-extensions.md
+++ b/desktop-src/direct3d9/d3dxvector3-extensions.md
@@ -8,6 +8,9 @@ ms.date: 05/31/2018
 
 # D3DXVECTOR3 Extensions
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
+
 The content from this page has been moved to the [**D3DXVECTOR3**](d3dxvector3.md) page.
 
 ## Related topics
@@ -20,6 +23,3 @@ The content from this page has been moved to the [**D3DXVECTOR3**](d3dxvector3.m
  
 
  
-
-
-

--- a/desktop-src/direct3d9/d3dxvector3.md
+++ b/desktop-src/direct3d9/d3dxvector3.md
@@ -4,18 +4,21 @@ ms.assetid: 4d73de4b-82fe-452a-8a1e-17208f172a03
 title: D3DXVECTOR3 structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR3
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXVECTOR3 structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a three-component vector including operator overloads and type casts.
 
@@ -141,7 +144,7 @@ public:
     D3DXFLOAT16 x, y, z;
 
 } D3DXVECTOR3_16F, *LPD3DXVECTOR3_16F;
-        
+
 ```
 
 

--- a/desktop-src/direct3d9/d3dxvector4-extensions.md
+++ b/desktop-src/direct3d9/d3dxvector4-extensions.md
@@ -8,6 +8,9 @@ ms.date: 05/31/2018
 
 # D3DXVECTOR4 Extensions
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
+
 The content from this page has been moved to the [**D3DXVECTOR4**](d3dxvector4.md) page.
 
 ## Related topics
@@ -20,6 +23,3 @@ The content from this page has been moved to the [**D3DXVECTOR4**](d3dxvector4.m
  
 
  
-
-
-

--- a/desktop-src/direct3d9/d3dxvector4.md
+++ b/desktop-src/direct3d9/d3dxvector4.md
@@ -4,18 +4,21 @@ ms.assetid: fbfe7851-7bec-4fa0-b4dc-52f5cb83d0a4
 title: D3DXVECTOR4 structure (D3dx9math.h)
 ms.topic: reference
 ms.date: 05/31/2018
-topic_type: 
+topic_type:
 - APIRef
 - kbSyntax
-api_name: 
+api_name:
 - D3DXVECTOR4
-api_type: 
+api_type:
 - HeaderDef
-api_location: 
+api_location:
 - d3dx9math.h
 ---
 
 # D3DXVECTOR4 structure (D3dx9math.h)
+
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
 
 Describes a four-component vector including operator overloads and type casts.
 
@@ -154,7 +157,7 @@ public:
     D3DXFLOAT16 x, y, z, w;
 
 } D3DXVECTOR4_16F, *LPD3DXVECTOR4_16F;
-        
+
 ```
 
 

--- a/desktop-src/direct3d9/math-function-support-in-d3dx.md
+++ b/desktop-src/direct3d9/math-function-support-in-d3dx.md
@@ -8,6 +8,9 @@ ms.date: 05/31/2018
 
 # Math Function Support in D3DX (Direct3D 9)
 
+> [!Note]
+> The D3DX utility library is deprecated. We recommend that you use [DirectXMath](../dxmath/pg-xnamath-migration-d3dx.md) instead.
+
 D3DX is a utility library that provides helper services. It is a layer above the Direct3D component.
 
 ## Math
@@ -40,6 +43,3 @@ When using the FLOAT16 data type, be sure to limit values to a maximum of D3DX\_
  
 
  
-
-
-


### PR DESCRIPTION
Add links to DirectXMath (specifically the porting table from D3DXMath) for each D3DXMath function in D3DX9 and D3DX10.