### PR TITLE
Reinstate info about Win32 API for accessing SDR white level

### DIFF
--- a/desktop-src/direct3darticles/high-dynamic-range.md
+++ b/desktop-src/direct3darticles/high-dynamic-range.md
@@ -357,10 +357,10 @@ However, if your app performs its own composition of SDR and HDR content into a 
 
 ### Step 1. Obtain the current SDR reference white level
 
-You can obtain the current SDR reference white level via either:
+You can obtain the current SDR reference white level in one of these ways:
 
-* [**DISPLAYCONFIG_SDR_WHITE_LEVEL**](/win32/api/wingdi/ns-wingdi-displayconfig_sdr_white_level) and [**QueryDisplayConfig**](/win32/api/winuser/nf-winuser-querydisplayconfig) in a desktop application, or
-* [**AdvancedColorInfo.SdrWhiteLevelInNits**](/uwp/api/windows.graphics.display.advancedcolorinfo.sdrwhitelevelinnits) using a [**CoreWindow**](/uwp/api/Windows.UI.Core.CoreWindow) in a UWP app.
+* **In a desktop app**. [**DISPLAYCONFIG_SDR_WHITE_LEVEL**](/win32/api/wingdi/ns-wingdi-displayconfig_sdr_white_level) and [**QueryDisplayConfig**](/win32/api/winuser/nf-winuser-querydisplayconfig).
+* **In a UWP app**. [**AdvancedColorInfo.SdrWhiteLevelInNits**](/uwp/api/windows.graphics.display.advancedcolorinfo.sdrwhitelevelinnits) (using a [**CoreWindow**](/uwp/api/Windows.UI.Core.CoreWindow)).
 
 ### Step 2. Adjust color values of SDR content
 

--- a/desktop-src/direct3darticles/high-dynamic-range.md
+++ b/desktop-src/direct3darticles/high-dynamic-range.md
@@ -357,7 +357,10 @@ However, if your app performs its own composition of SDR and HDR content into a 
 
 ### Step 1. Obtain the current SDR reference white level
 
-Currently, only UWP apps can obtain the current SDR reference white level via [**AdvancedColorInfo.SdrWhiteLevelInNits**](/uwp/api/windows.graphics.display.advancedcolorinfo.sdrwhitelevelinnits). That API requires a [**CoreWindow**](/uwp/api/Windows.UI.Core.CoreWindow).
+You can obtain the current SDR reference white level via either:
+
+* [**DISPLAYCONFIG_SDR_WHITE_LEVEL**](/win32/api/wingdi/ns-wingdi-displayconfig_sdr_white_level) and [**QueryDisplayConfig**](/win32/api/winuser/nf-winuser-querydisplayconfig) in a desktop application, or
+* [**AdvancedColorInfo.SdrWhiteLevelInNits**](/uwp/api/windows.graphics.display.advancedcolorinfo.sdrwhitelevelinnits) using a [**CoreWindow**](/uwp/api/Windows.UI.Core.CoreWindow) in a UWP app.
 
 ### Step 2. Adjust color values of SDR content
 


### PR DESCRIPTION
In #1183 (March 2022), a Win32 API was added to the document as a way to access the SDR white level on Win32 applications. It was later reformatted in ea917b9961e39fbdad1c4a1d33f210abc90a75c9, which is the wording I used here.

In 2a63ff1fdf0cf30c5e71c7b43ba6f4b1c34db528 (October 2022, could not find the PR) the reference to this API was lost in a major refactor. The current document text states that only UWP apps can access the SDR white level and does not mention `DISPLAYCONFIG_SDR_WHITE_LEVEL`.

This PR reintroduces the missing text.