### PR TITLE
The dev population needs to be informed of the status of MFC controls…

### DIFF
--- a/desktop-src/menurc/resource-compiler.md
+++ b/desktop-src/menurc/resource-compiler.md
@@ -15,6 +15,9 @@ The Microsoft Windows Resource Compiler (RC) is a tool used in building Windows-
 
 This tool is available in Visual Studio and the Microsoft Windows Software Development Kit (SDK).
 
+Note! Although the RC is obtained by downloading [Windows App SDK](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/), responsibility for the design of emerging UI controls befalls the Windows OS team. Maintenance and migration of the legacy RC tool suite befalls the Windows App SDK team, who are defining a merge path for legacy RC control tools and emerging modern Fluent UI frameworks. [Unified API surface across desktop app platforms](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/#benefits-of-the-windows-app-sdk-for-windows-developers) and [Consistent experience across Windows versions](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/#benefits-of-the-windows-app-sdk-for-windows-developers) describe their merge path promise. 
+ 
+
 The following topics describe the resource file syntax and the RC command line:
 
 -   [About Resource Files](about-resource-files.md)


### PR DESCRIPTION
…, their creation and editing regardless of platform or migration to Windows UI Framework

There needs to be an MFC developer (and legacy code maintainers) notification informing them of what is happening with the platform's UI control software. 
I am proposing a note (needs to be formatted) that addresses this issue. Here is the feedback note I left at Windows Feedback Hub:
*The legacy native C++ MFC is slowly getting a facelift. This is due to durability of C++ and the fact that there still is a ton of code out there that is MFC, as well as due to the fact that Microsoft if anything, pledges to observe backwards compatibility. Also, it is clear that the latest UI Framework XAML controls, like the ones that were used to program the elaborate, but effective, Windows 11 Settings control, are to be desired. I am also pretty sure these new controls will be programmatically includable in an MFC program. I would like to know how to do that, or at least have an idea that this will be possible at some point. MFC is certainly capable of accessing anything.*
[Build a C# .NET app with WinUI 3 and Win32 interop](https://docs.microsoft.com/en-us/windows/apps/winui/winui3/desktop-winui3-app-with-basic-interop).