### PR TITLE
Fix the example of appending one file to another

### DIFF
--- a/desktop-src/FileIO/appending-one-file-to-another-file.md
+++ b/desktop-src/FileIO/appending-one-file-to-another-file.md
@@ -45,7 +45,7 @@ void main()
 
   if (hFile == INVALID_HANDLE_VALUE)
   {
-     printf("Could not open One.txt."); 
+     printf("Could not open one.txt."); 
      return;
   }
 
@@ -53,16 +53,16 @@ void main()
   // create a new file.
 
   hAppend = CreateFile(TEXT("two.txt"), // open Two.txt
-              FILE_APPEND_DATA,         // open for writing
-              FILE_SHARE_READ,          // allow multiple readers
-              NULL,                     // no security
-              OPEN_ALWAYS,              // open or create
-              FILE_ATTRIBUTE_NORMAL,    // normal file
-              NULL);                    // no attr. template
+              FILE_APPEND_DATA | FILE_GENERIC_READ,    // open for appending and locking
+              FILE_SHARE_READ,                         // allow multiple readers
+              NULL,                                    // no security
+              OPEN_ALWAYS,                             // open or create
+              FILE_ATTRIBUTE_NORMAL,                   // normal file
+              NULL);                                   // no attr. template
 
   if (hAppend == INVALID_HANDLE_VALUE)
   {
-     printf("Could not open Two.txt."); 
+     printf("Could not open two.txt."); 
      return;
   }
 
@@ -75,7 +75,10 @@ void main()
       && dwBytesRead > 0)
     {
     dwPos = SetFilePointer(hAppend, 0, NULL, FILE_END);
-    LockFile(hAppend, dwPos, 0, dwBytesRead, 0);
+    if (!LockFile(hAppend, dwPos, 0, dwBytesRead, 0))
+    {
+       printf("Could not lock two.txt");
+    }
     WriteFile(hAppend, buff, dwBytesRead, &dwBytesWritten, NULL);
     UnlockFile(hAppend, dwPos, 0, dwBytesRead, 0);
     }


### PR DESCRIPTION
The example in [appending-one-file-to-another-file.md](https://github.com/MicrosoftDocs/win32/blob/8761e854c2fa1ef1cb0b7a8ace5f481400f0f5b3/desktop-src/FileIO/appending-one-file-to-another-file.md) does not actually lock the file and this goes unnoticed because it also doesn't check if locking succeeds. [`LockFile`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfile) is documented as requiring either `FILE_GENERIC_READ` or `FILE_GENERIC_WRITE` but the example only had `FILE_APPEND_DATA`. This is fixed by using `FILE_APPEND_DATA | FILE_GENERIC_READ`. You only actually need to add `FILE_READ_DATA` but I thought it best to go with the documented requirement. Tbh, I'm not entirely sure why this is necessary but it is.

Also the example was inconsistent in the case used for the file name. Modern Windows filesystems, in some configurations, can be case sensitive so it's wise to be consistent.