### PR TITLE
Update shared-heaps.md

### DIFF
--- a/desktop-src/direct3d12/shared-heaps.md
+++ b/desktop-src/direct3d12/shared-heaps.md
@@ -58,6 +58,7 @@ The following limitations also apply:
 -   D3D12\_HEAP\_FLAG\_SHARED must also be set.
 -   Either D3D12\_HEAP\_TYPE\_DEFAULT must be set or D3D12\_HEAP\_TYPE\_CUSTOM with D3D12\_MEMORY\_POOL\_L0 and D3D12\_CPU\_PAGE\_PROPERTY\_NOT\_AVAILABLE must be set.
 -   Only resources with D3D12\_RESOURCE\_FLAG\_ALLOW\_CROSS\_ADAPTER may be placed on cross-adapter heaps.
+-   A protected session cannot be passed into the creation of the heap when D3D12\_HEAP\_FLAG\_SHARED\_CROSS\_ADAPTER is specified
 
 For more information on using multiple adapters, refer to the [Multi-adapter systems](multi-engine.md) section.
 

--- a/desktop-src/direct3d12/shared-heaps.md
+++ b/desktop-src/direct3d12/shared-heaps.md
@@ -1,19 +1,14 @@
 ---
-title: Shared Heaps
+title: Shared heaps
 description: Sharing is useful for multi-process and multi-adapter architectures.
 ms.assetid: 67C6B1D4-BF76-45A9-BADC-7C9520C900EB
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# Shared Heaps
+# Shared heaps
 
 Sharing is useful for multi-process and multi-adapter architectures.
-
--   [Sharing overview](#sharing-overview)
--   [Sharing heaps across processes](#sharing-heaps-across-processes)
--   [Sharing heaps across adapters](#sharing-heaps-across-adapters)
--   [Related topics](#related-topics)
 
 ## Sharing overview
 
@@ -37,7 +32,7 @@ Precluding a non-deterministic choice of undefined texture layout can significan
 
 Shared heaps come with other minor costs as well:
 
--   Shared heap data cannot be recycled as flexibly as in-process heaps due to information disclosure concerns, so physical memory is zero'ed more often.
+-   Shared heap data can't be recycled as flexibly as in-process heaps due to information disclosure concerns, so physical memory is zero'ed more often.
 -   There is a minor additional CPU overhead and increased system memory usage during creation and destruction of shared heaps.
 
 ## Sharing heaps across adapters
@@ -46,11 +41,11 @@ Shared heaps across adapters is specified with the D3D12\_HEAP\_FLAG\_SHARED\_CR
 
 Cross adapter shared heaps enable multiple adapters to share data without the CPU marshaling the data between them. While varying adapter capabilities determine how efficient adapters can pass data between them, merely enabling GPU copies increases the effective bandwidth achieved. Some texture layouts are allowed on cross adapter heaps to support an interchange of texture data, even if such texture layouts are not otherwise supported. Certain restrictions may apply to such textures, such as only supporting copying.
 
-Cross-adapter sharing works with heaps created by calling [**ID3D12Device::CreateHeap**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createheap). Applications can then create resources via [**CreatePlacedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource). It is also allowed by resources/heaps created by [**CreateCommittedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createcommittedresource) but only for row-major D3D12\_RESOURCE\_DIMENSION\_TEXTURE2D resources (refer to [**D3D12\_RESOURCE\_DIMENSION**](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_dimension)). Cross-adapter sharing does not work with [**CreateReservedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createreservedresource).
+Cross-adapter sharing works with heaps created by calling [**ID3D12Device::CreateHeap**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createheap). Your application can then create resources via [**CreatePlacedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createplacedresource). It is also allowed by resources/heaps created by [**CreateCommittedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createcommittedresource) but only for row-major D3D12\_RESOURCE\_DIMENSION\_TEXTURE2D resources (refer to [**D3D12\_RESOURCE\_DIMENSION**](/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_dimension)). Cross-adapter sharing does not work with [**CreateReservedResource**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-createreservedresource).
 
-For cross-adapter sharing, all of the usual cross-queue resource sharing rules still apply. Applications must issue the appropriate barriers to ensure proper synchronization and coherence between the two adapters. Applications should use cross-adapter fences to coordinate the scheduling of command lists submitted to multiple adapters. There is no mechanism to share cross-adapter resources across D3D API versions. Cross-adapter shared resources are only supported in system memory. Cross-adapter shared heaps/resources are supported in D3D12\_HEAP\_TYPE\_DEFAULT heaps and D3D12\_HEAP\_TYPE\_CUSTOM heaps (with the L0 memory pool, and write-combine CPU page properties). Drivers must be sure that GPU read/write operations to cross-adapter shared heaps are coherent with other GPUs on the system. For example, the driver may need to exclude the heap data from residing in GPU caches that typically don’t need to be flushed when the CPU cannot directly access the heap data.
+For cross-adapter sharing, all of the usual cross-queue resource sharing rules still apply. Your application must issue the appropriate barriers to ensure proper synchronization and coherence between the two adapters. Your application should use cross-adapter fences to coordinate the scheduling of command lists submitted to multiple adapters. There is no mechanism to share cross-adapter resources across D3D API versions. Cross-adapter shared resources are only supported in system memory. Cross-adapter shared heaps/resources are supported in D3D12\_HEAP\_TYPE\_DEFAULT heaps and D3D12\_HEAP\_TYPE\_CUSTOM heaps (with the L0 memory pool, and write-combine CPU page properties). Drivers must be sure that GPU read/write operations to cross-adapter shared heaps are coherent with other GPUs on the system. For example, the driver may need to exclude the heap data from residing in GPU caches that typically don’t need to be flushed when the CPU can't directly access the heap data.
 
-Applications should confine the usage of cross adapter heaps to only those scenarios which require the functionality they provide. Cross-adapter heaps are located in D3D12\_MEMORY\_POOL\_L0, which is not always what [**GetCustomHeapProperties**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-getcustomheapproperties) suggests. That memory pool is not efficient for discrete/ NUMA adapter architectures. And, the most efficient texture layouts are not always available.
+Your application should confine the usage of cross adapter heaps to only those scenarios which require the functionality they provide. Cross-adapter heaps are located in D3D12\_MEMORY\_POOL\_L0, which is not always what [**GetCustomHeapProperties**](/windows/win32/api/d3d12/nf-d3d12-id3d12device-getcustomheapproperties) suggests. That memory pool is not efficient for discrete/ NUMA adapter architectures. And, the most efficient texture layouts are not always available.
 
 The following limitations also apply:
 
@@ -58,21 +53,10 @@ The following limitations also apply:
 -   D3D12\_HEAP\_FLAG\_SHARED must also be set.
 -   Either D3D12\_HEAP\_TYPE\_DEFAULT must be set or D3D12\_HEAP\_TYPE\_CUSTOM with D3D12\_MEMORY\_POOL\_L0 and D3D12\_CPU\_PAGE\_PROPERTY\_NOT\_AVAILABLE must be set.
 -   Only resources with D3D12\_RESOURCE\_FLAG\_ALLOW\_CROSS\_ADAPTER may be placed on cross-adapter heaps.
--   A protected session cannot be passed into the creation of the heap when D3D12\_HEAP\_FLAG\_SHARED\_CROSS\_ADAPTER is specified
+-   A protected session can't be passed into the creation of the heap when D3D12\_HEAP\_FLAG\_SHARED\_CROSS\_ADAPTER is specified
 
 For more information on using multiple adapters, refer to the [Multi-adapter systems](multi-engine.md) section.
 
 ## Related topics
 
-<dl> <dt>
-
-[Suballocation Within Heaps](suballocation-within-heaps.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
+* [Suballocation Within Heaps](suballocation-within-heaps.md)


### PR DESCRIPTION
Added note that protected sessions cannot be used for the creation of the heap when D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER is specified