### PR TITLE
Update link for C++ learn page.

### DIFF
--- a/desktop-src/LearnWin32/learn-to-program-for-windows.md
+++ b/desktop-src/LearnWin32/learn-to-program-for-windows.md
@@ -12,7 +12,8 @@ The aim of this Get Started series is to teach you how to write a desktop progra
 
 In the first module, you'll learn step-by-step how to create and show a window. Later modules will introduce the Component Object Model (COM), graphics and text, and user input.
 
-For this series, it is assumed that you have a good working knowledge of C++ programming. No previous experience with Windows programming is assumed. If you are new to C++, learning material is available in the [C++ language documentation](https://msdn.microsoft.com/vstudio//default.aspx).
+For this series, it is assumed that you have a good working knowledge of C++ programming. No previous experience with Windows programming is assumed. If you are new to C++, learning material is available in the [C++ language documentation](https://learn.microsoft.com/en-us/cpp/cpp/?view=msvc-170).
+
 
 ## In this section
 


### PR DESCRIPTION
Currently the link is https://msdn.microsoft.com/vstudio//default.aspx and will be redirected to https://visualstudio.microsoft.com/. Is this correct behaviour ?

If not, then the link should be
https://learn.microsoft.com/en-us/cpp/cpp/?view=msvc-170