### PR TITLE
Add app manifest compatibility code snippet for making it easy for most of developers (on windows 10 and 11)

### DIFF
--- a/desktop-src/winmsg/using-windows.md
+++ b/desktop-src/winmsg/using-windows.md
@@ -221,6 +221,18 @@ RedrawWindow(hwnd,
 
 In order to use layered child windows, the application has to declare itself Windows 8-aware in the manifest.
 
+For windows 10/11, one can include this compatibility snippet in its `app.manifest` to make it Windows 10-aware :
+```
+...
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 GUID -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+</compatibility>
+...
+```
+More about modifying app manifest can be read here :  [Application manifests](https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests)
  
 
  


### PR DESCRIPTION
Many users are left confused when they cannot create a WS_EX_LAYERED child window. This page has the reason, but it is not very apparent. It is easy to miss. I have added code snippets which highlights this issue so that most of the users which are developing on windows 10 and 11, will not miss this crucial information. 