### PR TITLE
Fix incorrectly code syntax for INonDelegatingUnknown

### DIFF
--- a/desktop-src/DirectShow/inondelegatingunknown.md
+++ b/desktop-src/DirectShow/inondelegatingunknown.md
@@ -31,9 +31,9 @@ The `INonDelegatingUnknown` interface is a version of **IUnknown** that is renam
 ```C++
 interface INonDelegatingUnknown
 {
-    virtual HRESULT NonDelegatingQueryInterface) (REFIID riid, LPVOID *ppv) PURE;
-    virtual ULONG NonDelegatingAddRef)(void) PURE;
-    virtual ULONG NonDelegatingRelease)(void) PURE;
+    virtual HRESULT NonDelegatingQueryInterface(REFIID riid, LPVOID *ppv) PURE;
+    virtual ULONG NonDelegatingAddRef(void) PURE;
+    virtual ULONG NonDelegatingRelease(void) PURE;
 };
 ```
 


### PR DESCRIPTION
Hi, Im found a typo in [inondelegatingunknown.md#syntax](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/DirectShow/inondelegatingunknown.md#syntax) .

https://github.com/MicrosoftDocs/win32/blob/8cd324318d65a509832757beed193fb38ab10ce4/desktop-src/DirectShow/inondelegatingunknown.md?plain=1#L31-L37