### PR TITLE
Update AVDecVideoAcceleration_H264 to call out MF behavior

### DIFF
--- a/desktop-src/DirectShow/avdecvideoacceleration-h264-property.md
+++ b/desktop-src/DirectShow/avdecvideoacceleration-h264-property.md
@@ -24,11 +24,10 @@ This property is read/write.
 
 If the value is zero, the decoder does not use DirectX Video Acceleration (DXVA) for H.264 video decoding. For DirectShow filters, set this property before the decoder's output pin is connected.
 
-Note that when using Media Foundation (or the IMFTransform interface), this property has no effect.  See [**Supporting Direct3D 11 Video Decoding in Media Foundation**](https://docs.microsoft.com/en-us/windows/win32/medfound/supporting-direct3d-11-video-decoding-in-media-foundation) for how to use hardware acceleration with Media Foundation components.
+> [!NOTE]
+> When using Media Foundation (or the **IMFTransform** interface), this property has no effect. See [Supporting Direct3D 11 video decoding in Media Foundation](/windows/win32/medfound/supporting-direct3d-11-video-decoding-in-media-foundation) for how to use hardware acceleration with Media Foundation components.
 
 ## Requirements
-
-
 
 | Requirement | Value |
 |-------------------------------------|---------------------------------------------------------------------------------------|

--- a/desktop-src/DirectShow/avdecvideoacceleration-h264-property.md
+++ b/desktop-src/DirectShow/avdecvideoacceleration-h264-property.md
@@ -24,6 +24,8 @@ This property is read/write.
 
 If the value is zero, the decoder does not use DirectX Video Acceleration (DXVA) for H.264 video decoding. For DirectShow filters, set this property before the decoder's output pin is connected.
 
+Note that when using Media Foundation (or the IMFTransform interface), this property has no effect.  See [**Supporting Direct3D 11 Video Decoding in Media Foundation**](https://docs.microsoft.com/en-us/windows/win32/medfound/supporting-direct3d-11-video-decoding-in-media-foundation) for how to use hardware acceleration with Media Foundation components.
+
 ## Requirements
 
 


### PR DESCRIPTION
Add a clarifying statement to AVDecVideoAcceleration_H264 CodecAPI to describe MF behavior.  The current document is misleading in that it only applies when using DShow transforms.  But CodecAPIs are also available for MF transforms.