### PR TITLE
Fix misplaced closing brace in WndProc

### DIFF
--- a/desktop-src/inputdev/wm-lbuttondown.md
+++ b/desktop-src/inputdev/wm-lbuttondown.md
@@ -86,7 +86,6 @@ LRESULT CALLBACK WndProc(_In_ HWND hWnd, _In_ UINT msg, _In_ WPARAM wParam, _In_
                 pt.x = GET_X_LPARAM(lParam);
                 pt.y = GET_Y_LPARAM(lParam);
             }
-        }
         break;
 
     default:


### PR DESCRIPTION
This commit fixes a misplaced closing brace in the WndProc function's switch statement handling the WM_LBUTTONDOWN case. The closing brace has been moved to close the case block before the break statement properly.