### PR TITLE
Fix typo on page: 'UAV' should be 'SRV'

### DIFF
--- a/desktop-src/direct3dhlsl/sm5-object-structuredbuffer.md
+++ b/desktop-src/direct3dhlsl/sm5-object-structuredbuffer.md
@@ -31,7 +31,7 @@ A read-only buffer, which can take a T type that is a structure.
 
  
 
-The UAV format bound to this resource needs to be created with the DXGI\_FORMAT\_UNKNOWN format.
+The SRV format bound to this resource needs to be created with the DXGI\_FORMAT\_UNKNOWN format.
 
 To find out more about [structured buffers](/windows/desktop/direct3d11/direct3d-11-advanced-stages-cs-resources), see the overview material.
 

--- a/desktop-src/direct3dhlsl/sm5-object-structuredbuffer.md
+++ b/desktop-src/direct3dhlsl/sm5-object-structuredbuffer.md
@@ -19,19 +19,13 @@ api_location:
 
 A read-only buffer, which can take a T type that is a structure.
 
-
-
 | Method                                                             | Description                            |
 |--------------------------------------------------------------------|----------------------------------------|
 | [**GetDimensions**](sm5-object-structuredbuffer-getdimensions.md) | Gets the resource dimensions.          |
 | [**Load**](structuredbuffer-load.md)                              | Reads buffer data.                     |
 | [**Operator\[\]**](sm5-object-structuredbuffer-operatorindex.md)  | Returns a read-only resource variable. |
 
-
-
- 
-
-The SRV format bound to this resource needs to be created with the DXGI\_FORMAT\_UNKNOWN format.
+The SRV format bound to this resource needs to be created with the **DXGI_FORMAT_UNKNOWN** format.
 
 To find out more about [structured buffers](/windows/desktop/direct3d11/direct3d-11-advanced-stages-cs-resources), see the overview material.
 
@@ -39,27 +33,15 @@ To find out more about [structured buffers](/windows/desktop/direct3d11/direct3d
 
 This object is supported in the following shader models.
 
-
-
 | Shader Model                                                                                                                                                                                                            | Supported |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
 | [Shader Model 5](d3d11-graphics-reference-sm5.md) and higher shader models [Shader Model 4](dx-graphics-hlsl-sm4.md) (Available for compute and pixel shaders in Direct3D 11 on some Direct3D 10 devices.)<br/> | yes       |
 
-
-
- 
-
 This object is supported for the following types of shaders.
-
-
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
 | x      | x    | x      | x        | x     | x       |
-
-
-
- 
 
 ## See also
 
@@ -67,6 +49,3 @@ This object is supported for the following types of shaders.
 
 [Shader Model 5 Objects](d3d11-graphics-reference-sm5-objects.md)
 </dt> </dl>
-
- 
-


### PR DESCRIPTION
A read-only StructuredBuffer is bound using a Shader Resource View (SRV), not an Unordered Access View (UAV).