### PR TITLE
Correct the Location param for gather HLSL builtins

### DIFF
--- a/desktop-src/direct3dhlsl/t2array-gatherblue-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2array-gatherblue-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float3       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2darray-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2d-gather-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gather-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the four texel values that would be used in a bi-linear filtering operat
 
 ``` syntax
 TemplateType Gather(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [Gather methods](texture2d-gather.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2d-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float2       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2d-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2d-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2d-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float2       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2d-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherblue-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float        Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2d-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float2       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2d-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2d-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gathergreen-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2d-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2d-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float2       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2d-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2d-gatherred-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float2       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2d-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gather-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gather-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the four texel values that would be used in a bi-linear filtering operat
 
 ``` syntax
 TemplateType Gather(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [Gather methods](texture2darray-gather.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the four texel values that would be used in a bi-linear filtering operat
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2darray-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float3       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2darray-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatheralpha-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherAlpha methods](texture2darray-gatheralpha.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2darray-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherblue-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherBlue methods](texture2darray-gatherblue.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2darray-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float3       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2darray-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gathergreen-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherGreen methods](texture2darray-gathergreen.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int-uint-.md
@@ -24,10 +24,10 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  in  int          Offset,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int          Offset,
+  out uint         Status
 );
 ```
 
@@ -93,7 +93,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -102,6 +102,6 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2darray-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-.md
@@ -24,12 +24,12 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in SamplerState S,
-  in float        Location,
-  in int2         Offset1,
-  in int2         Offset2,
-  in int2         Offset3,
-  in int2         Offset4
+  in SamplerState S,
+  in float3       Location,
+  in int2         Offset1,
+  in int2         Offset2,
+  in int2         Offset3,
+  in int2         Offset4
 );
 ```
 
@@ -113,7 +113,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -122,9 +122,9 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2darray-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+
 
 
 

--- a/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md
+++ b/desktop-src/direct3dhlsl/t2darray-gatherred-s-float-int2-int2-int2-int2-uint-.md
@@ -24,13 +24,13 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  in  int2         Offset1,
-  in  int2         Offset2,
-  in  int2         Offset3,
-  in  int2         Offset4,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  in  int2         Offset1,
+  in  int2         Offset2,
+  in  int2         Offset3,
+  in  int2         Offset4,
+  out uint         Status
 );
 ```
 
@@ -123,7 +123,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -132,6 +132,6 @@ This function is supported for the following types of shaders:
 [GatherRed methods](texture2darray-gatherred.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcube-gather-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gather-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the four texel values that would be used in a bi-linear filtering operat
 
 ``` syntax
 TemplateType Gather(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCube**](texturecube.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcube-gatheralpha-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatheralpha-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCube**](texturecube.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcube-gatherblue-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatherblue-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCube**](texturecube.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcube-gathergreen-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gathergreen-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCube**](texturecube.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcube-gatherred-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcube-gatherred-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float3       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCube**](texturecube.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcubearray-gather-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gather-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the four texel values that would be used in a bi-linear filtering operat
 
 ``` syntax
 TemplateType Gather(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float4       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCubeArray**](texturecubearray.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcubearray-gatheralpha-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatheralpha-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the alpha components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherAlpha(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float4       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCubeArray**](texturecubearray.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcubearray-gatherblue-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatherblue-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the blue components of the four texel values that would be used in a bi-
 
 ``` syntax
 TemplateType GatherBlue(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float4       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCubeArray**](texturecubearray.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcubearray-gathergreen-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gathergreen-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the green components of the four texel values that would be used in a bi
 
 ``` syntax
 TemplateType GatherGreen(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float4       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCubeArray**](texturecubearray.md)
 </dt> </dl>
 
- 
 
- 
+
+

--- a/desktop-src/direct3dhlsl/tcubearray-gatherred-s-float-uint-.md
+++ b/desktop-src/direct3dhlsl/tcubearray-gatherred-s-float-uint-.md
@@ -24,9 +24,9 @@ Returns the red components of the four texel values that would be used in a bi-l
 
 ``` syntax
 TemplateType GatherRed(
-  in  SamplerState S,
-  in  float        Location,
-  out uint         Status
+  in  SamplerState S,
+  in  float4       Location,
+  out uint         Status
 );
 ```
 
@@ -83,7 +83,7 @@ This function is supported for the following types of shaders:
 
 
 
- 
+
 
 ## See also
 
@@ -95,6 +95,6 @@ This function is supported for the following types of shaders:
 [**TextureCubeArray**](texturecubearray.md)
 </dt> </dl>
 
- 
 
- 
+
+


### PR DESCRIPTION
Many of the gather documentations simply listed the Location parameter as a float even though that was incorrect. This corrects them according to the texture object in question.

Additionally removes several unnecessary nbsp characters

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/871