### PR TITLE
Add link for `Wow64GetThreadContext` in debugging functions

### DIFF
--- a/desktop-src/Debug/debugging-functions.md
+++ b/desktop-src/Debug/debugging-functions.md
@@ -31,7 +31,7 @@ The following functions are used with debugging.
 | [**SetThreadContext**](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadcontext)                       | Sets the context for the specified thread.                                          |
 | [**WaitForDebugEvent**](/windows/win32/api/debugapi/nf-debugapi-waitfordebugevent)                     | Waits for a debugging event to occur in a process being debugged.                   |
 | [**WaitForDebugEventEx**](/windows/win32/api/debugapi/nf-debugapi-waitfordebugeventex)                     | Waits for a debugging event to occur in a process being debugged, and enables support for Unicode strings from OutputDebugStringW.                   |
-| **Wow64GetThreadContext**          | Retrieves the context of the specified WOW64 thread.                                |
+| [**Wow64GetThreadContext**](/windows/win32/api/wow64apiset/nf-wow64apiset-wow64getthreadcontext)          | Retrieves the context of the specified WOW64 thread.                                |
 | [**Wow64GetThreadSelectorEntry**](/windows/desktop/api/WinBase/nf-winbase-wow64getthreadselectorentry) | Retrieves a descriptor table entry for the specified selector and WOW64 thread.     |
 | [**Wow64SetThreadContext**](/windows/win32/api/wow64apiset/nf-wow64apiset-wow64setthreadcontext)             | Sets the context of the specified WOW64 thread.                                     |
 | [**WriteProcessMemory**](/windows/win32/api/memoryapi/nf-memoryapi-writeprocessmemory)                   | Writes data to an area of memory in a specified process.                            |


### PR DESCRIPTION
Hopefully the sole API that does not have a hyperlink is not intentional.