### PR TITLE
Fix return statement placement in WindowProc

### DIFF
--- a/desktop-src/LearnWin32/your-first-windows-program.md
+++ b/desktop-src/LearnWin32/your-first-windows-program.md
@@ -93,9 +93,9 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             FillRect(hdc, &ps.rcPaint, (HBRUSH) (COLOR_WINDOW+1));
 
             EndPaint(hwnd, &ps);
+            
+            return 0;
         }
-        return 0;
-
     }
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }


### PR DESCRIPTION
This commit corrects the placement of the "return 0;" statement inside the WM_PAINT case of the WindowProc function. Previously, the return statement was positioned outside the WM_PAINT case's scope, causing it always to return 0 even if the message was not processed. By moving the return statement inside the WM_PAINT case's scope, the function now correctly returns 0 only if the WM_PAINT message is processed. Unhandled messages will be forwarded to the default window procedure as expected.