### PR TITLE
Change bits to bytes where 2 bytes were clearly meant

### DIFF
--- a/desktop-src/medfound/10-bit-and-16-bit-yuv-video-formats.md
+++ b/desktop-src/medfound/10-bit-and-16-bit-yuv-video-formats.md
@@ -149,7 +149,7 @@ This format is a packed 16-bit representation that includes 16 bits of alpha. Ea
 
 Bits 0-15 contain the U sample, bits 16-31 contain the Y sample, bits 32-47 contain the V sample, and bits 48-63 contain the alpha value.
 
-To indicate that a pixel is fully opaque, an application must set the two alpha bits equal to 0xFFFF. This format is intended primarily as an intermediate format during image processing to avoid the accumulation of errors.
+To indicate that a pixel is fully opaque, an application must set the two alpha bytes equal to 0xFFFF. This format is intended primarily as an intermediate format during image processing to avoid the accumulation of errors.
 
 ## Preferred YUV Formats
 


### PR DESCRIPTION
The Y416 description wrote that the 2 alpha bits should be set to 0xFFFF. That is clearly just a copy/paste issue, and should simply be 2 alpha bytes.