### PR TITLE
It's LPCWSTR and not LPWSTR

### DIFF
--- a/desktop-src/Dlls/creating-a-simple-dynamic-link-library.md
+++ b/desktop-src/Dlls/creating-a-simple-dynamic-link-library.md
@@ -33,7 +33,7 @@ For an example that uses myPuts, see [Using Load-Time Dynamic Linking](using-loa
 extern "C" {          // we need to export the C interface
 #endif
  
-__declspec(dllexport) int __cdecl myPuts(LPWSTR lpszMsg)
+__declspec(dllexport) int __cdecl myPuts(LPCWSTR lpszMsg)
 {
     DWORD cchWritten;
     HANDLE hConout;


### PR DESCRIPTION
So it can work with its example: https://docs.microsoft.com/en-us/windows/win32/dlls/using-run-time-dynamic-linking