### PR TITLE
Update a-tokengroups.md

### DIFF
--- a/desktop-src/ADSchema/a-tokengroups.md
+++ b/desktop-src/ADSchema/a-tokengroups.md
@@ -18,7 +18,7 @@ ms.date: 05/31/2018
 
 # Token-Groups attribute
 
-A computed attribute that contains the list of SIDs due to a transitive group membership expansion operation on a given user or computer. Token Groups cannot be retrieved if no Global Catalog is present to retrieve the transitive reverse memberships.
+A computed attribute that contains the list of SIDs due to a transitive group membership expansion operation on a given user or computer. Token Groups cannot be retrieved if no Global Catalog is present to retrieve the transitive reverse memberships. Retrieving tokenGroups is an expensive operation on the domain controllers so requires a BASE scope LDAP query to return the attribute values for a given security principal object. Care should be taken when scaling use of this attribute in larger environments as it can impact overall domain controller performance up to and including preventing the domain controller from processing other requests. 
 
 
 

--- a/desktop-src/ADSchema/a-tokengroups.md
+++ b/desktop-src/ADSchema/a-tokengroups.md
@@ -18,7 +18,10 @@ ms.date: 05/31/2018
 
 # Token-Groups attribute
 
-A computed attribute that contains the list of SIDs due to a transitive group membership expansion operation on a given user or computer. Token Groups cannot be retrieved if no Global Catalog is present to retrieve the transitive reverse memberships. Retrieving tokenGroups is an expensive operation on the domain controllers so requires a BASE scope LDAP query to return the attribute values for a given security principal object. Care should be taken when scaling use of this attribute in larger environments as it can impact overall domain controller performance up to and including preventing the domain controller from processing other requests. 
+A computed attribute that contains the list of SIDs due to a transitive group membership expansion operation on a given user or computer. Token Groups cannot be retrieved if no Global Catalog is present to retrieve the transitive reverse memberships.
+
+> [!NOTE]
+> Retrieving Token Groups is an expensive operation on the domain controllers, requiring a BASE scope LDAP query to return the attribute values for a given security principal object. Care should be taken when scaling the use of this attribute in larger environments. It can impact overall domain controller performance up to the point that it prevents the domain controller from processing other requests. 
 
 
 


### PR DESCRIPTION
That is just some possible verbiage to use. Companies (software vendors) are getting confused about this attribute thinking they can simply use it without any thoughts about scaling concerns. We have seen issues with large orgs where an application (Centrify) with tens of thousands of clients will try to resolve tokengroups for sec prins and will bring groups of domain controllers to their knees until they can work through the request load.