### PR TITLE
Invalid type declaration for ErrorHandler

### DIFF
--- a/desktop-src/ProcThread/creating-threads.md
+++ b/desktop-src/ProcThread/creating-threads.md
@@ -24,7 +24,7 @@ The calling thread uses the [**WaitForMultipleObjects**](/windows/desktop/api/sy
 #define BUF_SIZE 255
 
 DWORD WINAPI MyThreadFunction( LPVOID lpParam );
-void ErrorHandler(LPTSTR lpszFunction);
+void ErrorHandler(LPTCSTR lpszFunction);
 
 // Sample custom data structure for threads to use.
 // This is passed by void pointer so it can be any data type
@@ -138,7 +138,7 @@ DWORD WINAPI MyThreadFunction( LPVOID lpParam )
 
 
 
-void ErrorHandler(LPTSTR lpszFunction) 
+void ErrorHandler(LPCTSTR lpszFunction) 
 { 
     // Retrieve the system error message for the last-error code.
 


### PR DESCRIPTION
```
main.cpp: In function 'int WinMain(HINSTANCE, HINSTANCE, LPSTR, int)':
main.cpp:489:35: warning: ISO C++ forbids converting a string constant to 'LPTSTR' {aka 'char*'} [-Wwrite-strings]
  489 |                 ErrorHandler(TEXT("CreateThread"));
      |                                   ^~~~~~~~~~~~~~
```
ErrorHandler needs the type LPCTSTR because TEXT("CreateThread") returns `const wchar_t*`.