### PR TITLE
Update getting-system-information.md

### DIFF
--- a/desktop-src/SysInfo/getting-system-information.md
+++ b/desktop-src/SysInfo/getting-system-information.md
@@ -75,7 +75,7 @@ void main( )
 void printError( TCHAR* msg )
 {
   DWORD eNum;
-  TCHAR sysMsg[256];
+  TCHAR sysMsg[MAX_PATH] = {'\0'};      //  it can remain as it is: TCHAR sysMsg[256];
   TCHAR* p;
 
   eNum = GetLastError( );
@@ -87,10 +87,14 @@ void printError( TCHAR* msg )
 
   // Trim the end of the line and terminate it with a null
   p = sysMsg;
-  while( ( *p > 31 ) || ( *p == 9 ) )
-    ++p;
-  do { *p-- = 0; } while( ( p >= sysMsg ) &&
-                          ( ( *p == '.' ) || ( *p < 33 ) ) );
+  while (*p++)
+  {
+      if ((*p != 9 && *p < 32) || *p == 46)
+      {
+          *p = 0;
+          break;
+      }
+  }	
 
   // Display the message
   _tprintf( TEXT("\n\t%s failed with error %d (%s)"), msg, eNum, sysMsg );


### PR DESCRIPTION
Even if the sysMsg array would not be modified, this part is highly suboptimal and can be performed more optimally with  a single loop. You can test it without sysMsg array modification to be sure this loop is very non optimal.  In the first "while loop", all "control characters" - [0 - 32) - except for "9 - \t (horizontal tab)" - "p - pointer" -  are "pre- increment" and the following two ending with different characters depending on the version. :

// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and while( ( *p > 31 ) || ( *p == 9 ) ) version p: 000000A131EEEC04 *p: 13 <---\

NOTE: index sysMsg[50]: \r = 13 (cycle ends with this character)


// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and 1st modification of the while(((*p > 31) && (*p != 46)) || (*p == 9)) version p: 000000FEDA0EECC2 *p: 46 <---\ after "while" until entering "do-while" loop

NOTE: index sysMsg[49]: . = 46 (cycle ends with this character)


Then, a new second do-while loop kicks in, which I think is more readable in the modified version -
- while ((p >= sysMsg) && ((*p == '.') || (*p < 33))); --> while ((p >= sysMsg) && ((*p == 46) || (*p < 33))); The most interesting is the line of code where "post-decrement + indirection" operations are executed together: *p-- = 0; The sequence of operations performed by this code snippet can be found from this official source - https://en.cppreference.com/w/c/language/operator_precedence -
- we can learn. The post-decrement operation has a higher priority than the indirection (dereference). Moreover, since it is also true from the associativity point of view, we can group this piece of code like this: *(p--) = 0; The value of the expression "post-decrement" is the value of p before the "decrement" operation, but the value of p is also "decremented" at the same time. Actually "operator-- overloading" occurs during "post-decrement" - T T::operator--(int); ---> T operator--(T& a, int); - and in the first step, it creates a copy of the received p, then "decrements" the value of p, and finally from the "decrement" process in the first step returns the previously created copy. Then *(p--) "indirection (dereference)" is applied to these operations:


// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and while( ( *p > 31 ) || ( *p == 9 ) ) version p: 000000A131EEEC04 *p: 13 <---\ when entering "do-while" loop, *(p--) = 0; before the line p: 000000A131EEEC02 *p: 46 <---\ "do-while" loop, after line - *(p--) = 0; p: 000000A131EEEC00 *p: 1099


// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and 1st modification of the while(((*p > 31) && (*p != 46)) || (*p == 9)) version p: 000000FEDA0EECC2 *p: 46 <---\ when entering "do-while" loop, *(p--) = 0; before the line p: 000000FEDA0EECC0 *p: 1099 <---\ "do-while" loop, *(p--) = 0; after the line


In general, it is very inconvenient to run 2 loops to perform the cleaning process and it is can be adjusted with a single loop. For this, exactly these code parts should be "refactored".