### PR TITLE
Update rules-for-using-pointers.md

### DIFF
--- a/desktop-src/WinProg64/rules-for-using-pointers.md
+++ b/desktop-src/WinProg64/rules-for-using-pointers.md
@@ -81,7 +81,7 @@ Porting your code to compile for both 32- and 64-bit Microsoft Windows is straig
 
     -   GWL\_WNDPROC
     -   GWL\_HINSTANCE
-    -   GWL\_HWDPARENT
+    -   GWL\_HWNDPARENT
     -   GWL\_USERDATA
 
     Instead, Winuser.h defines the following new indexes:


### PR DESCRIPTION
Fixed type (it's `GWL_HWNDPARENT`, not `GWL_HWDPARENT`).