### PR TITLE
[stevewhims: recommend closing] Update taking-a-snapshot-and-viewing-processes.md

### DIFF
--- a/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
+++ b/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
@@ -38,7 +38,7 @@ BOOL GetProcessList( )
   DWORD dwPriorityClass;
 
   // Take a snapshot of all processes in the system.
-  hProcessSnap = CreateToolhelp32Snapshot( TH32CS_SNAPPROCESS, 0 );
+  hProcessSnap = ::CreateToolhelp32Snapshot( TH32CS_SNAPPROCESS, 0 );
   if( hProcessSnap == INVALID_HANDLE_VALUE )
   {
     printError( TEXT("CreateToolhelp32Snapshot (of processes)") );
@@ -50,10 +50,10 @@ BOOL GetProcessList( )
 
   // Retrieve information about the first process,
   // and exit if unsuccessful
-  if( !Process32First( hProcessSnap, &pe32 ) )
+  if( !::Process32First( hProcessSnap, &pe32 ) )
   {
     printError( TEXT("Process32First") ); // show cause of failure
-    CloseHandle( hProcessSnap );          // clean the snapshot object
+    ::CloseHandle( hProcessSnap );          // clean the snapshot object
     return( FALSE );
   }
 
@@ -67,15 +67,15 @@ BOOL GetProcessList( )
 
     // Retrieve the priority class.
     dwPriorityClass = 0;
-    hProcess = OpenProcess( PROCESS_ALL_ACCESS, FALSE, pe32.th32ProcessID );
+    hProcess = ::OpenProcess( PROCESS_ALL_ACCESS, FALSE, pe32.th32ProcessID );
     if( hProcess == NULL )
       printError( TEXT("OpenProcess") );
     else
     {
-      dwPriorityClass = GetPriorityClass( hProcess );
+      dwPriorityClass = ::GetPriorityClass( hProcess );
       if( !dwPriorityClass )
         printError( TEXT("GetPriorityClass") );
-      CloseHandle( hProcess );
+      ::CloseHandle( hProcess );
     }
 
     _tprintf( TEXT("\n  Process ID        = 0x%08X"), pe32.th32ProcessID );
@@ -89,9 +89,9 @@ BOOL GetProcessList( )
     ListProcessModules( pe32.th32ProcessID );
     ListProcessThreads( pe32.th32ProcessID );
 
-  } while( Process32Next( hProcessSnap, &pe32 ) );
+  } while( ::Process32Next( hProcessSnap, &pe32 ) );
 
-  CloseHandle( hProcessSnap );
+  ::CloseHandle( hProcessSnap );
   return( TRUE );
 }
 
@@ -102,7 +102,7 @@ BOOL ListProcessModules( DWORD dwPID )
   MODULEENTRY32 me32;
 
   // Take a snapshot of all modules in the specified process.
-  hModuleSnap = CreateToolhelp32Snapshot( TH32CS_SNAPMODULE, dwPID );
+  hModuleSnap = ::CreateToolhelp32Snapshot( TH32CS_SNAPMODULE, dwPID );
   if( hModuleSnap == INVALID_HANDLE_VALUE )
   {
     printError( TEXT("CreateToolhelp32Snapshot (of modules)") );
@@ -114,10 +114,10 @@ BOOL ListProcessModules( DWORD dwPID )
 
   // Retrieve information about the first module,
   // and exit if unsuccessful
-  if( !Module32First( hModuleSnap, &me32 ) )
+  if( !::Module32First( hModuleSnap, &me32 ) )
   {
     printError( TEXT("Module32First") );  // show cause of failure
-    CloseHandle( hModuleSnap );           // clean the snapshot object
+    ::CloseHandle( hModuleSnap );           // clean the snapshot object
     return( FALSE );
   }
 
@@ -133,9 +133,9 @@ BOOL ListProcessModules( DWORD dwPID )
     _tprintf( TEXT("\n     Base address   = 0x%08X"), (DWORD) me32.modBaseAddr );
     _tprintf( TEXT("\n     Base size      = %d"),             me32.modBaseSize );
 
-  } while( Module32Next( hModuleSnap, &me32 ) );
+  } while( ::Module32Next( hModuleSnap, &me32 ) );
 
-  CloseHandle( hModuleSnap );
+  ::CloseHandle( hModuleSnap );
   return( TRUE );
 }
 
@@ -145,7 +145,7 @@ BOOL ListProcessThreads( DWORD dwOwnerPID )
   THREADENTRY32 te32; 
  
   // Take a snapshot of all running threads  
-  hThreadSnap = CreateToolhelp32Snapshot( TH32CS_SNAPTHREAD, 0 ); 
+  hThreadSnap = ::CreateToolhelp32Snapshot( TH32CS_SNAPTHREAD, 0 ); 
   if( hThreadSnap == INVALID_HANDLE_VALUE ) 
     return( FALSE ); 
  
@@ -154,10 +154,10 @@ BOOL ListProcessThreads( DWORD dwOwnerPID )
  
   // Retrieve information about the first thread,
   // and exit if unsuccessful
-  if( !Thread32First( hThreadSnap, &te32 ) ) 
+  if( !::Thread32First( hThreadSnap, &te32 ) ) 
   {
     printError( TEXT("Thread32First") ); // show cause of failure
-    CloseHandle( hThreadSnap );          // clean the snapshot object
+    ::CloseHandle( hThreadSnap );          // clean the snapshot object
     return( FALSE );
   }
 
@@ -173,33 +173,40 @@ BOOL ListProcessThreads( DWORD dwOwnerPID )
       _tprintf( TEXT("\n     Delta priority = %d"), te32.tpDeltaPri ); 
       _tprintf( TEXT("\n"));
     }
-  } while( Thread32Next(hThreadSnap, &te32 ) ); 
+  } while( ::Thread32Next(hThreadSnap, &te32 ) ); 
 
-  CloseHandle( hThreadSnap );
+  ::CloseHandle( hThreadSnap );
   return( TRUE );
 }
 
 void printError( const TCHAR* msg )
 {
-  DWORD eNum;
-  TCHAR sysMsg[256];
-  TCHAR* p;
+  TCHAR sysMsg[MAX_PATH] = {'\0'};
+  TCHAR* p = sysMsg;   // &sysMsg[0];
+  DWORD eNum = ::GetLastError();
 
-  eNum = GetLastError( );
-  FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-         NULL, eNum,
+  ::FormatMessage( FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+         nullptr, eNum,
          MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // Default language
-         sysMsg, 256, NULL );
+         sysMsg, MAX_PATH, nullptr );
 
   // Trim the end of the line and terminate it with a null
-  p = sysMsg;
-  while( ( *p > 31 ) || ( *p == 9 ) )
-    ++p;
-  do { *p-- = 0; } while( ( p >= sysMsg ) &&
-                          ( ( *p == '.' ) || ( *p < 33 ) ) );
+  // 9 - \t (horizontal tab)
+  // [0 - 32) - All characters in this area excepting 9
+  // 46 - . (dot)
+  while (*p++)   //  != &sysMsg[MAX_PATH]
+  {
+      if ((*p != 9 && *p < 32) || *p == 46)
+      {
+          *p = 0;
+          break;
+      }
+  }
 
   // Display the message
   _tprintf( TEXT("\n  WARNING: %s failed with error %d (%s)"), msg, eNum, sysMsg );
+
+  p = nullptr;
 }
 ```
 


### PR DESCRIPTION
1) Let's take a look at the "declaration" in the input part of the "printError()" function. After editing, the "uninitialized variable, array and wild pointer" are gone, the size of the "array" is replaced by the "MAX_PATH (256->MAX_PATH)" macro, which defines the maximum length value (currently 260) and is more efficient on my opinion. Which value is also supported by "lpBuffer and nSize - 64K bytes = 64000 bytes" parameters of "FormatMessage()" function.

2) Even if the sysMsg array would not be modified, this part is highly suboptimal and can be performed more optimally with  a single loop. You can test it without sysMsg array modification to be sure this loop is very non optimal. In the first "while loop", all "control characters" - [0 - 32) - except for "9 - \t (horizontal tab)" - "p - pointer" - are "pre- increment" and the following two ending with different characters depending on the version:

// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and while( ( *p > 31 ) || ( *p == 9 ) ) version p: 000000A131EEEC04 *p: 13 <---\

NOTE: index sysMsg[50]: \r = 13 (cycle ends with this character)

// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and 1st modification of the while(((*p > 31) && (*p != 46)) || (*p == 9)) version p: 000000FEDA0EECC2 *p: 46 <---\ after "while" until entering "do-while" loop

NOTE: index sysMsg[49]: . = 46 (cycle ends with this character)

Then, a new second do-while loop kicks in, which I think is more readable in the modified version -
- while ((p >= sysMsg) && ((*p == '.') || (*p < 33))); --> while ((p >= sysMsg) && ((*p == 46) || (*p < 33))); The most interesting is the line of code where "post-decrement + indirection" operations are executed together: *p-- = 0; The sequence of operations performed by this code snippet can be found from this official source - https://en.cppreference.com/w/c/language/operator_precedence - we can learn. The post-decrement operation has a higher priority than the indirection (dereference). Moreover, since it is also true from the associativity point of view, we can group this piece of code like this: *(p--) = 0; The value of the expression "post-decrement" is the value of p before the "decrement" operation, but the value of p is also "decremented" at the same time. Actually "operator-- overloading" occurs during "post-decrement" - T T::operator--(int); ---> T operator--(T& a, int); - and in the first step, it creates a copy of the received p, then "decrements" the value of p, and finally from the "decrement" process in the first step returns the previously created copy. Then *(p--) "indirection (dereference)" is applied to these operations:

// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and while( ( *p > 31 ) || ( *p == 9 ) ) version p: 000000A131EEEC04 *p: 13 <---\ when entering "do-while" loop, *(p--) = 0; before the line p: 000000A131EEEC02 *p: 46 <---\ "do-while" loop, after line - *(p--) = 0; p: 000000A131EEEC00 *p: 1099

// after TCHAR sysMsg[MAX_PATH] = { '\0' }; and 1st modification of the while(((*p > 31) && (*p != 46)) || (*p == 9)) version p: 000000FEDA0EECC2 *p: 46 <---\ when entering "do-while" loop, *(p--) = 0; before the line p: 000000FEDA0EECC0 *p: 1099 <---\ "do-while" loop, *(p--) = 0; after the line

In general, it is very inconvenient to run 2 loops to perform the cleaning process and it can be adjusted through a single loop. For this, exactly these code parts should be "refactored".

3) Added double colon before the some function names to emphasize that they are part of Windows API and "p = nullptr;" line to the end of "printError()" function.

4) These lines were changed: NULL to nullptr parameters in "FormatMessage()" function.