### PR TITLE
Update image-stride.md

### DIFF
--- a/desktop-src/medfound/image-stride.md
+++ b/desktop-src/medfound/image-stride.md
@@ -39,8 +39,8 @@ void ProcessVideoImage(
 {
     for (DWORD y = 0; y < dwHeightInPixels; y++)
     {
-        SOURCE_PIXEL_TYPE *pSrcPixel = (SOURCE_PIXEL_TYPE*)pDestScanLine0;
-        DEST_PIXEL_TYPE *pDestPixel = (DEST_PIXEL_TYPE*)pSrcScanLine0;
+        SOURCE_PIXEL_TYPE *pSrcPixel = (SOURCE_PIXEL_TYPE*)pSrcScanLine0;
+        DEST_PIXEL_TYPE *pDestPixel = (DEST_PIXEL_TYPE*)pDestScanLine0;
 
         for (DWORD x = 0; x < dwWidthInPixels; x +=2)
         {


### PR DESCRIPTION
When setting the source pixels to the start of scan line 0, they should be set from the source image's scan line, and vice versa for the destination pixels/image.