### PR TITLE
child-sessions.md: fix list formatting

### DIFF
--- a/desktop-src/TermServ/child-sessions.md
+++ b/desktop-src/TermServ/child-sessions.md
@@ -13,10 +13,9 @@ Beginning with Windows Server 2012 and Windows 8, Remote Desktop supports the 
 
 Child sessions are not supported on the following operating systems:
 
-<dl> Windows RT  
-Windows Server 2012 Server Core installation option  
-Microsoft Hyper-V Server 2012  
-</dl>
+-   Windows RT  
+-   Windows Server 2012 Server Core installation option  
+-   Microsoft Hyper-V Server 2012  
 
 A system can only have one active and connected child session at any given time.
 


### PR DESCRIPTION
If you look at the live docs site: https://learn.microsoft.com/en-us/windows/win32/termserv/child-sessions

You see the list of operating systems which *do not* support child sessions is all jumbled into one line:
> Child sessions are not supported on the following operating systems:
>
> Windows RT Windows Server 2012 Server Core installation option Microsoft Hyper-V Server 2012

That makes it rather hard to read, and doesn't look good either. I think it should be a bullet list instead:
> Child sessions are not supported on the following operating systems:
>
> -   Windows RT
> -   Windows Server 2012 Server Core installation option
> -   Microsoft Hyper-V Server 2012