### PR TITLE
Update getting-system-information.md

### DIFF
--- a/desktop-src/SysInfo/getting-system-information.md
+++ b/desktop-src/SysInfo/getting-system-information.md
@@ -16,7 +16,7 @@ The following example uses the [**GetComputerName**](/windows/desktop/api/Winbas
 #include <tchar.h>
 #include <stdio.h>
 
-TCHAR* envVarStrings[] =
+const TCHAR* envVarStrings[] =
 {
   TEXT("OS         = %OS%"),
   TEXT("PATH       = %PATH%"),
@@ -25,7 +25,7 @@ TCHAR* envVarStrings[] =
 };
 #define  ENV_VAR_STRING_COUNT  (sizeof(envVarStrings)/sizeof(TCHAR*))
 #define INFO_BUFFER_SIZE 32767
-void printError( TCHAR* msg );
+void printError(const TCHAR* msg );
 
 void main( )
 {
@@ -72,7 +72,7 @@ void main( )
   _tprintf( TEXT("\n\n"));
 }
 
-void printError( TCHAR* msg )
+void printError(const TCHAR* msg )
 {
   DWORD eNum;
   TCHAR sysMsg[256];


### PR DESCRIPTION
Added "const qualifiers" in 3 places.

"string" is also called as "character constants", "string constant" and "anonymous string" in C++. This is because a "string"  in the C++ standard has the "const qualifier".
But the situation in C is slightly different. Since the "const keyword" did not exist in C until the "ANSI C 1989" standard,  "string literals" dont have a "const qualifier" for such historical reasons. Hence "non-const string" in C is evaluated as  "undefined behavior".
"string literals", i.e. the elements of the "envVarStrings" array are located in memory in the ".rodata section" of the "data segment", but the "pointers" of this array even though are in the ".rwdata section", they "point" to the "first  character addresses", i.e. "base addresses" of "strings" located in the "read-only section" and store these addresses. That is why must be added the "const qualifier" that indicating they are "pointing" to "const character".  Although the "printError" function has a "non-const" parameter - void printError(TCHAR* msg); - , the program string attempts to pass a "const" argument to this function. - "printError( TEXT("GetComputerName") );" To eliminate the problem the "printError" function parameter must have the "const qualifier".