### PR TITLE
Prevent compilation failure with error C2664

### DIFF
--- a/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
+++ b/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
@@ -22,7 +22,7 @@ A simple error-reporting function, `printError`, displays the reason for any fai
 BOOL GetProcessList( );
 BOOL ListProcessModules( DWORD dwPID );
 BOOL ListProcessThreads( DWORD dwOwnerPID );
-void printError( TCHAR* msg );
+void printError( const TCHAR* msg );
 
 int main( void )
 {
@@ -179,7 +179,7 @@ BOOL ListProcessThreads( DWORD dwOwnerPID )
   return( TRUE );
 }
 
-void printError( TCHAR* msg )
+void printError( const TCHAR* msg )
 {
   DWORD eNum;
   TCHAR sysMsg[256];


### PR DESCRIPTION
Using the provided code sample leads compilation to fail with `error C2664: 'void printError(TCHAR *)': cannot convert argument 1 from 'const wchar_t [...]' to 'TCHAR *'` messages in a C++ console application project created under Visual Studio Community 17.2.5, where the `/permissive-` flag is used by default.