### PR TITLE
Update using-binding-handles-and-making-rpc-calls.md

### DIFF
--- a/desktop-src/Rpc/using-binding-handles-and-making-rpc-calls.md
+++ b/desktop-src/Rpc/using-binding-handles-and-making-rpc-calls.md
@@ -54,7 +54,7 @@ The problem with this handler is that it catches all errors, including errors in
 
 This exception handler has the advantage of letting a certain range of errors through. These errors will never be returned by the server, because they indicate a client side problem.
 
-Additionally, the use of the **\[**[strict\_context\_handle](/windows/desktop/Midl/strict-context-handle)**\]** and **\[**[type\_strict\_context\_handle](/windows/desktop/Midl/type-strict-context-handle)**\]**attributes are recommended to ensure the RPC run time creates a context handle on one interface that can be passed as an argument only to methods of that interface. Doing so will prevent server failures that occur when context handles are opened and passed between different interfaces that exist within the same process.
+Additionally, the use of the **\[**[strict\_context\_handle](/windows/desktop/Midl/strict-context-handle)**\]** and **\[**[type\_strict\_context\_handle](/windows/desktop/Midl/type-strict-context-handle)**\]** attributes are recommended to ensure the RPC run time creates a context handle on one interface that can be passed as an argument only to methods of that interface. Doing so will prevent server failures that occur when context handles are opened and passed between different interfaces that exist within the same process.
 
 ## Related topics
 


### PR DESCRIPTION
the right bracket of `type_strict_context_handle` is not bold because a Space missed between it and the subsequent word

