### PR TITLE
Update styling in configuring-a-service-using-sc.md

### DIFF
--- a/desktop-src/Services/configuring-a-service-using-sc.md
+++ b/desktop-src/Services/configuring-a-service-using-sc.md
@@ -12,7 +12,17 @@ The Windows SDK contains a command-line utility, Sc.exe, that can be used to que
 
 ## Syntax
 
-**sc** \[*ServerName*\] *Command* \[*ServiceName*\]\[*option1*\]\[*option2*\]...
+```
+sc.exe [<servername>] [<command>] [<servicename>] [<option1>] [<option2>] ...
+```
+
+To see complete syntax for a command, type:
+
+```
+sc Command
+```
+
+## Parameter
 
 <dl> <dt>
 
@@ -50,12 +60,6 @@ An optional parameter.
 An optional parameter.
 
 </dd> </dl>
-
-## Remarks
-
-To see complete syntax for a command, use the following command:
-
-**sc** *Command*
 
 ## Related topics
 


### PR DESCRIPTION
The reference documentation page for sc stop does not exist for the latest version but only for server 2012, see https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc742107(v=ws.11),
latest only lists sc config, create, delete and query, see https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-config

I was looking for suitable sc documentation to link to and found https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/sc-delete. For me, this general page would benefit from an update to the same styling.