### PR TITLE
Correct TLS protocol support on Windows versions

### DIFF
--- a/desktop-src/SecAuthN/protocols-in-tls-ssl--schannel-ssp-.md
+++ b/desktop-src/SecAuthN/protocols-in-tls-ssl--schannel-ssp-.md
@@ -35,8 +35,9 @@ The following table displays the Microsoft Schannel Provider support of TLS prot
 | Windows 10, version 1903                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not supported  | Not supported  |
 | Windows 10, version 1909                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not supported  | Not supported  |
 | Windows 10, version 2004                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not supported  | Not supported  |
-| Windows 10, version 20H2                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        |
-| Windows 10, version 21H1                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        |
+| Windows 10, version 20H2                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not Supported  | Not Supported  |
+| Windows 10, version 21H1                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not Supported  | Not Supported  |
+| Windows 10, version 21H2                              | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Not Supported  | Not Supported  |
 | Windows Server 2022                                   | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        |
 | Windows 11                                            | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        | Enabled        |
 


### PR DESCRIPTION
TLS 1.3 is not supported before Windows 11. Updating to correctly reflect this for Windows 10 20H1 and 21H1, and adding 21H2.

@Andrei-Popov and @Justin-Burke for review.