### PR TITLE
Update defining-tasks-and-opcodes.md

### DIFF
--- a/desktop-src/WES/defining-tasks-and-opcodes.md
+++ b/desktop-src/WES/defining-tasks-and-opcodes.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 Providers use tasks and opcodes to logically group events. Grouping events helps consumers query for only those events that contain specific task and opcode combinations. Typically, you use tasks to identify a major component of the provider such as the networking or database component. You could then use opcodes to identify the operations that the component performs, such as the send and receive operations for a networking component. If you had only one component, you could use task to reflect a major operation in the component, such as connect or disconnect, and use opcode to reflect an activity within the operation such as reading the registry. You could also use opcode without specifying a task. How you use task and opcodes to group events for the consumer is completely up to you.
 
-To define a task, use the **task** element. To define an opcode, use the **opcode** element. You can specify up to 228 opcodes. The task **value** must be greater than 0. The opcodes must be in the range from 11 through 239. The Winmeta.xml file defines common operations that you can use instead of defining your own.
+To define a task, use the **task** element. To define an opcode, use the **opcode** element. You can specify up to 228 opcodes. The task **value** must be greater than 0. The opcodes must be in the range from 10 through 239. The Winmeta.xml file defines common operations that you can use instead of defining your own.
 
 The following example shows how to define several tasks and opcodes.
 


### PR DESCRIPTION
Here, you saied 'The opcodes must be in the range from 11 through 239', but in https://learn.microsoft.com/en-us/windows/win32/wes/eventmanifestschema-opcodetype-complextype where defines the Opcode element, it said 'You can specify values in the range 10 and 239. ' Are they conflict?
As the pre-defined opcode value are range from 0-9, cutomized opcode value should start at 10.