### PR TITLE
BCM_SETTEXTMARGIN - Add macro mention, make description style consistent with other messages

### DIFF
--- a/desktop-src/Controls/bcm-settextmargin.md
+++ b/desktop-src/Controls/bcm-settextmargin.md
@@ -18,7 +18,7 @@ ms.date: 05/31/2018
 
 # BCM\_SETTEXTMARGIN message
 
-The **BCM\_SETTEXTMARGIN** message sets the margins for drawing text in a button control.
+Sets the margins used to draw text in a button control. You can send this message explicitly or use the [**Button\_SetTextMargin**](/windows/desktop/api/Commctrl/nf-commctrl-button_settextmargin) macro.
 
 ## Parameters
 


### PR DESCRIPTION
Description section in [BCM_SETTEXTMARGIN message](https://learn.microsoft.com/en-us/windows/win32/controls/bcm-settextmargin) is inconsistent when compared to other Button messages (which all follow the same format), and does not mention the macro. See [bcm-gettextmargin](https://learn.microsoft.com/en-us/windows/win32/controls/bcm-gettextmargin) for comparison.