### PR TITLE
EndQuery is supported by compute command lists

### DIFF
--- a/desktop-src/direct3d12/user-mode-heap-synchronization.md
+++ b/desktop-src/direct3d12/user-mode-heap-synchronization.md
@@ -173,6 +173,7 @@ Compute command lists can also use the following methods.
 -   [**SetDescriptorHeaps**](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-setdescriptorheaps)
 -   [**SetPipelineState**](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-setpipelinestate)
 -   [**SetPredication**](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-setpredication)
+-   [**EndQuery**](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-endquery)
 
 Compute command lists must set a compute PSO when calling [**SetPipelineState**](/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-setpipelinestate).
 


### PR DESCRIPTION
According to the query type support table in https://microsoft.github.io/DirectX-Specs/d3d/CountersAndQueries.html#queries, EndQuery method should be supported by compute command lists.