### PR TITLE
fix: code syntax error in desktop-src/inputdev/using-mouse-input.md

### DIFF
--- a/desktop-src/inputdev/using-mouse-input.md
+++ b/desktop-src/inputdev/using-mouse-input.md
@@ -159,6 +159,8 @@ LRESULT APIENTRY MainWndProc(HWND hwndMain, UINT uMsg, WPARAM wParam, LPARAM lPa
             break; 
  
         // Process other messages. 
+    }
+}
         
 ```
 


### PR DESCRIPTION
related code:

[https://github.com/malvinval/win32/blob/72a816df6bcf98821fd0dd854da6d4dba29df761/desktop-src/inputdev/using-mouse-input.md?plain=1#L162](https://github.com/malvinval/win32/blob/72a816df6bcf98821fd0dd854da6d4dba29df761/desktop-src/inputdev/using-mouse-input.md?plain=1#L162)

[https://github.com/malvinval/win32/blob/72a816df6bcf98821fd0dd854da6d4dba29df761/desktop-src/inputdev/using-mouse-input.md?plain=1#L163](https://github.com/malvinval/win32/blob/72a816df6bcf98821fd0dd854da6d4dba29df761/desktop-src/inputdev/using-mouse-input.md?plain=1#L163)

fixes:

- add missing switch case closing bracket at line 162
- add missing MainWndProc function closing bracket at line 163 