### PR TITLE
Update getting-system-information.md

### DIFF
--- a/desktop-src/SysInfo/getting-system-information.md
+++ b/desktop-src/SysInfo/getting-system-information.md
@@ -25,12 +25,12 @@ TCHAR* envVarStrings[] =
 };
 #define  ENV_VAR_STRING_COUNT  (sizeof(envVarStrings)/sizeof(TCHAR*))
 #define INFO_BUFFER_SIZE 32767
+TCHAR  infoBuf[INFO_BUFFER_SIZE] = {'\0'};
 void printError( TCHAR* msg );
 
 void main( )
 {
   DWORD i;
-  TCHAR  infoBuf[INFO_BUFFER_SIZE];
   DWORD  bufCharCount = INFO_BUFFER_SIZE;
  
   // Get and display the name of the computer. 


### PR DESCRIPTION
There are would be occurred compiler warnings if the stack frame size limit is appointed for "user mode" is exceeded. - 16 KB = 16000 Bytes, 16 KiB = 16384 Bytes. A large stack frame can cause a stack overflow. This can be resolved by transferring some data (a group of data) located on the "stack" to one of the dynamic segments in either the "heap" or the "global space". When "char" array is "initialized" in C++, '\0' is always appended to the end, either by "manual" or "compiler". Therefore, there must be a 1 byte reservation for '\0' at the end of the array. This should be taken into when the array is "initialized".