### PR TITLE
Update winsock select and fd

### DIFF
--- a/desktop-src/WinSock/select-and-fd---2.md
+++ b/desktop-src/WinSock/select-and-fd---2.md
@@ -1,14 +1,14 @@
 ---
 description: Since sockets are not represented by the UNIX-style, small, non-negative integer, the implementation of the select function was changed in Windows Sockets.
 ms.assetid: 97c7996c-c541-4673-b26f-d66f3fc0b62e
-title: Select, FD_SET, and FD_XXX Macros
+title: Select, fd_set, and FD_XXX Macros
 ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# Select, FD\_SET, and FD\_XXX Macros
+# Select, fd\_set, and FD\_XXX Macros
 
-Since sockets are not represented by the UNIX-style, small, non-negative integer, the implementation of the [**select**](/windows/desktop/api/Winsock2/nf-winsock2-select) function was changed in Windows Sockets. Each set of sockets is still represented by the **FD\_SET** structure, but instead of being stored as a bitmask, the set is implemented as an array of sockets. To avoid potential problems, applications must adhere to the use of the FD\_XXX macros to set, initialize, clear, and check the [**FD\_SET**](/windows/desktop/api/winsock/nf-winsock-fd_set) structures.
+Since sockets are not represented by the UNIX-style, small, non-negative integer, the implementation of the [**select**](/windows/desktop/api/winsock2/nf-winsock2-select) function was changed in Windows Sockets. Each set of sockets is still represented by the [**fd\_set**](/windows/desktop/api/winsock2/ns-winsock2-fd_set) structure, but instead of being stored as a bitmask, the set is implemented as an array of sockets. To avoid potential problems, applications must adhere to the use of the FD\_XXX macros to set ([**FD_SET**](/windows/desktop/api/winsock2/nf-winsock2-fd_set)), initialize (**FD_ZERO**), clear (**FD_CLR**), and check (**FD_ISSET**) the **fd\_set** structures.
 
 ## Related topics
 


### PR DESCRIPTION
Fix up some errors with difference between `fd_set` and `FD_SET`, together with a slight expansion on the corresponding `FD_XXX` macros mentioned at the bottom. Renamed the use of `FD_SET` (from the typedef of `fd_set` structure) when referring to the structure, to its actual name of `fd_set` to prevent confusion with `FD_SET` macro.