### PR TITLE
Correct the order of the Feature Level Array

### DIFF
--- a/desktop-src/direct3dgetstarted/work-with-dxgi.md
+++ b/desktop-src/direct3dgetstarted/work-with-dxgi.md
@@ -195,13 +195,13 @@ Obtain references (pointers) to both the Direct3D device and device context and 
 
 ```C++
 D3D_FEATURE_LEVEL levels[] = {
-    D3D_FEATURE_LEVEL_9_1,
-    D3D_FEATURE_LEVEL_9_2,
-    D3D_FEATURE_LEVEL_9_3,
-    D3D_FEATURE_LEVEL_10_0,
-    D3D_FEATURE_LEVEL_10_1,
-    D3D_FEATURE_LEVEL_11_0,
     D3D_FEATURE_LEVEL_11_1
+    D3D_FEATURE_LEVEL_11_0,
+    D3D_FEATURE_LEVEL_10_1,
+    D3D_FEATURE_LEVEL_10_0,
+    D3D_FEATURE_LEVEL_9_3,
+    D3D_FEATURE_LEVEL_9_2,
+    D3D_FEATURE_LEVEL_9_1,
 };
 
 // This flag adds support for surfaces with a color-channel ordering different


### PR DESCRIPTION
As the first supported is the one that is used.