### PR TITLE
Wrong library in pragma. Should be advapi32.lib

### DIFF
--- a/desktop-src/SecAuthZ/enabling-and-disabling-privileges-in-c--.md
+++ b/desktop-src/SecAuthZ/enabling-and-disabling-privileges-in-c--.md
@@ -32,7 +32,7 @@ The following example shows how to enable or disable a privilege in an [*access 
 ```C++
 #include <windows.h>
 #include <stdio.h>
-#pragma comment(lib, "cmcfg32.lib")
+#pragma comment(lib, "advapi32.lib")
 
 BOOL SetPrivilege(
     HANDLE hToken,          // access token handle


### PR DESCRIPTION
The sample does not compile as is (VS 2022, Windows 10 SDK). LookupPrivilegeValue and AdjustTokenPrivileges are exported by advapi32.lib