### PR TITLE
Fix ERROR_INVALID_PARAMETER in ReadFile/WriteFile

### DIFF
--- a/desktop-src/ipc/named-pipe-server-using-overlapped-i-o.md
+++ b/desktop-src/ipc/named-pipe-server-using-overlapped-i-o.md
@@ -85,6 +85,8 @@ int _tmain(VOID)
       }
  
       Pipe[i].oOverlap.hEvent = hEvents[i]; 
+      Pipe[i].oOverlap.Offset = 0;
+      Pipe[i].oOverlap.OffsetHigh = 0;
  
       Pipe[i].hPipeInst = CreateNamedPipe( 
          lpszPipename,            // pipe name 


### PR DESCRIPTION
The Offset and OffsetHigh fields of the OVERLAPPED structure must be explicitly set to 0 otherwise ReadFile/WriteFile will fail with ERROR_INVALID_PARAMETER.