### PR TITLE
Changed I switch to lowercase i

### DIFF
--- a/desktop-src/Rpc/generating-interface-uuids.md
+++ b/desktop-src/Rpc/generating-interface-uuids.md
@@ -38,7 +38,7 @@ When you run the Uuidgen utility from the command line, you can use the followin
 
 | Uuidgen switch           | Description                                                                |
 |--------------------------|----------------------------------------------------------------------------|
-| **/I**                   | Outputs UUID to an IDL interface template.                                 |
+| **/i**                   | Outputs UUID to an IDL interface template.                                 |
 | **/s**                   | Outputs UUID as an initialized C structure.                                |
 | **/o**<*filename*> | Redirects output to a file; specified immediately after the **/o** switch. |
 | **/n**<*number*>   | Specifies the number of UUIDs to generate.                                 |


### PR DESCRIPTION
When rendered in Edge, the /I (uppercase i) switch looks like it is a lower case L which is confusing. All the other switches are lower case, the example below the table uses a lower case i and the /? text produced by the tool uses a lower case i, as such this change makes things consistent. It might be an idea if docs.microsoft.com switched to a font where the lowercase l and uppercase I didn't look identical, but I suspect that is a bigger change.