### PR TITLE
Fix CoInitializeSecurity spelling

### DIFF
--- a/desktop-src/com/the-com-elevation-moniker.md
+++ b/desktop-src/com/the-com-elevation-moniker.md
@@ -246,7 +246,7 @@ else
     goto Cleanup;
 }
 
-// Call CoinitilizeSecurity.
+// Call CoInitializeSecurity .
 ```
 
 


### PR DESCRIPTION
The "Call CoinitilizeSecurity" comment is missing an "a" when spelling [`CoInitializeSecurity`](https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-coinitializesecurity). Proposing to fix this to avoid confusion.