### PR TITLE
Remarks on UB *MemoryBarrierWithGroupSync functions

### DIFF
--- a/desktop-src/direct3dhlsl/allmemorybarrierwithgroupsync.md
+++ b/desktop-src/direct3dhlsl/allmemorybarrierwithgroupsync.md
@@ -37,6 +37,8 @@ This function does not return a value.
 
 A memory barrier guarantees that outstanding memory operations have completed. Threads are synchronized at GroupSync barriers. This may stall a thread or threads if memory operations are in progress.
 
+The behavior of calls to this function that are within diverging branches of a thread group are undefined.
+
 ### Minimum Shader Model
 
 This function is supported in the following shader models.

--- a/desktop-src/direct3dhlsl/devicememorybarrierwithgroupsync.md
+++ b/desktop-src/direct3dhlsl/devicememorybarrierwithgroupsync.md
@@ -35,6 +35,8 @@ This function does not return a value.
 
 ## Remarks
 
+The behavior of calls to this function that are within diverging branches of a thread group are undefined.
+
 ### Minimum Shader Model
 
 This function is supported in the following shader models.

--- a/desktop-src/direct3dhlsl/groupmemorybarrierwithgroupsync.md
+++ b/desktop-src/direct3dhlsl/groupmemorybarrierwithgroupsync.md
@@ -35,6 +35,8 @@ This function does not return a value.
 
 ## Remarks
 
+The behavior of calls to this function that are within diverging branches of a thread group are undefined.
+
 ### Minimum Shader Model
 
 This function is supported in the following shader models.


### PR DESCRIPTION
Previously in FXC, AllMemoryBarrierWithGroupSync, DeviceMemoryBarrierWithGroupSync and GroupMemoryBarrierWithGroupSync would catch divergent thread usage and error out. Now in DXC this is no longer the case as concepts like dynamic uniform exist. It's important to inform developers of this undefined behavior and it can be tricky to discover if even the docs don't warn you.
