### PR TITLE
Add reserved COM/LPT names with CP-1252 superscript digits.

### DIFF
--- a/desktop-src/FileIO/naming-a-file.md
+++ b/desktop-src/FileIO/naming-a-file.md
@@ -70,7 +70,7 @@ The following fundamental rules enable applications to create and process valid 
 -   Use two consecutive periods (..) as a directory *component* in a path to represent the parent of the current directory, for example "..\\temp.txt". For more information, see [Paths](#fully-qualified-vs-relative-paths).
 -   Do not use the following reserved names for the name of a file:
 
-    CON, PRN, AUX, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9. Also avoid these names followed immediately by an extension; for example, NUL.txt and NUL.tar.gz are both equivalent to NUL. For more information, see [Namespaces](#win32-file-namespaces).
+    CON, PRN, AUX, NUL, COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, COM¹, COM², COM³, LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9, LPT¹, LPT², and LPT³. Also avoid these names followed immediately by an extension; for example, NUL.txt and NUL.tar.gz are both equivalent to NUL. For more information, see [Namespaces](#win32-file-namespaces).
 
 -   Do not end a file or directory name with a space or a period. Although the underlying file system may support such names, the Windows shell and user interface does not. However, it is acceptable to specify a period as the first character of a name. For example, ".temp".
 


### PR DESCRIPTION
Windows recognises the 8-bit ISO/IEC 8859-1 superscript digits ¹, ², and ³ as digits and treats them as valid parts of COM# and LPT# device names, making them reserved in every directory. As far as I can tell, this is the case on all NT versions.

For example, `echo test > COM¹` fails to create a file.

Tangentially, COM0 and LPT0 are in practice treated as normal file names, contrary to documentation; I have not changed this as it's not clear whether they're still reserved for future use or just in case.