### PR TITLE
Improve configuring-a-service-using-sc.md

### DIFF
--- a/desktop-src/Services/configuring-a-service-using-sc.md
+++ b/desktop-src/Services/configuring-a-service-using-sc.md
@@ -16,50 +16,28 @@ The Windows SDK contains a command-line utility, Sc.exe, that can be used to que
 sc.exe [<servername>] [<command>] [<servicename>] [<option1>] [<option2>] ...
 ```
 
-To see complete syntax for a command, type:
+To see the available commands, type:
 
 ```
-sc Command
+sc
 ```
 
-## Parameter
+To see the syntax for a specific command, include a command, e.g. 
 
-<dl> <dt>
+```
+sc pause
+```
 
-<span id="ServerName"></span><span id="servername"></span><span id="SERVERNAME"></span>*ServerName*
-</dt> <dd>
+## Parameters
 
-Optional server name. Use the form \\\\*ServerName*.
 
-</dd> <dt>
-
-<span id="Command"></span><span id="command"></span><span id="COMMAND"></span>*Command*
-</dt> <dd>
-
-One of the following commands:
-
-<dl> <dd>boot</dd> <dd>config</dd> <dd>create</dd> <dd>delete</dd> <dd>description</dd> <dd>EnumDepend</dd> <dd>failure</dd> <dd>failureflag</dd> <dd>GetDisplayName</dd> <dd>GetKeyName</dd> <dd>Lock</dd> <dd>qc</dd> <dd>qdescription</dd> <dd>qfailure</dd> <dd>qfailureflag</dd> <dd>qprivs</dd> <dd>qsidtype</dd> <dd>query</dd> <dd>queryex</dd> <dd>privs</dd> <dd>QueryLock</dd> <dd>sdset</dd> <dd>sdshow</dd> <dd>showsid</dd> <dd>sidtype</dd> </dl> </dd> <dt>
-
-<span id="ServiceName"></span><span id="servicename"></span><span id="SERVICENAME"></span>*ServiceName*
-</dt> <dd>
-
-The name of the service, as specified when it was installed.
-
-</dd> <dt>
-
-<span id="option1"></span><span id="OPTION1"></span>*option1*
-</dt> <dd>
-
-An optional parameter.
-
-</dd> <dt>
-
-<span id="option2"></span><span id="OPTION2"></span>*option2*
-</dt> <dd>
-
-An optional parameter.
-
-</dd> </dl>
+|Parameter|Description|
+|---------|-----------|
+| `<servername>` | Specifies the name of the remote server on which the service is located. The name must use the Universal Naming Convention (UNC) format (for example, \\myserver). To run SC.exe locally, don't use this parameter. |
+| `<command>` | One of the following commands: <dl> <dd>boot</dd> <dd>config</dd> <dd>create</dd> <dd>delete</dd> <dd>description</dd> <dd>EnumDepend</dd> <dd>failure</dd> <dd>failureflag</dd> <dd>GetDisplayName</dd> <dd>GetKeyName</dd> <dd>Lock</dd> <dd>qc</dd> <dd>qdescription</dd> <dd>qfailure</dd> <dd>qfailureflag</dd> <dd>qprivs</dd> <dd>qsidtype</dd> <dd>query</dd> <dd>queryex</dd> <dd>privs</dd> <dd>QueryLock</dd> <dd>sdset</dd> <dd>sdshow</dd> <dd>showsid</dd> <dd>sidtype</dd> </dl> </dd> <dt>
+| `<servicename>` | The name of the service, as specified when it was installed. |
+| `<option1>` | An optional parameter. |
+| `<option2>` | An optional parameter. |
 
 ## Related topics
 
@@ -70,10 +48,3 @@ An optional parameter.
 
 [Service Installation, Removal, and Enumeration](service-installation-removal-and-enumeration.md)
 </dt> </dl>
-
- 
-
- 
-
-
-


### PR DESCRIPTION
Relates to https://github.com/MicrosoftDocs/win32/pull/1537
Relates to https://github.com/MicrosoftDocs/win32/pull/1536

Following the two PRs linked above, I have added the following:
- example commands that do not show invalid command errors on the command prompt.
- a table for the parameters (as in the sc reference documentation)

Notes:
- This pattern should be applied to the other file I have previously edited. 
- I cannot preview my changes. Make sure that the HTML in the table works.