### PR TITLE
Fix wParam usage in the example for WM_SYSCOMMAND

### DIFF
--- a/desktop-src/menurc/wm-syscommand.md
+++ b/desktop-src/menurc/wm-syscommand.md
@@ -30,7 +30,7 @@ A window receives this message when the user chooses a command from the **Window
 
 ```cpp
  case WM_SYSCOMMAND:
-        if (wParam == SC_CLOSE)
+        if ((wParam & 0xFFF0) == SC_CLOSE)
         {
             EndDialog (hDlg, TRUE);
             return(TRUE);


### PR DESCRIPTION
In `WM_SYSCOMMAND` the Remarks section states:
> In WM_SYSCOMMAND messages, the four low-order bits of the wParam parameter are used internally by the system. To obtain the correct result when testing the value of wParam, an application must combine the value 0xFFF0 with the wParam value by using the bitwise AND operator.

This PR updates the example code that was **not** doing this on an assumption that it's this remark that is correct and not the example code. Should this be the other way around, I think that remark should be removed instead, but looking at the possible `wParam` parameters, there should be no harm in suggesting doing so even if it's not needed (anymore).