### PR TITLE
Update listing-the-files-in-a-directory.md

### DIFF
--- a/desktop-src/FileIO/listing-the-files-in-a-directory.md
+++ b/desktop-src/FileIO/listing-the-files-in-a-directory.md
@@ -40,7 +40,7 @@ int _tmain(int argc, TCHAR *argv[])
 
    // Check that the input path plus 3 is not longer than MAX_PATH.
    // Three characters are for the "\*" plus NULL appended below.
-
+   StringCchCopy(szDir, MAX_PATH, argv[1]);
    StringCchLength(argv[1], MAX_PATH, &length_of_arg);
 
    if (length_of_arg > (MAX_PATH - 3))


### PR DESCRIPTION
The current code accepts user input via argv[1] but this value is never stored into the szDir variable. Consequently, the root directory of the user's system is always displayed, regardless of the provided input. This behavior diverges from the expected output, which would be the content of the user-specified directory. This issue can be addressed by adding the following line of code before the StringCchCat(szDir, MAX_PATH, TEXT("\\*")); function: StringCchCopy(szDir, MAX_PATH, argv[1]);. Implementing this change ensures that szDir is correctly assigned the user-provided directory path, resulting in the expected display of the directory contents.