### PR TITLE
Remove dead link from asf-file-structure.md

### DIFF
--- a/desktop-src/medfound/asf-file-structure.md
+++ b/desktop-src/medfound/asf-file-structure.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 This topic describes the structure of an Advanced Systems Format (ASF) file.
 
-For detailed information about ASF files, download the [ASF Specification](https://www.microsoft.com/downloads/details.aspx?displaylang=en&FamilyID=56de5ee4-51ca-46c6-903b-97390ad14fea). You can also use the [Windows Media ASF Viewer 9 Series](https://www.microsoft.com/downloads/details.aspx?displaylang=en&FamilyID=56de5ee4-51ca-46c6-903b-97390ad14fea) tool to see the structure of an existing ASF file.
+For detailed information about ASF files, download the [ASF Specification](https://www.microsoft.com/downloads/details.aspx?displaylang=en&FamilyID=56de5ee4-51ca-46c6-903b-97390ad14fea).
 
 The base unit of organization for ASF files is called an *object*. An ASF file object contains the following data.
 


### PR DESCRIPTION
The ASF File Structure page currently contains a dead link/suggestion to use the Windows Media ASF Viewer 9 Series tool. 
I've been unable to locate a live link to this tool, so it should be removed from the documentation (or updated, if someone has a good link for it!).