### PR TITLE
Update manifest-file-schema.md

### DIFF
--- a/desktop-src/SbsCs/manifest-file-schema.md
+++ b/desktop-src/SbsCs/manifest-file-schema.md
@@ -154,14 +154,17 @@ The following is the complete listing of the manifest file schema.
   <!-- WindowsSettings elements from XML namespace http://schemas.microsoft.com/SMI/2005/WindowsSettings
   --> 
   <ElementType name="dpiAware" /> 
+  <ElementType name="autoElevate" /> 
+  <ElementType name="disableTheming" /> 
 
   <!-- WindowsSettings elements from XML namespace http://schemas.microsoft.com/SMI/2011/WindowsSettings
   --> 
-  <ElementType name="autoElevate" /> 
-  <ElementType name="disableTheming" /> 
   <ElementType name="disableWindowFiltering" /> 
-  <ElementType name="highResolutionScrollingAware" /> 
   <ElementType name="printerDriverIsolation" /> 
+    
+  <!-- WindowsSettings elements from XML namespace http://schemas.microsoft.com/SMI/2013/WindowsSettings
+  --> 
+  <ElementType name="highResolutionScrollingAware" /> 
   <ElementType name="ultraHighResolutionScrollingAware" /> 
 
   <!-- WindowsSettings elements from XML namespace http://schemas.microsoft.com/SMI/2016/WindowsSettings


### PR DESCRIPTION
Move some elements to correct namespaces. Tested namespaces on a real exe file. If those elements are put to other namespaces, exe file does not load.

Some elements are also documented with the corresponding correct namespaces:
- `highResolutionScrollingAware`, `ultraHighResolutionScrollingAware` should be in `http://schemas.microsoft.com/SMI/2013/WindowsSettings`: [link](https://learn.microsoft.com/en-us/windows/compatibility/precision-touchpad-devices#solution).
