### PR TITLE
Change RFC 4646 reference to BCP 47

### DIFF
--- a/desktop-src/Intl/locale-names.md
+++ b/desktop-src/Intl/locale-names.md
@@ -1,5 +1,5 @@
 ---
-description: A locale name is based on the language tagging conventions of RFC 4646 (Windows Vista and later), and is represented by LOCALE\_SNAME.
+description: A locale name is based on the language tagging conventions of IETF BCP 47 (Windows Vista and later), and is represented by LOCALE\_SNAME.
 ms.assetid: 221aae7b-3a7c-4995-ae78-50d97de436d8
 title: Locale Names
 ms.topic: article
@@ -8,12 +8,10 @@ ms.date: 05/31/2018
 
 # Locale Names
 
-A [locale](locales-and-languages.md) name is based on the language tagging conventions of RFC 4646 (Windows Vista and later), and is represented by [LOCALE\_SNAME](locale-sname.md). Generally, the pattern `<language>-<REGION>` is used. Here, language is a lowercase ISO 639 language code. The codes from ISO 639-1 are used when available. Otherwise, codes from ISO 639-2/T are used. REGION specifies an uppercase ISO 3166-1 country/region identifier. For example, the locale name for English (United States) is "en-US" and the locale name for Divehi (Maldives) is "dv-MV".
+A [locale](locales-and-languages.md) name is based on the language tagging conventions of [IETF BCP 47](https://www.rfc-editor.org/info/bcp47) ( Windows Vista and later), and is represented by [LOCALE\_SNAME](locale-sname.md). Generally, the pattern `<language>-<REGION>` is used. Here, language is a lowercase ISO 639 language code. The codes from ISO 639-1 are used when available. Otherwise, codes from ISO 639-2/T are used. REGION specifies an uppercase ISO 3166-1 country/region identifier. For example, the locale name for English (United States) is "en-US" and the locale name for Divehi (Maldives) is "dv-MV".
 
 > [!Note]  
 > The constant [LOCALE\_NAME\_MAX\_LENGTH](locale-name-constants.md) gives the maximum length of a locale name. It includes space for a terminating null character.
-
- 
 
 If the locale is a neutral locale (no region), the [LOCALE\_SNAME](locale-sname.md) value follows the pattern `<language>`. If it is a neutral locale for which the script is significant, the pattern is `<language>-<Script>`.
 
@@ -27,23 +25,10 @@ An application can retrieve the current locale names by using the [**GetSystemDe
 
 ## Related topics
 
-<dl> <dt>
-
 [Locales and Languages](locales-and-languages.md)
-</dt> <dt>
 
 [Custom Locales](custom-locales.md)
-</dt> <dt>
 
 [Locale Identifiers](locale-identifiers.md)
-</dt> <dt>
 
 [Sort Order Identifiers](sort-order-identifiers.md)
-</dt> </dl>
-
- 
-
- 
-
-
-

--- a/desktop-src/Intl/locale-sname.md
+++ b/desktop-src/Intl/locale-sname.md
@@ -8,11 +8,4 @@ ms.date: 05/31/2018
 
 # LOCALE\_SNAME
 
-**Windows Vista and later:** Locale name, a multi-part tag to uniquely identify the locale. The maximum number of characters allowed for this string is 85, including a terminating null character. The tag is based on the language tagging conventions of RFC 4646. The pattern to use is described in [Locale Names](locale-names.md).
-
- 
-
- 
-
-
-
+**Windows Vista and later:** Locale name, a multi-part tag to uniquely identify the locale. The maximum number of characters allowed for this string is [LOCALE_NAME_MAX_LENGTH](locale-name-constants.md), including a terminating null character. The tag is based on the language tagging conventions of [IETF BCP 47](https://www.rfc-editor.org/info/bcp47). The pattern to use is described in [Locale Names](locale-names.md).

--- a/desktop-src/Intl/preparing-a-resource-configuration-file.md
+++ b/desktop-src/Intl/preparing-a-resource-configuration-file.md
@@ -12,8 +12,7 @@ Both the MUIRCT and the RC Compiler utilities described in [Resource Utilities](
 
 All resource configuration files for Win32 applications begin and end identically:
 
-
-```C++
+```xml
 <?xml version="1.0" encoding="utf-8"?> 
 <localization>
 
@@ -25,68 +24,42 @@ All resource configuration files for Win32 applications begin and end identicall
 </localization>
 ```
 
-
-
 This topic focuses on the aspects of the XML schema that are useful in building unmanaged code on Windows Vista and later. In particular, it is only concerned with the behavior of the win32Resources element.
 
 ## win32Resources Element
 
 The win32Resources element has the attributes described in the following table.
 
-
-
 | Attribute name           | Mandatory | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 |--------------------------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fileType                 | No        | Type of file. Should always be "Application".                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | checksum                 | No        | Checksum value to appear in the resource configuration data of the LN file and language-specific resource files. For example, this attribute allows you to copy the checksum from a single language-specific resource file, by convention the one for English (United States), and place the checksum in a different language-specific resource file. The checksum can be specified as a hexadecimal number string that is no longer than 32 characters. The numerical value must be containable in a 128-bit number. |
-| language                 | No        | Language specified using a name format compliant with RFC 4646 (Windows Vista and later), for example, en-US for English (United States).                                                                                                                                                                                                                                                                                                                                                                             |
-| ultimateFallbackLanguage | No        | Language to insert into the resource configuration data for the LN file, representing the ultimate fallback language to use in a search for a corresponding language-specific resource file. If the resource loader fails to load a requested resource file from the thread preferred UI languages, it uses an ultimate fallback language as its last attempt. The language is specified using a name format compliant with RFC 4646 (Windows Vista and later), for example, en-US for English (United States).       |
+| language                 | No        | Language tag compliant with IETF BCP 47 (Windows Vista and later), for example, en-US for English (United States).                                                                                                                                                                                                                                                                                                                                                                             |
+| ultimateFallbackLanguage | No        | Language to insert into the resource configuration data for the LN file, representing the ultimate fallback language to use in a search for a corresponding language-specific resource file. If the resource loader fails to load a requested resource file from the thread preferred UI languages, it uses an ultimate fallback language as its last attempt. The language tag compliant with IETF BCP 47 (Windows Vista and later), for example, en-US for English (United States).       |
 | ultimateFallbackLocation | No        | Fallback location. Specify "internal" if ultimate fallback resources are compiled into the LN file. Specify "external" (default) if the LN file is to reference a language-specific resource file for its ultimate fallback resources.                                                                                                                                                                                                                                                                                |
 
-
-
- 
-
 In the resource configuration file, the win32Resources element has the sub-elements described in the next table.
-
-
 
 | Element Name       | Description                                                                                                                              |
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | localizedResources | Resources that encapsulate information about the resource types and individual resources contained in a language-specific resource file. |
 | neutralResources   | Resources that encapsulate information about the resource types contained in an LN file.                                                 |
 
-
-
- 
-
 ## localizedResources Element
 
 Localized resources element. By default, this element has no attributes and only one type of sub-element. It is just a container for resourceType elements.
-
-
 
 | Attribute Name | Description                                                                    |
 |----------------|--------------------------------------------------------------------------------|
 | resourceType   | Type of an individual resource contained in a language-specific resource file. |
 
-
-
- 
-
 ## neutralResources Element
 
 Neutral resources element. This element is just a container for resourceType elements.
 
-
-
 | Attribute Name | Description                                        |
 |----------------|----------------------------------------------------|
 | resourceType   | Type of a single resource contained in an LN file. |
-
-
-
- 
 
 ## resourceType Element
 
@@ -95,20 +68,12 @@ The resourceType element encapsulates information about a single resource type o
 > [!Caution]  
 > Some resource configuration defects are caught only by RC Compiler or MUIRCT, depending on the input resource file or binary file content. The resourceType errors in the resource configuration file that do not exist in the input file are not caught, resulting in unexpected behavior. Users can be using a defective resource configuration file and do not know until they introduce binaries that use the broken parts of the resource configuration file, which creates the appearance that the breaks are from the current binaries.
 
- 
-
-
-
 | Attribute name | Mandatory | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 |----------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | typeNameId     | Yes       | Type name or identifier for the resource. Specify a string name or a number. If using a number, prepend the string with a "\#" to indicate that it represents a number. Each resourceType element must have only one *typeNameId* attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | itemName       | No        | Item name string for the resource, to be placed in the language-specific resource file. You can specify multiple names, separated by white spaces, for example, "HTML MOFDATA".                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | itemId         | No        | Identifier of individual resource item, to be placed in the language-specific resource file. The item can be specified as a range (for example, "1-12") or by individual identifiers separated by white spaces (for example, "1 3 4").                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | stringId       | No        | String identifier for individual resource item, to be placed in the language-specific resource file. The string can be specified as a range (for example, "1-12") or by individual identifiers separated by white spaces (for example, "1 3 4").This attribute allows the specification of both localizable and nonlocalizable string table entries. It must be used in conjunction with the *typeNameId* value of "6", denoting a string table entry resource type.<br/> Strings are stored in blocks of 16 in a string table. For example, strings 0 to 15 are stored in a single resource item block and can be referenced in the resource configuration file as *itemId* 1, or as *stringId* "0-15". For example, if there are five localizable strings and three nonlocalizable strings, you should assign string identifiers 0-4 for the localizable strings, and string identifiers 16-18 for the nonlocalizable strings. If you do not organize strings this way, the affected blocks of strings are placed in both the LN file and the language-specific resource file.<br/> |
-
-
-
- 
 
 If you specify the *itemName*, *itemId*, and/or *stringId* attributes for a particular resource type under the localizedResource element, only these specified items or strings for the designated resource type are placed in the language-specific resource file. If a resourceType element is specified without any explicit item name, item identifier, or string identifier, all items of the specified resource type are placed in the language-specific resource file. Items or types not listed in any localizedResource element are placed in the LN file.
 
@@ -132,8 +97,7 @@ The following are the standard resource types and their numeric identifiers:
 
 ## Example
 
-
-```C++
+```xml
 <?xml version="1.0" encoding="utf-8"?> 
 <localization>
   <resources>
@@ -188,23 +152,10 @@ The following are the standard resource types and their numeric identifiers:
 </localization>
 ```
 
-
-
 ## Remarks
 
 If you include any ICON(3), DIALOG(5), STRING(6), or VERSION(16) resource type in the neutralResources element, then you have to duplicate that entry in the localizedResources element. You can see this illustrated in the example above, where resource type 16 appears in both neutral and localized resources sections.
 
 ## Related topics
 
-<dl> <dt>
-
 [Preparing Resources](preparing-resources.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-


### PR DESCRIPTION
RFC 4646 is a deprecated part of [IETF BCP 47](https://www.rfc-editor.org/info/bcp47).
UWP docs already referring to BCP 47 not legacy RFC 4647: https://github.com/MicrosoftDocs/winrt-api/search?q=BCP-47&type=code