### PR TITLE
Update faulty important markup

### DIFF
--- a/desktop-src/DirectShow/step-1--choose-a-base-class.md
+++ b/desktop-src/DirectShow/step-1--choose-a-base-class.md
@@ -16,7 +16,7 @@ Assuming that you decide to write a filter and not a DMO, the first step is choo
 -   [**CTransInPlaceFilter**](ctransinplacefilter.md) is designed for filters that modify data in the original buffer, also called trans-in-place filters. When a trans-in-place filter receives a sample, it changes the data inside that sample and delivers the same sample downstream. The filter's input pin and output pin always connect with matching media types.
 -   [**CVideoTransformFilter**](cvideotransformfilter.md) is designed primarily for video decoders. It derives from **CTransformFilter**, but includes functionality for dropping frames if the downstream renderer falls behind.
 -   [**CBaseFilter**](cbasefilter.md) is a generic filter class. The other classes in this list all derive from **CBaseFilter**. If none of them is suitable, you can fall back on this class. However, this class also requires the most work on your part.
--   \[!Important\]  
+-   ![Important]  
     > In-place video transforms can have a serious impact on rendering performance. In-place transforms require read-modify-write operations on the buffer. If the memory resides on a graphics card, read operations are significantly slower. Moreover, even a copy transform can cause unintended read operations if you do not implement it carefully. Therefore, you should always do performance testing if you write a video transform.
 
      

--- a/desktop-src/DirectShow/using-the-overlay-mixer-in-video-capture.md
+++ b/desktop-src/DirectShow/using-the-overlay-mixer-in-video-capture.md
@@ -16,7 +16,7 @@ There are certain kinds of video that the [Video Renderer](video-renderer-filter
 
 The Capture Graph Builder's **RenderStream** method inserts the Overlay Mixer whenever needed. If you are building the graph without using the Capture Graph Builder, however, you must check for each of these situations and insert the Overlay Mixer yourself.
 
--   \[!Important\]  
+-   ![Important]  
     > If the device has a VP pin, you must connect the Overlay Mixer even if you do not need preview functionality in your application. With a video port, the capture device always sends the video data to the hardware overlay, so the Overlay Mixer is always needed.
 
      

--- a/desktop-src/DirectShow/using-windows-media-with-directshow-editing-services.md
+++ b/desktop-src/DirectShow/using-windows-media-with-directshow-editing-services.md
@@ -21,7 +21,7 @@ To use DES with Windows Media files, the following DES objects require the softw
 
 -   The render engine, for previewing or file writing.
 -   The MediaDet object, to get video frames or media types from ASF files.
--   \[!Important\]  
+-   ![Important]  
     > Do not use the Smart Render Engine to read or write Windows Media files. Always use the Basic Render Engine (CLSID\_RenderEngine).
 
      

--- a/desktop-src/DirectShow/video-renderer-filter.md
+++ b/desktop-src/DirectShow/video-renderer-filter.md
@@ -17,7 +17,7 @@ The Video Renderer filter is a robust, all-purpose video renderer.
 
 The Video Renderer uses DirectDraw and overlay surfaces, if the video card supports them. The Filter Graph Manager exposes the [**IVideoWindow**](/windows/desktop/api/Control/nn-control-ivideowindow) interface, which enables applications to set and retrieve properties on the Video Renderer. With newer video cards, the Video Renderer supports full-screen rendering. Otherwise, the Filter Graph Manager automatically switches to the [Full Screen Renderer](full-screen-renderer-filter.md) filter for full-screen mode. See [**IVideoWindow::put\_FullScreenMode**](/windows/desktop/api/Control/nf-control-ivideowindow-put_fullscreenmode) for more information.
 
--   \[!Important\]  
+-   ![Important]  
     > Normally, this filter's video window processes messages on a worker thread created by the Filter Graph Manager. Howerver, if an application directly creates the filter using **CoCreateInstance**, the video window processes messages on the application thread. In that case, the application thread must have a message loop, to dispatch messages to the video window. Also, the thread must not exit until the final **Release** call to the Video Renderer, which occurs when the Filter Graph Manager shuts down. Otherwise, the application might deadlock.
 
      

--- a/desktop-src/inputmsg/dm-pointerhittest.md
+++ b/desktop-src/inputmsg/dm-pointerhittest.md
@@ -22,7 +22,7 @@ ms.date: 02/03/2020
 
 Sent to a window, when pointer input is first detected, in order to determine the most probable input target for [Direct Manipulation](/previous-versions/windows/desktop/directmanipulation/direct-manipulation-portal).
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-ncpointerdown.md
+++ b/desktop-src/inputmsg/wm-ncpointerdown.md
@@ -22,7 +22,7 @@ Posted when a pointer makes contact over the non-client area of a window. The me
 
 If a window has captured this pointer, this message is not posted. Instead, a [**WM_POINTERDOWN**](wm-pointerdown.md) is posted to the window that has captured this pointer.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-ncpointerup.md
+++ b/desktop-src/inputmsg/wm-ncpointerup.md
@@ -22,7 +22,7 @@ Posted when a pointer that made contact over the non-client area of a window bre
 
 If a window has captured this pointer, this message is not posted. Instead, a [**WM_POINTERUP**](wm-pointerup.md) is posted to the window that has captured this pointer.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-ncpointerupdate.md
+++ b/desktop-src/inputmsg/wm-ncpointerupdate.md
@@ -22,7 +22,7 @@ Posted to provide an update on a pointer that made contact over the non-client a
 
 If a window has captured this pointer, this message is not posted. Instead, a [**WM_POINTERUPDATE**](wm-pointerupdate.md) is posted to the window that has captured this pointer.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-parentnotify.md
+++ b/desktop-src/inputmsg/wm-parentnotify.md
@@ -22,7 +22,7 @@ Sent to a window when a significant action occurs on a descendant window. This m
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerdevicechange.md
+++ b/desktop-src/inputmsg/wm-pointerdevicechange.md
@@ -20,7 +20,7 @@ ms.date: 02/03/2020
 
 Sent to a window when there is a change in the settings of a monitor that has a digitizer attached to it. This message contains information regarding the scaling of the display mode.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerdeviceinrange.md
+++ b/desktop-src/inputmsg/wm-pointerdeviceinrange.md
@@ -20,7 +20,7 @@ ms.date: 02/03/2020
 
 Sent to a window when a pointer device is detected within range of an input digitizer. This message contains information regarding the device and its proximity.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerdeviceoutofrange.md
+++ b/desktop-src/inputmsg/wm-pointerdeviceoutofrange.md
@@ -20,7 +20,7 @@ ms.date: 02/03/2020
 
 Sent to a window when a pointer device has departed the range of an input digitizer. This message contains information regarding the device and its proximity.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerdown.md
+++ b/desktop-src/inputmsg/wm-pointerdown.md
@@ -22,7 +22,7 @@ Posted when a pointer makes contact over the client area of a window. This input
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  
@@ -93,7 +93,7 @@ If the application does not process this message, it should call [**DefWindowPro
 
 ## Remarks
 
-> \[!Important\]  
+> ![Important]  
 > When a window loses capture of a pointer and it receives the [**WM_POINTERCAPTURECHANGED**](wm-pointercapturechanged.md) notification, it typically will not receive any further notifications. For this reason, it is important that you not make any assumptions based on evenly paired **WM_POINTERDOWN**/[**WM_POINTERUP**](wm-pointerup.md) or [**WM_POINTERENTER**](wm-pointerenter.md)/[**WM_POINTERLEAVE**](wm-pointerleave.md) notifications.
 
  

--- a/desktop-src/inputmsg/wm-pointerenter.md
+++ b/desktop-src/inputmsg/wm-pointerenter.md
@@ -22,7 +22,7 @@ Sent to a window when a new pointer enters detection range over the window (hove
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  
@@ -90,7 +90,7 @@ This notification is only sent to the window that is receiving input for the poi
 
  
 
-> \[!Important\]  
+> ![Important]  
 > When a window loses capture of a pointer and it receives the [**WM_POINTERCAPTURECHANGED**](wm-pointercapturechanged.md) notification, it typically will not receive any further notifications. For this reason, it is important that you not make any assumptions based on evenly paired [**WM_POINTERDOWN**](wm-pointerdown.md)/[**WM_POINTERUP**](wm-pointerup.md) or **WM_POINTERENTER**/[**WM_POINTERLEAVE**](wm-pointerleave.md) notifications.
 
  

--- a/desktop-src/inputmsg/wm-pointerhwheel.md
+++ b/desktop-src/inputmsg/wm-pointerhwheel.md
@@ -22,7 +22,7 @@ Posted to the window with foreground keyboard focus when a horizontal scroll whe
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerleave.md
+++ b/desktop-src/inputmsg/wm-pointerleave.md
@@ -22,7 +22,7 @@ Sent to a window when a pointer leaves detection range over the window (hover) o
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  
@@ -89,7 +89,7 @@ This notification is only sent to the window that is receiving input for the poi
 
  
 
-> \[!Important\]  
+> ![Important]  
 > When a window loses capture of a pointer and it receives the [**WM_POINTERCAPTURECHANGED**](wm-pointercapturechanged.md) notification, it typically will not receive any further notifications. For this reason, it is important that you not make any assumptions based on evenly paired [**WM_POINTERDOWN**](wm-pointerdown.md)/[**WM_POINTERUP**](wm-pointerup.md) or [**WM_POINTERENTER**](wm-pointerenter.md)/**WM_POINTERLEAVE** notifications.
 
  

--- a/desktop-src/inputmsg/wm-pointerup.md
+++ b/desktop-src/inputmsg/wm-pointerup.md
@@ -22,7 +22,7 @@ Posted when a pointer that made contact over the client area of a window breaks 
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  
@@ -93,7 +93,7 @@ If the application does not process this message, it should call [**DefWindowPro
 
 ## Remarks
 
-> \[!Important\]  
+> ![Important]  
 > When a window loses capture of a pointer and it receives the [**WM_POINTERCAPTURECHANGED**](wm-pointercapturechanged.md) notification, it typically will not receive any further notifications. For this reason, it is important that you not make any assumptions based on evenly paired [**WM_POINTERDOWN**](wm-pointerdown.md)/**WM_POINTERUP** or [**WM_POINTERENTER**](wm-pointerenter.md)/[**WM_POINTERLEAVE**](wm-pointerleave.md) notifications.
 
  

--- a/desktop-src/inputmsg/wm-pointerupdate.md
+++ b/desktop-src/inputmsg/wm-pointerupdate.md
@@ -20,7 +20,7 @@ ms.date: 02/03/2020
 
 Posted to provide an update on a pointer that made contact over the client area of a window or on a hovering uncaptured pointer over the client area of a window. While the pointer is hovering, the message targets whichever window the pointer happens to be over. While the pointer is in contact with the surface, the pointer is implicitly captured to the window over which the pointer made contact and that window continues to receive input for the pointer until it breaks contact.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-pointerwheel.md
+++ b/desktop-src/inputmsg/wm-pointerwheel.md
@@ -22,7 +22,7 @@ Posted to the window with foreground keyboard focus when a scroll wheel is rotat
 
 A window receives this message through its [**WindowProc**](/previous-versions/windows/desktop/legacy/ms633573(v=vs.85)) function.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/inputmsg/wm-touchhittesting.md
+++ b/desktop-src/inputmsg/wm-touchhittesting.md
@@ -20,7 +20,7 @@ ms.date: 02/03/2020
 
 Sent to a window on a touch down in order to determine the most probable touch target.
 
-> \[!Important\]  
+> ![Important]  
 > Desktop apps should be DPI aware. If your app is not DPI aware, screen coordinates contained in pointer messages and related structures might appear inaccurate due to DPI virtualization. DPI virtualization provides automatic scaling support to applications that are not DPI aware and is active by default (users can turn it off). For more information, see [Writing High-DPI Win32 Applications](/previous-versions//dd464660(v=vs.85)).
 
  

--- a/desktop-src/windowsribbon/windowsribbon-controls-applicationmenu.md
+++ b/desktop-src/windowsribbon/windowsribbon-controls-applicationmenu.md
@@ -57,7 +57,7 @@ The following is a list of constraints for a [**MenuGroup**](windowsribbon-eleme
 
 -   All [**MenuGroup**](windowsribbon-element-menugroup.md) items must be declared with a *Class* attribute value of `MajorItems`.
 -   An Application Menu [**MenuGroup**](windowsribbon-element-menugroup.md) supports only the [Button](windowsribbon-controls-button.md), [Toggle Button](windowsribbon-controls-togglebutton.md), [Drop-Down Button](windowsribbon-controls-dropdownbutton.md), [Split Button](windowsribbon-controls-splitbutton.md), [Drop-Down Gallery](windowsribbon-controls-dropdowngallery.md), and [Split Button Gallery](windowsribbon-controls-splitbuttongallery.md) controls.
-    > \[!Important\]  
+    > ![Important]  
     > Command galleries are the only type of gallery that are supported in the Application Menu. See [Working with Galleries](./ribbon-controls-galleries.md), for more information on gallery controls.
 
      

--- a/desktop-src/windowsribbon/windowsribbon-stepbystep.md
+++ b/desktop-src/windowsribbon/windowsribbon-stepbystep.md
@@ -149,7 +149,7 @@ The following steps describe in detail how to implement a simple Ribbon applicat
 
     The application calls [**IUIFramework::Initialize**](/windows/desktop/api/uiribbon/nf-uiribbon-iuiframework-initialize), passing in two parameters: the handle to the top-level window that will contain the Ribbon and a pointer to the [**IUIApplication**](/windows/desktop/api/uiribbon/nn-uiribbon-iuiapplication) implementation that allows the framework to make callbacks to the application.
 
-    > \[!Important\]  
+    > ![Important]  
     > The Ribbon framework is initialized as a single-threaded apartment (STA).
 
      


### PR DESCRIPTION
Some documents had escaped Important markup rendering that is showing up as followed on the documentation sites:

![Screenshot of faulty important section markup rendering](https://user-images.githubusercontent.com/16122379/211648071-08498c93-8d36-409d-ae19-4d3f94646fc1.png)

This PR fixes that.

@Karl-Bridge-Microsoft FYI since you checked in some of those changes.
