### PR TITLE
Description and Casing Corrections

### DIFF
--- a/desktop-src/dstorage/dstorage-portal.md
+++ b/desktop-src/dstorage/dstorage-portal.md
@@ -1,17 +1,17 @@
 ---
 title: DirectStorage
-description: DirectStorage is a feature intended to allow games to make full use of high-speed storage (such as NVMe SSDs) that can can deliver multiple gigabytes a second of small (for example, 64kb) data reads with minimal CPU overhead.
+description: DirectStorage is a feature intended to allow games to make full use of high-speed storage (such as NVMe SSDs) that can deliver multiple gigabytes a second of small (for example, 64kb) data reads with minimal CPU overhead.
 ms.topic: article
 ms.date: 08/25/2022
 ---
 
 # DirectStorage
 
-DirectStorage is a feature intended to allow games to make full use of high-speed storage (such as NVMe SSDs) that can can deliver multiple gigabytes a second of small (for example, 64kb) data reads with minimal CPU overhead.
+DirectStorage is a feature intended to allow games to make full use of high-speed storage (such as NVMe SSDs) that can deliver multiple gigabytes a second of small (for example, 64kb) data reads with minimal CPU overhead.
 
 ## In this section
 
 | Topic | Description |
 |-|-|
 | [Using DirectStorage](using-dstorage.md) | A quick introduction to using DirectStorage. |
-| [DirectStorage API reference](dstorage-api-reference.md) | This section is a reference for APIs declared in `dstorage.h` for DirectStorage-based programming. |
+| [DirectStorage API Reference](dstorage-api-reference.md) | This section is a reference for APIs declared in `dstorage.h` for DirectStorage-based programming. |

--- a/desktop-src/dstorage/dstorage-portal.md
+++ b/desktop-src/dstorage/dstorage-portal.md
@@ -14,4 +14,4 @@ DirectStorage is a feature intended to allow games to make full use of high-spee
 | Topic | Description |
 |-|-|
 | [Using DirectStorage](using-dstorage.md) | A quick introduction to using DirectStorage. |
-| [DirectStorage API Reference](dstorage-api-reference.md) | This section is a reference for APIs declared in `dstorage.h` for DirectStorage-based programming. |
+| [DirectStorage API reference](dstorage-api-reference.md) | This section is a reference for APIs declared in `dstorage.h` for DirectStorage-based programming. |


### PR DESCRIPTION
Both descriptions for DirectStorage have had repeated words omitted and the casing of the DirectStorage API reference entry has been updated.