### PR TITLE
ETW Autologgers are not configured with EnabeTraceEx2

### DIFF
--- a/desktop-src/ETW/configuring-and-starting-an-autologger-session.md
+++ b/desktop-src/ETW/configuring-and-starting-an-autologger-session.md
@@ -117,8 +117,6 @@ The AutoLogger sessions increase the system boot time and should be used sparing
 
 To stop an AutoLogger session, call the [**ControlTrace**](/windows/win32/api/evntrace/nf-evntrace-controltracea) function. The session name that you pass to the function is the name of the registry key that you used to define the session in the registry.
 
-On Windows 8.1,Windows Server 2012 R2, and later, event payload , scope, and stack walk filters can be used by the [**EnableTraceEx2**](/windows/win32/api/evntrace/nf-evntrace-enabletraceex2) function and the [**ENABLE\_TRACE\_PARAMETERS**](/windows/win32/api/evntrace/ns-evntrace-enable_trace_parameters) and [**EVENT\_FILTER\_DESCRIPTOR**](/windows/desktop/api/Evntprov/ns-evntprov-event_filter_descriptor) structures to filter on specific conditions in a logger session. For more information on event payload filters, see the [**TdhCreatePayloadFilter**](/windows/desktop/api/Tdh/nf-tdh-tdhcreatepayloadfilter), and [**TdhAggregatePayloadFilters**](/windows/desktop/api/Tdh/nf-tdh-tdhaggregatepayloadfilters) functions and the **ENABLE\_TRACE\_PARAMETERS**, **EVENT\_FILTER\_DESCRIPTOR**, and [**PAYLOAD\_FILTER\_PREDICATE**](/windows/desktop/api/Tdh/ns-tdh-payload_filter_predicate) structures.
-
 For details on starting an event tracing session, see [Configuring and Starting an Event Tracing Session](configuring-and-starting-an-event-tracing-session.md).
 
 For details on starting a private logger session, see [Configuring and Starting a Private Logger Session](configuring-and-starting-a-private-logger-session.md).


### PR DESCRIPTION
Hi.

I suggest that this paragraph should be deleted. It appears to have been copied verbatim from [configuring-and-starting-an-event-tracing-session](https://docs.microsoft.com/en-us/windows/win32/etw/configuring-and-starting-an-event-tracing-session) and does not seem to be relevant to Autologger configuration.

Specifically, this paragraph references `EnableTraceEx2` and the previous paragraphs explicitly states that Autologger sessions are configured by `EnableTraceEx` plus the table only references parameters relevant to `EnableTraceEx`.

That said, it would be awesome if ETW Autologger sessions could be configured via `EnableTraceEx2`. If that is the case then can you please update the table with the necessary registry keys to set. :-)