### PR TITLE
Update about-keyboard-input.md

### DIFF
--- a/desktop-src/inputdev/about-keyboard-input.md
+++ b/desktop-src/inputdev/about-keyboard-input.md
@@ -110,10 +110,10 @@ case WM_SYSKEYUP:
     if (isExtendedKey)
         scanCode = MAKEWORD(scanCode, 0xE0);
 
-    BOOL repeatFlag = (keyFlags & KF_REPEAT) == KF_REPEAT;        // previous key-state flag, 1 on autorepeat
+    BOOL wasKeyDown = (keyFlags & KF_REPEAT) == KF_REPEAT;        // previous key-state flag, 1 on autorepeat
     WORD repeatCount = LOWORD(lParam);                            // repeat count, > 0 if several keydown messages was combined into one message
 
-    BOOL upFlag = (keyFlags & KF_UP) == KF_UP;                    // transition-state flag, 1 on keyup
+    BOOL isKeyReleased = (keyFlags & KF_UP) == KF_UP;             // transition-state flag, 1 on keyup
 
     // if we want to distinguish these keys:
     switch (vkCode)


### PR DESCRIPTION
Reaname variables in example code to be on par with [Windows.UI.Core.CorePhysicalKeyStatus](https://learn.microsoft.com/uwp/api/windows.ui.core.corephysicalkeystatus) field names.