### PR TITLE
Direct3D9: Clarify that Occlusion Queries return the number of samples, not pixels

### DIFF
--- a/desktop-src/direct3d9/d3dquerytype.md
+++ b/desktop-src/direct3d9/d3dquerytype.md
@@ -79,7 +79,7 @@ Query for any and all asynchronous events that have been issued from API calls.
 <span id="D3DQUERYTYPE_OCCLUSION"></span><span id="d3dquerytype_occlusion"></span>**D3DQUERYTYPE\_OCCLUSION**
 </dt> <dd>
 
-An occlusion query returns the number of pixels that pass z-testing. These pixels are for primitives drawn between the issue of [**D3DISSUE\_BEGIN**](d3dissue-begin.md) and [**D3DISSUE\_END**](d3dissue-end.md). This enables an application to check the occlusion result against 0. Zero is fully occluded, which means the pixels are not visible from the current camera position.
+An occlusion query returns the number of pixels (or samples when multisampling is enabled) that pass z-testing. These pixels/samples are for primitives drawn between the issue of [**D3DISSUE\_BEGIN**](d3dissue-begin.md) and [**D3DISSUE\_END**](d3dissue-end.md). This enables an application to check the occlusion result against 0. Zero is fully occluded, which means the pixels/samples are not visible from the current camera position. To get the number of pixels when a multisampled render target is used, the result should be divided by the sample count of the target.
 
 </dd> <dt>
 


### PR DESCRIPTION
As per a discussion on DirectX Discord, it's been determined with high probability that the docs for D3D9 occlusion queries mistakenly claim the query returns pixels drawn, not samples. This was deemed not to be true for the following reasons:
1. Other APIs (like D3D11 and OpenGL) refer to samples when talking about occlusion queries.
2. Tests have revealed that when multisampled rendertargets are used, the returned value is **exactly** X times higher than expected where X is the sample count of the target.

I was able to prove this via a bug in a commercial application from 2003, Colin McRae Rally 3: [THIS SUN COLORS BUG](https://www.youtube.com/watch?v=3ci8sFPCLpU) is caused exactly by the game assuming that occlusion queries return pixels, not samples, and therefore a calculated exposure value that is expected to be in `0.0f - 1.0f` range goes out of that range to e.g. `0.0f - 8.0f` when 8x MSAA is in use. Modifying the application to divide the query result by the sample count fixes the issue, which in my opinion serves as a good empirical proof:
![image](https://user-images.githubusercontent.com/7947461/197498553-0eec0e65-2c22-4ed1-a2ba-7f85acd854bd.png)
