### PR TITLE
Return value error in documentation.

### DIFF
--- a/desktop-src/direct3d12/objecttoworld3x4.md
+++ b/desktop-src/direct3d12/objecttoworld3x4.md
@@ -20,7 +20,7 @@ A matrix for transforming from object-space to world-space. Object-space refers 
 ## Syntax
 
 ```
-void ObjectToWorld3x4();
+float3x4 ObjectToWorld3x4();
 
 ```
 

--- a/desktop-src/direct3d12/objecttoworld4x3.md
+++ b/desktop-src/direct3d12/objecttoworld4x3.md
@@ -20,7 +20,7 @@ A matrix for transforming from object-space to world-space. Object-space refers 
 ## Syntax
 
 ```
-void ObjectToWorld4x3();
+float4x3 ObjectToWorld4x3();
 
 ```
 

--- a/desktop-src/direct3d12/worldtoobject3x4.md
+++ b/desktop-src/direct3d12/worldtoobject3x4.md
@@ -20,7 +20,7 @@ A matrix for transforming from world-space to object-space. Object-space refers 
 ## Syntax
 
 ```
-void WorldToObject3x4();
+float3x4 WorldToObject3x4();
 
 ```
 

--- a/desktop-src/direct3d12/worldtoobject4x3.md
+++ b/desktop-src/direct3d12/worldtoobject4x3.md
@@ -20,7 +20,7 @@ A matrix for transforming from world-space to object-space. Object-space refers 
 ## Syntax
 
 ```
-void WorldToObject4x3();
+float4x3 WorldToObject4x3();
 
 ```
 


### PR DESCRIPTION
The return value of ObjectToWorld3x4()/WorldToObject3x4() should be float3x4 and the return value of ObjectToWorld4x3()/WorldToObject4x3() should be float4x3.