### PR TITLE
Direct3D HDR: Fix parenthesis in `simpleReinhardTonemapper`

### DIFF
--- a/desktop-src/direct3darticles/high-dynamic-range.md
+++ b/desktop-src/direct3darticles/high-dynamic-range.md
@@ -572,9 +572,9 @@ D2D1_VECTOR_4F simpleReinhardTonemapper(
     output.g /= inputMax;
     output.b /= inputMax;
 
-    output.r = (output.r / 1 + output.r);
-    output.g = (output.g / 1 + output.g);
-    output.b = (output.b / 1 + output.b);
+    output.r = output.r / (1 + output.r);
+    output.g = output.g / (1 + output.g);
+    output.b = output.b / (1 + output.b);
 
     output.r *= outputMax;
     output.g *= outputMax;


### PR DESCRIPTION
The parenthesis in the `simpleReinhardTonemapper` was missplaced:
```    
    output.r = (output.r / 1 + output.r);
    output.g = (output.g / 1 + output.g);
    output.b = (output.b / 1 + output.b);
```
It should be 
```` 
    output.r = output.r / (1 + output.r);
    output.g = output.g / (1 + output.g);
    output.b = output.b / (1 + output.b);
````