### PR TITLE
Fix IExplorerCommand link in ShareHandler documentation

### DIFF
--- a/desktop-src/cfApi/build-a-cloud-file-sync-engine.md
+++ b/desktop-src/cfApi/build-a-cloud-file-sync-engine.md
@@ -70,7 +70,7 @@ The following image demonstrates how the placeholder, full, and pinned full file
   * The provider registers their copy hook by setting the **CopyHook** registry value under their sync root registry key to a the CLSID of their COM local server object. This local server object implements the [IStorageProviderCopyHook](../shell/nn-shobjidl-istorageprovidercopyhook.md) interface.
 * File sharing (supported in Windows 11 version 21H2 and later versions):
   * Cloud storage providers can register a share handler that will be invoked when the user selects the "Share" command on a cloud file under their sync root.
-  * The provider registers their share handler by setting the **ShareHandler** registry value under their sync root registry key to the CLSID of their COM local server object. This local server object implements the [IExplorerCommand](/win32/api/shobjidl_core/nn-shobjidl_core-iexplorercommand) interface.
+  * The provider registers their share handler by setting the **ShareHandler** registry value under their sync root registry key to the CLSID of their COM local server object. This local server object implements the [IExplorerCommand](/windows/win32/api/shobjidl_core/nn-shobjidl_core-iexplorercommand) interface.
 
 ### Desktop Bridge
 


### PR DESCRIPTION
Recent PR adding ShareHandler documentation had a broken link to the IExplorerCommand interface - fixing this to the correct relative link.