### PR TITLE
Fix some typos & layout across SecAuthN/tls-cipher-suites-in-windows-*

### DIFF
--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10--version-1507.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10--version-1507.md
@@ -77,7 +77,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                  | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                 | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                      | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_RSA\_WITH\_NULL\_MD5 Only used when application explicitly requests.<br/> | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_RSA\_WITH\_NULL\_MD5 <br/>  Only used when application explicitly requests.<br/> | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                        | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                            | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | SSL\_CK\_DES\_64\_CBC\_WITH\_MD5<br/>                                          | Yes<br/>                      | SSL 2.0<br/>                            |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10--version-1507.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10--version-1507.md
@@ -20,7 +20,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1507, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1511.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1511.md
@@ -20,7 +20,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1511, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1607.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1607.md
@@ -20,7 +20,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1607 and Windows Server 2016, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1703.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1703.md
@@ -73,7 +73,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_DHE\_DSS\_WITH\_3DES\_EDE\_CBC\_SHA<br/>                                               | Yes<br/>                      | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                         | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1703.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1703.md
@@ -20,7 +20,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1703, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1709.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1709.md
@@ -22,7 +22,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1709, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1709.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1709.md
@@ -75,7 +75,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_RSA\_WITH\_RC4\_128\_MD5<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                         | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1803.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1803.md
@@ -74,7 +74,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_RSA\_WITH\_RC4\_128\_MD5<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                         | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1803.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1803.md
@@ -21,7 +21,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1803, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1809.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1809.md
@@ -19,7 +19,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 For Windows 10, version 1809, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1903.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v1903.md
@@ -72,7 +72,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_RSA\_WITH\_RC4\_128\_MD5<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                         | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v20H2.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-10-v20H2.md
@@ -72,7 +72,7 @@ The following cipher suites are supported by the Microsoft Schannel Provider, bu
 | TLS\_RSA\_WITH\_RC4\_128\_MD5<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_DES\_CBC\_SHA<br/>                                                          | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_DHE\_DSS\_WITH\_DES\_CBC\_SHA<br/>                                                     | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
-| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA No TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/>   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
+| TLS\_DHE\_DSS\_EXPORT1024\_WITH\_DES\_CBC\_SHA<br/>                                         | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_WITH\_NULL\_MD5 <br/> Only used when application explicitly requests. <br/> | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT1024\_WITH\_RC4\_56\_SHA<br/>                                               | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |
 | TLS\_RSA\_EXPORT\_WITH\_RC4\_40\_MD5<br/>                                                   | No<br/>                       | TLS 1.2, TLS 1.1, TLS 1.0, SSL 3.0<br/> |

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-11.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-11.md
@@ -19,7 +19,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
 
 For Windows 11, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-8.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-8.md
@@ -20,7 +20,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf).
 
 Windows 7, Windows 8, and Windows Server 2012 are updated by the Windows Update by the 3042058 update which changes the priority order. See [Microsoft Security Advisory 3042058](/security-updates/SecurityAdvisories/2015/3042058) for more information. The following cipher suites are enabled and in this priority order by default by the Microsoft Schannel Provider:
 

--- a/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
+++ b/desktop-src/SecAuthN/tls-cipher-suites-in-windows-server-2022.md
@@ -19,7 +19,7 @@ Availability of cipher suites should be controlled in one of two ways:
 
  
 
-FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-complaint when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
+FIPS-compliance has become more complex with the addition of elliptic curves making the FIPS mode enabled column in previous versions of this table misleading. For example, a cipher suite such as TLS\_ECDHE\_RSA\_WITH\_AES\_128\_CBC\_SHA256 is only FIPS-compliant when using NIST elliptic curves. To find out which combinations of elliptic curves and cipher suites will be enabled in FIPS mode, see section 3.3.1 of [Guidelines for the Selection, Configuration, and Use of TLS Implementations]( https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r2.pdf).
 
 For Windows Server 2022, the following cipher suites are enabled and in this priority order by default using the Microsoft Schannel Provider:
 

--- a/desktop-src/SecCNG/sslenumciphersuites.md
+++ b/desktop-src/SecCNG/sslenumciphersuites.md
@@ -119,15 +119,3 @@ To enumerate all cipher suites supported by the SSL provider, call the **SslEnum
 | Header<br/>                   | <dl> <dt>Sslprovider.h</dt> </dl> |
 | Library<br/>                  | <dl> <dt>Ncrypt.lib</dt> </dl>    |
 | DLL<br/>                      | <dl> <dt>Ncrypt.dll</dt> </dl>    |
-
-
-
-## See also
-
-<dl> <dt>
-
-[**NCRYPT\_SSL\_CIPHER\_SUITE**](https://www.bing.com/search?q=**NCRYPT\_SSL\_CIPHER\_SUITE**)
-</dt> </dl>
-
- 
-

--- a/desktop-src/SecCNG/sslenumciphersuites.md
+++ b/desktop-src/SecCNG/sslenumciphersuites.md
@@ -62,7 +62,7 @@ Set this parameter to **NULL** when you are not specifying a private key.
 *ppCipherSuite* \[out\]
 </dt> <dd>
 
-A pointer to a [**NCRYPT\_SSL\_CIPHER\_SUITE**](https://www.bing.com/search?q=**NCRYPT\_SSL\_CIPHER\_SUITE**) structure to receive the address of the next cipher suite in the list.
+A pointer to a **NCRYPT\_SSL\_CIPHER\_SUITE** structure to receive the address of the next cipher suite in the list.
 
 </dd> <dt>
 


### PR DESCRIPTION
Fixes some typos & layout across SecAuthN/tls-cipher-suites-in-windows-*

Removes search engine result links for NCRYPT_SSL_CIPHER_SUITE from SecCNG/sslenumciphersuites.md since it doesn't produce any useful results. This is because the structure has had it's official public documentation removed. It is available in the downloadable Cryptographic Provider Development Kit which is linked to in the SecCNG/cng-portal page.
As an alternative to removing the links we could direct the reader back to SecCNG/cng-portal for the CPD Kit download link.