### PR TITLE
Update system-power-states.md

### DIFF
--- a/desktop-src/Power/system-power-states.md
+++ b/desktop-src/Power/system-power-states.md
@@ -40,6 +40,9 @@ In the *S0* low-power idle mode of the working state, also referred to as [Moder
 > [!Note]  
 > Modern Standby is only available on some SoC systems. When it's supported, the system doesn't support S1-S3.
 
+> [!Caution]  
+> Do not enable S3 wake-on-LAN (WoL) on Modern Standaby capable systems. Waking a computer with a magic packet is natively supported by Modern Standby. Enabling legacy S3 WoL is not necessary and may cause DHCP and/or DNS packet storms on your network.
+
 ## Sleep state: S1-S3
 
 The system enters sleep based on a number of criteria, including user or application activity and preferences that the user sets on the **Power & sleep** page of the **Settings** app. By default, the system uses the lowest-powered sleep state supported by all enabled wake-up devices. For more information about how the system determines when to enter sleep, see [System sleep criteria](system-sleep-criteria.md).


### PR DESCRIPTION
Added content:

> [!Caution]  
> Do not enable S3 Wake-on-LAN (WoL) on Modern Standaby capable systems. Waking a computer with a magic packet should be natively supported by Modern Standby. Enabling legacy S3 WoL on a Modern Standby computer may cause DHCP and/or DNS packet storms on your network.


NOTE from jakehr: This is a known incompatibility between S0 MS/CS and S3 WoL. CSS has been seeing an influx of cases with this issue and we are pushing for documentation around this behavior.