### PR TITLE
Update getting-system-information.md

### DIFF
--- a/desktop-src/SysInfo/getting-system-information.md
+++ b/desktop-src/SysInfo/getting-system-information.md
@@ -74,11 +74,10 @@ void main( )
 
 void printError( TCHAR* msg )
 {
-  DWORD eNum;
-  TCHAR sysMsg[256];
-  TCHAR* p;
+  TCHAR sysMsg[MAX_PATH] = {'\0'};
+  TCHAR* p = sysMsg;  // or nullptr: in the case of below assignment of p = SysMsg
+  DWORD eNum = GetLastError();
 
-  eNum = GetLastError( );
   FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM | 
          FORMAT_MESSAGE_IGNORE_INSERTS,
          NULL, eNum,
@@ -86,7 +85,6 @@ void printError( TCHAR* msg )
          sysMsg, 256, NULL );
 
   // Trim the end of the line and terminate it with a null
-  p = sysMsg;
   while( ( *p > 31 ) || ( *p == 9 ) )
     ++p;
   do { *p-- = 0; } while( ( p >= sysMsg ) &&


### PR DESCRIPTION
Let's take a look at the "declaration" in the input part of the "printError()" function. After editing, the "uninitialized variable, array and wild pointer" are gone, the size of the "array" is replaced by the "MAX_PATH (256->MAX_PATH)" macro, which defines the maximum length value (currently 260) and is more efficient in my opinion. Which value is also supported by "lpBuffer and nSize - 64K bytes = 64000 bytes" parameters of "FormatMessage()" function.