### PR TITLE
Fixed typo in RPC_BINDING_HANDLE

### DIFF
--- a/desktop-src/Rpc/rpc-binding-handle.md
+++ b/desktop-src/Rpc/rpc-binding-handle.md
@@ -1,6 +1,6 @@
 ---
 title: RPC_BINDING_HANDLE (Rpcdce.h)
-description: The RPC\_BINDING HANDLE data type declares a binding handle containing information that the RPC run-time library uses to access binding information.
+description: The RPC_BINDING_HANDLE data type declares a binding handle containing information that the RPC run-time library uses to access binding information.
 ms.assetid: 3e07d9e9-04d8-4f94-8104-cd0ee89a9407
 keywords:
 - RPC_BINDING_HANDLE
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 # RPC\_BINDING\_HANDLE
 
-The **RPC\_BINDING HANDLE** data type declares a binding handle containing information that the RPC run-time library uses to access binding information.
+The **RPC\_BINDING\_HANDLE** data type declares a binding handle containing information that the RPC run-time library uses to access binding information.
 
 
 ```C++


### PR DESCRIPTION
Fixed a minor typo where an underscore was missing in the RPC_BINDING_HANDLE type.