### PR TITLE
Update incorrect IPv6 IPSec statement.

### DIFF
--- a/desktop-src/FWP/ipsec-configuration.md
+++ b/desktop-src/FWP/ipsec-configuration.md
@@ -12,7 +12,7 @@ Windows Filtering Platform (WFP) is the underlying platform for Windows Firewall
 
 ## What is IPsec
 
-Internet Protocol Security (IPsec) is a set of security protocols used to transfer IP packets confidentially across the Internet. IPsec is mandatory for all IPv6 implementations and optional for IPv4.
+Internet Protocol Security (IPsec) is a set of security protocols used to transfer IP packets confidentially across the Internet. IPsec is ~mandatory~ (optional, see [RFC6434](https://www.rfc-editor.org/rfc/rfc6434.txt)) for all IPv6 implementations and optional for IPv4.
 
 Secured IP traffic has two optional IPsec headers, which identify the types of cryptographic protection applied to the IP packet and include information for decoding the protected packet.
 

--- a/desktop-src/FWP/ipsec-configuration.md
+++ b/desktop-src/FWP/ipsec-configuration.md
@@ -12,7 +12,7 @@ Windows Filtering Platform (WFP) is the underlying platform for Windows Firewall
 
 ## What is IPsec
 
-Internet Protocol Security (IPsec) is a set of security protocols used to transfer IP packets confidentially across the Internet. IPsec is ~mandatory~ (optional, see [RFC6434](https://www.rfc-editor.org/rfc/rfc6434.txt)) for all IPv6 implementations and optional for IPv4.
+Internet Protocol Security (IPsec) is a set of security protocols used to transfer IP packets confidentially across the Internet. IPsec was formerly mandatory for all IPv6 implementations (but see [IPv6 Node Requirements](https://www.rfc-editor.org/rfc/rfc6434.txt); and optional for IPv4.
 
 Secured IP traffic has two optional IPsec headers, which identify the types of cryptographic protection applied to the IP packet and include information for decoding the protected packet.
 


### PR DESCRIPTION
IPSec is not mandatory for all IPv6 implementations is not an accurate statement.

RFC 6434 – IPsec from MUST to SHOULD




Jankiewicz, et al.            Informational                    [Page 17]

RFC 6434                 IPv6 Node Requirements            December 2011


   IPsec provides channel security at the Internet layer, making it
   possible to provide secure communication for all (or a subset of)
   communication flows at the IP layer between pairs of internet nodes.
   IPsec provides sufficient flexibility and granularity that individual
   TCP connections can (selectively) be pro

In December 2011, the IETF updated the IPv6 Node Requirements RFC with RFC 6434. In section 11 (Security), they make this unmistakable statement:

    Previously, IPv6 mandated implementation of IPsec and recommended the key management approach of IKE. This document updates that recommendation by making support of the IPsec Architecture [RFC4301] a SHOULD for all IPv6 nodes.
    https://datatracker.ietf.org/doc/html/rfc6434

Source: https://www.questioncomputer.com/ipv6-ipsec-not-mandatory-to-use-or-exist/