### PR TITLE
Update pe-format.md

### DIFF
--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -2160,11 +2160,18 @@ The archive file signature identifies the file type. Any utility (for example, a
 
 `!<arch>\n`
 
+The Windows SDK winnt.h header defines following macros:
+
+```
+#define IMAGE_ARCHIVE_START_SIZE             8
+#define IMAGE_ARCHIVE_START                  "!<arch>\n"
+```
+
 ### Archive Member Headers
 
 Each member (linker, longnames, or object-file member) is preceded by a header. An archive member header has the following format, in which each field is an ASCII text string that is left justified and padded with spaces to the end of the field. There is no terminating null character in any of these fields.
 
-Each member header starts on the first even address after the end of the previous archive member.
+Each member header starts on the first even address after the end of the previous archive member, one byte '\n' (IMAGE_ARCHIVE_PAD) may inserted after an archive member to make the following member starts on even address.
 
 
 
@@ -2176,9 +2183,17 @@ Each member header starts on the first even address after the end of the previou
 | 34 <br/> | 6 <br/>  | Group ID <br/>      | An ASCII decimal representation of the group ID. This field does not contain a meaningful value on Windows platforms because Microsoft tools emit all blanks. <br/>                                   |
 | 40 <br/> | 8 <br/>  | Mode <br/>          | An ASCII octal representation of the member's file mode. This is the ST\_MODE value from the C run-time function \_wstat. <br/>                                                                       |
 | 48 <br/> | 10 <br/> | Size <br/>          | An ASCII decimal representation of the total size of the archive member, not including the size of the header. <br/>                                                                                  |
-| 58 <br/> | 2 <br/>  | End of Header <br/> | The two bytes in the C string "`\\n" (0x60 0x0A). <br/>                                                                                                                                               |
+| 58 <br/> | 2 <br/>  | End of Header <br/> | The two bytes (0x60 0x0A) in the C string "`\\n" (IMAGE_ARCHIVE_END). <br/>                                                             
 
+The Windows SDK winnt.h header defines following macros:
 
+```
+#define IMAGE_ARCHIVE_END                    "`\n"
+#define IMAGE_ARCHIVE_PAD                    "\n"
+#define IMAGE_ARCHIVE_LINKER_MEMBER          "/               "
+#define IMAGE_ARCHIVE_LONGNAMES_MEMBER       "//              "
+#define IMAGE_ARCHIVE_HYBRIDMAP_MEMBER       "/<HYBRIDMAP>/   "
+```
 
  
 
@@ -2199,7 +2214,7 @@ The Name field has one of the formats shown in the following table. As mentioned
 
 ### First Linker Member
 
-The name of the first linker member is "/". The first linker member is included for backward compatibility. It is not used by current linkers, but its format must be correct. This linker member provides a directory of symbol names, as does the second linker member. For each symbol, the information indicates where to find the archive member that contains the symbol.
+The name of the first linker member is "/" (IMAGE_ARCHIVE_LINKER_MEMBER). The first linker member is included for backward compatibility. It is not used by current linkers, but its format must be correct. This linker member provides a directory of symbol names, as does the second linker member. For each symbol, the information indicates where to find the archive member that contains the symbol.
 
 The first linker member has the following format. This information appears after the header:
 
@@ -2219,7 +2234,7 @@ The elements in the offsets array must be arranged in ascending order. This fact
 
 ### Second Linker Member
 
-The second linker member has the name "/" as does the first linker member. Although both linker members provide a directory of symbols and archive members that contain them, the second linker member is used in preference to the first by all current linkers. The second linker member includes symbol names in lexical order, which enables faster searching by name.
+The second linker member has the name "/" (IMAGE_ARCHIVE_LINKER_MEMBER) as does the first linker member. Although both linker members provide a directory of symbols and archive members that contain them, the second linker member is used in preference to the first by all current linkers. The second linker member includes symbol names in lexical order, which enables faster searching by name.
 
 The second member has the following format. This information appears after the header:
 
@@ -2239,7 +2254,7 @@ The second member has the following format. This information appears after the h
 
 ### Longnames Member
 
-The name of the longnames member is "//". The longnames member is a series of strings of archive member names. A name appears here only when there is insufficient room in the Name field (16 bytes). The longnames member is optional. It can be empty with only a header, or it can be completely absent without even a header.
+The name of the longnames member is "//" (IMAGE_ARCHIVE_LONGNAMES_MEMBER). The longnames member is a series of strings of archive member names. A name appears here only when there is insufficient room in the Name field (16 bytes). The longnames member is optional. It can be empty with only a header, or it can be completely absent without even a header.
 
 The strings are null-terminated. Each string begins immediately after the null byte in the previous string.
 

--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -2160,11 +2160,16 @@ The archive file signature identifies the file type. Any utility (for example, a
 
 `!<arch>\n`
 
-The Windows SDK winnt.h header defines following macros:
+The Windows SDK winnt.h header defines the following macros:
 
 ```
 #define IMAGE_ARCHIVE_START_SIZE             8
 #define IMAGE_ARCHIVE_START                  "!<arch>\n"
+#define IMAGE_ARCHIVE_END                    "`\n"
+#define IMAGE_ARCHIVE_PAD                    "\n"
+#define IMAGE_ARCHIVE_LINKER_MEMBER          "/               "
+#define IMAGE_ARCHIVE_LONGNAMES_MEMBER       "//              "
+#define IMAGE_ARCHIVE_HYBRIDMAP_MEMBER       "/<HYBRIDMAP>/   "
 ```
 
 ### Archive Member Headers
@@ -2184,18 +2189,6 @@ Each member header starts on the first even address after the end of the previou
 | 40 <br/> | 8 <br/>  | Mode <br/>          | An ASCII octal representation of the member's file mode. This is the ST\_MODE value from the C run-time function \_wstat. <br/>                                                                       |
 | 48 <br/> | 10 <br/> | Size <br/>          | An ASCII decimal representation of the total size of the archive member, not including the size of the header. <br/>                                                                                  |
 | 58 <br/> | 2 <br/>  | End of Header <br/> | The two bytes (0x60 0x0A) in the C string "`\\n" (IMAGE_ARCHIVE_END). <br/>                                                             
-
-The Windows SDK winnt.h header defines following macros:
-
-```
-#define IMAGE_ARCHIVE_END                    "`\n"
-#define IMAGE_ARCHIVE_PAD                    "\n"
-#define IMAGE_ARCHIVE_LINKER_MEMBER          "/               "
-#define IMAGE_ARCHIVE_LONGNAMES_MEMBER       "//              "
-#define IMAGE_ARCHIVE_HYBRIDMAP_MEMBER       "/<HYBRIDMAP>/   "
-```
-
- 
 
 The Name field has one of the formats shown in the following table. As mentioned earlier, each of these strings is left justified and padded with trailing spaces within a field of 16 bytes:
 

--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -2227,7 +2227,7 @@ The elements in the offsets array must be arranged in ascending order. This fact
 
 ### Second Linker Member
 
-The second linker member has the name "/" (IMAGE_ARCHIVE_LINKER_MEMBER) as does the first linker member. Although both linker members provide a directory of symbols and archive members that contain them, the second linker member is used in preference to the first by all current linkers. The second linker member includes symbol names in lexical order, which enables faster searching by name.
+Like the first linker member, the second linker member has the name "/" (IMAGE_ARCHIVE_LINKER_MEMBER). Although both linker members provide a directory of symbols and archive members that contain them, the second linker member is used in preference to the first by all current linkers. The second linker member includes symbol names in lexical order, which enables faster searching by name.
 
 The second member has the following format. This information appears after the header:
 

--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -2176,7 +2176,7 @@ The Windows SDK winnt.h header defines the following macros:
 
 Each member (linker, longnames, or object-file member) is preceded by a header. An archive member header has the following format, in which each field is an ASCII text string that is left justified and padded with spaces to the end of the field. There is no terminating null character in any of these fields.
 
-Each member header starts on the first even address after the end of the previous archive member, one byte '\n' (IMAGE_ARCHIVE_PAD) may inserted after an archive member to make the following member starts on even address.
+Each member header starts on the first even address after the end of the previous archive member, one byte '\n' (IMAGE_ARCHIVE_PAD) may be inserted after an archive member to make the following member start on an even address.
 
 
 


### PR DESCRIPTION
Mention following constants defined in Windows SDK (winnt.h):
+ IMAGE_ARCHIVE_START_SIZE
+ IMAGE_ARCHIVE_START
+ IMAGE_ARCHIVE_END
+ IMAGE_ARCHIVE_PAD
+ IMAGE_ARCHIVE_LINKER_MEMBER
+ IMAGE_ARCHIVE_LONGNAMES_MEMBER
+ IMAGE_ARCHIVE_HYBRIDMAP_MEMBER

and interpret the usage of `IMAGE_ARCHIVE_PAD`.