### PR TITLE
Waitable Timer Example: fix E0513

### DIFF
--- a/desktop-src/Sync/using-a-waitable-timer-with-an-asynchronous-procedure-call.md
+++ b/desktop-src/Sync/using-a-waitable-timer-with-an-asynchronous-procedure-call.md
@@ -32,7 +32,7 @@ When you are using a waitable timer with an APC, the thread that sets the timer 
 #define _SECOND 10000000
 
 typedef struct _MYDATA {
-   TCHAR *szText;
+   LPCTSTR szText;
    DWORD dwValue;
 } MYDATA;
 


### PR DESCRIPTION
Attempting to assign a string literal (aka const wchar_t*) to a non-const string (TCHAR*) results in E0513. Change TCHAR* to LPCTSTR to fix the error.

Signed-off-by: Will Eccles <will@eccles.dev>