### PR TITLE
Toggle Button not allowed in ApplicationMenu

### DIFF
--- a/desktop-src/windowsribbon/windowsribbon-controls-applicationmenu.md
+++ b/desktop-src/windowsribbon/windowsribbon-controls-applicationmenu.md
@@ -56,13 +56,13 @@ The [**ApplicationMenu**](windowsribbon-element-applicationmenu.md) element must
 The following is a list of constraints for a [**MenuGroup**](windowsribbon-element-menugroup.md) element of an Application Menu:
 
 -   All [**MenuGroup**](windowsribbon-element-menugroup.md) items must be declared with a *Class* attribute value of `MajorItems`.
--   An Application Menu [**MenuGroup**](windowsribbon-element-menugroup.md) supports only the [Button](windowsribbon-controls-button.md), [Toggle Button](windowsribbon-controls-togglebutton.md), [Drop-Down Button](windowsribbon-controls-dropdownbutton.md), [Split Button](windowsribbon-controls-splitbutton.md), [Drop-Down Gallery](windowsribbon-controls-dropdowngallery.md), and [Split Button Gallery](windowsribbon-controls-splitbuttongallery.md) controls.
+-   An Application Menu [**MenuGroup**](windowsribbon-element-menugroup.md) supports only the [Button](windowsribbon-controls-button.md), [Drop-Down Button](windowsribbon-controls-dropdownbutton.md), [Split Button](windowsribbon-controls-splitbutton.md), [Drop-Down Gallery](windowsribbon-controls-dropdowngallery.md), and [Split Button Gallery](windowsribbon-controls-splitbuttongallery.md) controls.
     > ![Important]  
     > Command galleries are the only type of gallery that are supported in the Application Menu. See [Working with Galleries](./ribbon-controls-galleries.md), for more information on gallery controls.
 
      
 
-When a [Button](windowsribbon-controls-button.md) or [Toggle Button](windowsribbon-controls-togglebutton.md) is used in a [**MenuGroup**](windowsribbon-element-menugroup.md), the value of [**Command.LabelTitle**](windowsribbon-element-command-labeltitle.md) is displayed in the menu and the values of [**Command.TooltipTitle**](windowsribbon-element-command-tooltiptitle.md) and [**Command.TooltipDescription**](windowsribbon-element-command-tooltipdescription.md) are displayed as the tooltip, as shown in the following screen shot.
+When a [Button](windowsribbon-controls-button.md) is used in a [**MenuGroup**](windowsribbon-element-menugroup.md), the value of [**Command.LabelTitle**](windowsribbon-element-command-labeltitle.md) is displayed in the menu and the values of [**Command.TooltipTitle**](windowsribbon-element-command-tooltiptitle.md) and [**Command.TooltipDescription**](windowsribbon-element-command-tooltipdescription.md) are displayed as the tooltip, as shown in the following screen shot.
 
 ![screen shot of a button control in an application menu.](images/overviews/applicationmenu-menubutton.png)
 


### PR DESCRIPTION
Toggle Button is not supported in the MenuGroup of an ApplicationMenu in the Windows Ribbon Framework. Toggle Button is only supported in the ApplicationMenu when selecting a SplitButton and setting the ButtonItem to a Toggle Button.