### PR TITLE
Wrong type in signature of function myPust(...)

### DIFF
--- a/desktop-src/Dlls/using-load-time-dynamic-linking.md
+++ b/desktop-src/Dlls/using-load-time-dynamic-linking.md
@@ -16,7 +16,7 @@ Because this example calls the DLL function explicitly, the module for the appli
 ```C++
 #include <windows.h> 
 
-extern "C" int __cdecl myPuts(LPWSTR);   // a function from a DLL
+extern "C" int __cdecl myPuts(LPCWSTR);   // a function from a DLL
 
 int main(VOID) 
 { 


### PR DESCRIPTION
Basing on code shown in [Creating a Simple Dynamic-Link Library](https://docs.microsoft.com/en-us/windows/win32/dlls/creating-a-simple-dynamic-link-library) I believe that it should be `int myPuts(LPCWSTR lpszMsg)` and not `int myPush(LPWSTR lpszMsg)` as it is now.