### PR TITLE
Fix missing word in D3D10 block compression docs

### DIFF
--- a/desktop-src/direct3d10/d3d10-graphics-programming-guide-resources-block-compression.md
+++ b/desktop-src/direct3d10/d3d10-graphics-programming-guide-resources-block-compression.md
@@ -88,7 +88,7 @@ In summary, be careful to use aligned memory blocks when copying regions that co
 
 ## Compression Algorithms
 
-Block compression techniques in Direct3D break up uncompressed texture data into 4×4 blocks, compress each block, and then store the data. For this reason, textures are expected to be compressed must have texture dimensions that are multiples of 4.
+Block compression techniques in Direct3D break up uncompressed texture data into 4×4 blocks, compress each block, and then store the data. For this reason, textures that are expected to be compressed must have texture dimensions that are multiples of 4.
 
 ![diagram of block compression](images/d3d10-compression-1.png)
 


### PR DESCRIPTION
This is a very small change, it just adds the word `that`, which seems to be missing in the sentence.