### PR TITLE
Fixed Href Tag for "Shell"

### DIFF
--- a/desktop-src/shell/autorun-cmds.md
+++ b/desktop-src/shell/autorun-cmds.md
@@ -18,7 +18,7 @@ This topic is a reference for the entries that can be used in an Autorun.inf fil
     -   [open](#parameters)
     -   [UseAutoPlay](#parameters)
     -   [shellexecute](#shellexecute)
-    -   [shell](#autoruninf-entries)
+    -   [shell](#shell)
     -   [shell\\verb](#shellverb)
 -   [\[Content\] Keys](#content-keys)
 -   [\[ExclusiveContentPaths\] Keys](#exclusivecontentpaths-keys)


### PR DESCRIPTION
For "Shell" text, href Tag was set to "#autoruninf-entries" instead of "#shell" due to which clicking the Shell Text was navigating to wrong section. 
Fixed: Now, clicking the Shell Text is navigating to respective section properly.