### PR TITLE
Add link to WaitForDebugEventEx

### DIFF
--- a/desktop-src/Debug/debugging-functions.md
+++ b/desktop-src/Debug/debugging-functions.md
@@ -30,6 +30,7 @@ The following functions are used with debugging.
 | [**ReadProcessMemory**](/windows/win32/api/memoryapi/nf-memoryapi-readprocessmemory)                     | Reads data from an area of memory in a specified process.                           |
 | [**SetThreadContext**](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext)                       | Sets the context for the specified thread.                                          |
 | [**WaitForDebugEvent**](/windows/win32/api/debugapi/nf-debugapi-waitfordebugevent)                     | Waits for a debugging event to occur in a process being debugged.                   |
+| [**WaitForDebugEventEx**](/windows/win32/api/debugapi/nf-debugapi-waitfordebugeventex)                     | Waits for a debugging event to occur in a process being debugged, and enables support for Unicode strings from OutputDebugStringW.                   |
 | **Wow64GetThreadContext**          | Retrieves the context of the specified WOW64 thread.                                |
 | [**Wow64GetThreadSelectorEntry**](/windows/desktop/api/WinBase/nf-winbase-wow64getthreadselectorentry) | Retrieves a descriptor table entry for the specified selector and WOW64 thread.     |
 | [**Wow64SetThreadContext**](/windows/desktop/api/WinBase/nf-winbase-wow64setthreadcontext)             | Sets the context of the specified WOW64 thread.                                     |


### PR DESCRIPTION
This adds a link to WaitForDebugEventEx in the Debugging Functions overview page. This function opts into Unicode strings from OutputDebugStringW, and is generally the better function to use for any new program.