### PR TITLE
Update dynamic-link-library-best-practices.md

### DIFF
--- a/desktop-src/Dlls/dynamic-link-library-best-practices.md
+++ b/desktop-src/Dlls/dynamic-link-library-best-practices.md
@@ -39,7 +39,7 @@ You should never perform the following tasks from within [**DllMain**](dllmain.m
 -   Synchronize with other threads. This can cause a deadlock.
 -   Acquire a synchronization object that is owned by code that is waiting to acquire the loader lock. This can cause a deadlock.
 -   Initialize COM threads by using [**CoInitializeEx**](/windows/desktop/api/combaseapi/nf-combaseapi-coinitializeex). Under certain conditions, this function can call [**LoadLibraryEx**](/windows/desktop/api/LibLoaderAPI/nf-libloaderapi-loadlibraryexa).
--   Call the registry functions. These functions are implemented in Advapi32.dll. If Advapi32.dll is not initialized before your DLL, the DLL can access uninitialized memory and cause the process to crash.
+-   Call the registry functions.
 -   Call [**CreateProcess**](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa). Creating a process can load another DLL.
 -   Call [**ExitThread**](/windows/win32/api/libloaderapi/nf-libloaderapi-freelibraryandexitthread). Exiting a thread during DLL detach can cause the loader lock to be acquired again, causing a deadlock or a crash.
 -   Call [**CreateThread**](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createthread). Creating a thread can work if you do not synchronize with other threads, but it is risky.


### PR DESCRIPTION
Removing the "reason" after the rule that says don't call registry functions regarding advapi32. We are getting a lot of developers that read the reason and try to mitigate the reason through various means. This reason is only one of many reasons you cannot use registry functions in dllmain, e.g., if you use a pre-defined handle the registry code will use a critical section which can lead to deadlocks.