### PR TITLE
pseudo-vs--true-blocking-2.md: correct nonsensical reference to 16-bit Windows

### DIFF
--- a/desktop-src/WinSock/pseudo-vs--true-blocking-2.md
+++ b/desktop-src/WinSock/pseudo-vs--true-blocking-2.md
@@ -1,21 +1,17 @@
 ---
-description: Pseudoblocking pseudo blocking operations in Windows Sockets (Winsock).
+title: Pseudo-blocking and true blocking
+description: Pseudo-blocking operations in Windows Sockets (Winsock).
 ms.assetid: fa8f29f1-bb4f-4814-ab8a-52d3c83232bb
-title: Pseudo Blocking and True Blocking
 ms.topic: article
-ms.date: 05/31/2018
+ms.date: 02/08/2023
 ---
 
-# Pseudo Blocking and True Blocking
+# Pseudo-blocking and true blocking
 
-In 16-bit Windows environments, true blocking is not supported by the operating system; therefore, a blocking operation that cannot be completed immediately is handled as follows:
+In 16-bit Windows environments, true blocking isn't supported by the operating system (OS); therefore, a blocking operation that can't be completed immediately is handled as follows:
 
--   The service provider initiates the operation, and then enters a loop during which it dispatches any Windows messages (yielding the processor to another thread if necessary)
--   It then checks for the completion of the Windows Sockets function.
--   If the function has completed, or if [**WSPCancelBlockingCall**](/previous-versions/windows/desktop/legacy/ms742269(v=vs.85)) has been invoked, the loop is terminated and the blocking function completes with an appropriate result.
+* The service provider initiates the operation, and then enters a loop during which it dispatches any Windows messages (yielding the processor to another thread if necessary).
+* It then checks for the completion of the Windows Sockets function.
+* If the function has completed, or if [**WSPCancelBlockingCall**](/previous-versions/windows/desktop/legacy/ms742269(v=vs.85)) has been invoked, then the loop is terminated and the blocking function completes with an appropriate result.
 
-This is what is meant by the term pseudo blocking, and the loop referred to above is known as the default blocking hook.
-
- 
-
- 
+This is what is meant by the term pseudo-blocking, and the loop referred to above is known as the default blocking hook.

--- a/desktop-src/WinSock/pseudo-vs--true-blocking-2.md
+++ b/desktop-src/WinSock/pseudo-vs--true-blocking-2.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Pseudo Blocking and True Blocking
 
-In 16 Windows environments, true blocking is not supported by the operating system; therefore, a blocking operation that cannot be completed immediately is handled as follows:
+In 16-bit Windows environments, true blocking is not supported by the operating system; therefore, a blocking operation that cannot be completed immediately is handled as follows:
 
 -   The service provider initiates the operation, and then enters a loop during which it dispatches any Windows messages (yielding the processor to another thread if necessary)
 -   It then checks for the completion of the Windows Sockets function.


### PR DESCRIPTION
This doesn't make sense:

> In 16 Windows environments, true blocking is not supported by the operating system

What are "16 Windows environments"? But I assume someone just forgot to say "bit", and therefore it should read:

> In 16-bit Windows environments, true blocking is not supported by the operating system

Which I believe is true, the Win16 API doesn't support "blocking" in the sense that Win32 does.