### PR TITLE
Correct the redistribution policy for DbgHelp

### DIFF
--- a/desktop-src/Debug/dbghelp-versions.md
+++ b/desktop-src/Debug/dbghelp-versions.md
@@ -10,7 +10,7 @@ ms.date: 05/31/2018
 
 The DbgHelp library is implemented by DbgHelp.dll. Although this DLL is included in all supported versions of Windows, it is rarely the most current version of DbgHelp available. Furthermore, the version of DbgHelp that ships in Windows has reduced functionality from the other releases-- specifically, it lacks support for Symbol Server and Source Server.
 
-The most current versions of DbgHelp.dll, SymSrv.dll, and SrcSrv.dll are available as a part of the [Debugging Tools For Windows](https://developer.microsoft.com/windows/downloads/windows-10-sdk) package. The redistribution policies for these included DLLs were specifically designed to make it as easy as possible for people to include these files in their own packages and releases.
+The most current versions of DbgHelp.dll, SymSrv.dll, and SrcSrv.dll are available as a part of the [Debugging Tools For Windows](https://developer.microsoft.com/windows/downloads/windows-10-sdk) package. The redistribution policies make it possible for people to include the Debugging Tools For Windows installer in their own packages and releases.
 
 > [!Caution]  
 > Users should never attempt to install the [Debugging Tools For Windows](https://developer.microsoft.com/windows/downloads/windows-10-sdk) versions of DbgHelp.dll into the Windows system directories because they are untested in this scenario and likely to destabilize the system. There are separate X64 and X86 versions of the debugging package and both are necessary for people interested in supporting both platforms.


### PR DESCRIPTION
The dll was last redistributable in the 7.1 WDK. Ever since 8 only the installer is redistributable. The current text probably wasn't updated and makes people who don't explicitly search up the license believe the dlls are still redistributable.

See the current license: http://go.microsoft.com/fwlink/?LinkId=294840


>Debugging Tools for Windows
>
>The following files may only be distributed unmodified, as a package, as part of your program:
>
>Program Files\Windows Kits\10\Debuggers\Redist\X86 Debuggers and Tools-x86_en-us.msi
>Program Files\Windows Kits\10\Debuggers\Redist\X64 Debuggers and Tools-x64_en-us.msi
