### PR TITLE
Fix link display in `Related topics` section

### DIFF
--- a/desktop-src/Rpc/string-uuid.md
+++ b/desktop-src/Rpc/string-uuid.md
@@ -17,6 +17,7 @@ When providing a string UUID as an input parameter to an RPC run-time function, 
 ## Related topics
 
 <dl> <dt>
+  
 [**UUID**](./rpcdce/ns-rpcdce-uuid.md)
 </dt> </dl>
 


### PR DESCRIPTION
There was no newline above the link notation, which seemed to prevent the parser from interpreting it as a link text.  

( This behavior is observed at https://learn.microsoft.com/en-us/windows/win32/rpc/string-uuid )

Therefore, by adding a blank line, I've corrected it to display as a link on the screen.