### PR TITLE
Fix: Update User Themes Path in themesfileformat-overview.md

### DIFF
--- a/desktop-src/Controls/themesfileformat-overview.md
+++ b/desktop-src/Controls/themesfileformat-overview.md
@@ -664,7 +664,7 @@ Transparency=1
 
 ## Installing Theme Files
 
-When Windows is initialized, the operating system enumerates the first-level subdirectories of %WinDir%\\Resources\\ to identify available themes. The system default theme files are located in %WinDir%\\Resources\\Themes. The user theme files are stored in %WinDir%\\Users\\&lt;username&gt;\\AppData\\Local\\Microsoft\\Windows\\Themes.
+When Windows is initialized, the operating system enumerates the first-level subdirectories of %WinDir%\\Resources\\ to identify available themes. The system default theme files are located in %WinDir%\\Resources\\Themes. The user theme files are stored in %LOCALAPPDATA%\\Microsoft\\Windows\\Themes (or %SystemDrive%\\Users\\&lt;username&gt;\\AppData\\Local\\Microsoft\\Windows\\Themes).
 
 A .theme file has file associations; therefore, theme installer applications can call [**ShellExecute**](/windows/desktop/api/shellapi/nf-shellapi-shellexecutea) on a .theme file to open the **Personalization** window in Control Panel to the specified theme.
 


### PR DESCRIPTION
In the documentation for the [Theme File Format - Win32 apps](https://learn.microsoft.com/en-us/windows/win32/controls/themesfileformat-overview#example-of-a-theme-file) the section 
[Installing Theme Files](https://learn.microsoft.com/en-us/windows/win32/controls/themesfileformat-overview#installing-theme-files) currently states:

> The system default theme files are located in %WinDir%\Resources\Themes. The user theme files are stored in %WinDir%\Users\<username>\AppData\Local\Microsoft\Windows\Themes.

which is not correct with regards to the *User* theme file location.

I changed it to reference `%LOCALAPPDATA%\\Microsoft\\Windows\\Themes` instead of `%WinDir%\Users\<username>\AppData\Local\Microsoft\Windows\Themes`.