### PR TITLE
Use codeblock to show signtool command

### DIFF
--- a/desktop-src/SecCrypto/adding-time-stamps-to-previously-signed-files.md
+++ b/desktop-src/SecCrypto/adding-time-stamps-to-previously-signed-files.md
@@ -8,9 +8,11 @@ ms.date: 05/31/2018
 
 # Adding Time Stamps to Previously Signed Files
 
-Time stamps are normally included when a file is signed using SignTool with the **-t** option. In addition, time stamps can be added to files that were signed without a time stamp. The following command adds a time stamp to a previously signed file:
+Time stamps are normally included when a file is signed using SignTool with the `-t` option. In addition, time stamps can be added to files that were signed without a time stamp. The following command adds a time stamp to a previously signed file:
 
-**signtool timestamp -t https:\//timestamp.digicert.com *MyControl.exe***
+```console
+signtool timestamp -t https://timestamp.digicert.com MyControl.exe
+```
 
 > [!Note]  
 > The file to be time stamped must have previously been signed.


### PR DESCRIPTION
This PR fixes command line example to use codeblock instead of bold text.

Actual issue is that the [Japanese translation](https://docs.microsoft.com/ja-jp/windows/win32/seccrypto/adding-time-stamps-to-previously-signed-files) of this document has a wrong command line as below. A space between the timestamp server and the file name is removed.
```
signtool timestamp -t https://timestamp.digicert.comMyControl.exe
```
