### PR TITLE
Update d3d device name

### DIFF
--- a/desktop-src/direct3d9/creating-a-device.md
+++ b/desktop-src/direct3d9/creating-a-device.md
@@ -14,7 +14,7 @@ First, initialize values for the [**D3DPRESENT\_PARAMETERS**](d3dpresent-paramet
 
 
 ```
-LPDIRECT3DDEVICE9 pDevice = NULL;
+LPDIRECT3DDEVICE9 d3dDevice = NULL;
 
 D3DPRESENT_PARAMETERS d3dpp; 
 


### PR DESCRIPTION
It seems that the device name wasn't matching with the one used on the referenced example

![image](https://user-images.githubusercontent.com/5873073/214961539-736aa93c-9d67-43a5-8382-e23f4d81f1ee.png)
