### PR TITLE
Update -search-sql-literalvaluecomparison.md

### DIFF
--- a/desktop-src/search/-search-sql-literalvaluecomparison.md
+++ b/desktop-src/search/-search-sql-literalvaluecomparison.md
@@ -56,6 +56,8 @@ In conjunction with the "=" operator, Windows Search Structured Query Language (
 ...WHERE <column> <comparison operator> [BEFORE | AFTER](<https://msdn.microsoft.com/library/Ff637626(v=MSDN.10).aspx>)
 ```
 
+Note: to compare dates, you must use [DATEADD](https://learn.microsoft.com/en-us/windows/win32/search/-search-sql-dateadd).
+
 
 
 ## Examples

--- a/desktop-src/search/-search-sql-literalvaluecomparison.md
+++ b/desktop-src/search/-search-sql-literalvaluecomparison.md
@@ -56,7 +56,7 @@ In conjunction with the "=" operator, Windows Search Structured Query Language (
 ...WHERE <column> <comparison operator> [BEFORE | AFTER](<https://msdn.microsoft.com/library/Ff637626(v=MSDN.10).aspx>)
 ```
 
-Note: to compare dates, you must use [DATEADD](https://learn.microsoft.com/en-us/windows/win32/search/-search-sql-dateadd).
+Note: to compare dates, you must use [DATEADD](/windows/win32/search/-search-sql-dateadd).
 
 
 


### PR DESCRIPTION
Updated the literal value comparison page to specify that you must use DATEADD to compare dates in the search index.