### PR TITLE
Update protecting-anti-malware-services-.md

### DIFF
--- a/desktop-src/Services/protecting-anti-malware-services-.md
+++ b/desktop-src/Services/protecting-anti-malware-services-.md
@@ -116,10 +116,10 @@ For more info about user-defined resource file, see [User-Defined Resource](/win
 
 ### CertHash
 
-The hash of the certificate that's used to sign the anti-malware service. The CertMgr.exe tool, which ships in the Windows SDK, can be used to obtain the hash.
+The hash of the certificate that's used to sign the anti-malware service. The CertUtil.exe tool, which ships in the Windows SDK, can be used to obtain the hash.
 
 ``` syntax
-certmgr.exe –v <path to the signed file>
+certutil.exe –v <path to the signed file>
 ```
 
 For example:


### PR DESCRIPTION
The tool to grab the certhash is incorrectly referred to as "CertMgr.exe". The right tool to use to grab the certhash is certutil.exe