### PR TITLE
Update enumerating-registry-subkeys.md

### DIFF
--- a/desktop-src/SysInfo/enumerating-registry-subkeys.md
+++ b/desktop-src/SysInfo/enumerating-registry-subkeys.md
@@ -21,29 +21,29 @@ The following example uses the [**RegQueryInfoKey**](/windows/desktop/api/Winreg
 
 #define MAX_KEY_LENGTH 255
 #define MAX_VALUE_NAME 16383
- 
-void QueryKey(HKEY hKey) 
-{ 
+
+void QueryKey(HKEY hKey)
+{
     TCHAR    achKey[MAX_KEY_LENGTH];   // buffer for subkey name
-    DWORD    cbName;                   // size of name string 
+    DWORD    cbName = 0;                   // size of name string 
     TCHAR    achClass[MAX_PATH] = TEXT("");  // buffer for class name 
     DWORD    cchClassName = MAX_PATH;  // size of class string 
-    DWORD    cSubKeys=0;               // number of subkeys 
-    DWORD    cbMaxSubKey;              // longest subkey size 
-    DWORD    cchMaxClass;              // longest class string 
-    DWORD    cValues;              // number of values for key 
-    DWORD    cchMaxValue;          // longest value name 
-    DWORD    cbMaxValueData;       // longest value data 
-    DWORD    cbSecurityDescriptor; // size of security descriptor 
+    DWORD    cSubKeys = 0;               // number of subkeys 
+    DWORD    cbMaxSubKey = 0;              // longest subkey size 
+    DWORD    cchMaxClass = 0;              // longest class string 
+    DWORD    cValues = 0;              // number of values for key 
+    DWORD    cchMaxValue = 0;          // longest value name 
+    DWORD    cbMaxValueData = 0;       // longest value data 
+    DWORD    cbSecurityDescriptor = 0; // size of security descriptor 
     FILETIME ftLastWriteTime;      // last write time 
- 
-    DWORD i, retCode; 
- 
-    TCHAR  achValue[MAX_VALUE_NAME]; 
-    DWORD cchValue = MAX_VALUE_NAME; 
- 
+
+    DWORD i = 0, j = 0, retCode = 0;
+
+    TCHAR  achValue[MAX_VALUE_NAME] = {'\0'};
+    DWORD cchValue = MAX_VALUE_NAME;
+
     // Get the class name and the value count. 
-    retCode = RegQueryInfoKey(
+    retCode = ::RegQueryInfoKey(
         hKey,                    // key handle 
         achClass,                // buffer for class name 
         &cchClassName,           // size of class string 
@@ -56,71 +56,76 @@ void QueryKey(HKEY hKey)
         &cbMaxValueData,         // longest value data 
         &cbSecurityDescriptor,   // security descriptor 
         &ftLastWriteTime);       // last write time 
- 
+
+
+
     // Enumerate the subkeys, until RegEnumKeyEx fails.
-    
+
     if (cSubKeys)
     {
-        printf( "\nNumber of subkeys: %d\n", cSubKeys);
+        printf("\nNumber of subkeys: %d\n", cSubKeys);
 
-        for (i=0; i<cSubKeys; i++) 
-        { 
+        for (i = 0; i < cSubKeys; i++)
+        {
             cbName = MAX_KEY_LENGTH;
-            retCode = RegEnumKeyEx(hKey, i,
-                     achKey, 
-                     &cbName, 
-                     NULL, 
-                     NULL, 
-                     NULL, 
-                     &ftLastWriteTime); 
-            if (retCode == ERROR_SUCCESS) 
+            retCode = ::RegEnumKeyEx(hKey, i,
+                achKey,
+                &cbName,
+                NULL,
+                NULL,
+                NULL,
+                &ftLastWriteTime);
+
+            if (retCode == ERROR_SUCCESS)
             {
-                _tprintf(TEXT("(%d) %s\n"), i+1, achKey);
+                _tprintf(TEXT("(%d) %s\n"), i + 1, achKey);
             }
         }
-    } 
- 
+    }
+
     // Enumerate the key values. 
 
-    if (cValues) 
+    if (cValues)
     {
-        printf( "\nNumber of values: %d\n", cValues);
+        printf("\nNumber of values: %d\n", cValues);
 
-        for (i=0, retCode=ERROR_SUCCESS; i<cValues; i++) 
-        { 
-            cchValue = MAX_VALUE_NAME; 
-            achValue[0] = '\0'; 
-            retCode = RegEnumValue(hKey, i, 
-                achValue, 
-                &cchValue, 
-                NULL, 
+        for (i = 0; i < cValues; i++)
+        {
+            cchValue = MAX_VALUE_NAME;
+            achValue[0] = '\0';
+            retCode = ::RegEnumValue(hKey, i,
+                achValue,
+                &cchValue,
+                NULL,
                 NULL,
                 NULL,
                 NULL);
- 
-            if (retCode == ERROR_SUCCESS ) 
-            { 
-                _tprintf(TEXT("(%d) %s\n"), i+1, achValue); 
-            } 
+
+            if (retCode == ERROR_SUCCESS)
+            {
+                _tprintf(TEXT("(%d) %s\n"), i + 1, achValue);
+            }
         }
     }
 }
 
 int __cdecl _tmain()
 {
-   HKEY hTestKey;
+    HKEY hTestKey = 0;
 
-   if( RegOpenKeyEx( HKEY_CURRENT_USER,
+    if (::RegOpenKeyEx(HKEY_CURRENT_USER,
         TEXT("SOFTWARE\\Microsoft"),
         0,
         KEY_READ,
         &hTestKey) == ERROR_SUCCESS
-      )
-   {
-      QueryKey(hTestKey);
-   }
-   
-   RegCloseKey(hTestKey);
+        )
+    {
+        QueryKey(hTestKey);
+    }
+
+    ::RegCloseKey(hTestKey);
+
+    return 0;
 }
 ```
 


### PR DESCRIPTION
This assignment - retCode=ERROR_SUCCESS - in for loop within "void QueryKey(HKEY hKey)" is nonsense and useless.  
**POC:** The return value that ERROR_SUCCESS indicates success and nonzero error code indicates a failure of RegEnumValue function. Therefore, if there is no ERROR_SUCCESS value returned by "RegEnumValue" function the "achValue (lpValueName)" parameter which "[out] Pointer to a buffer that receives the name of the value, including the terminating null character", expecting this equality is created to use for a first time or later, it does not matter,  this buffer wont have store the desired results, more precisely will be empty and will print nothing (+logically). 

```
        for (i=0, retCode=ERROR_SUCCESS; i<cValues; i++) 
        { 
            cchValue = MAX_VALUE_NAME; 
            achValue[0] = '\0'; 
            retCode = RegEnumValue(hKey, i, 
                achValue, 
                &cchValue, 
                NULL, 
                NULL,
                NULL,
                NULL);
 
            if (retCode == ERROR_SUCCESS ) 
            { 
                _tprintf(TEXT("(%d) %s\n"), i+1, achValue); 
            } 
        }
```

Left here the results from another keys - System\\\GameConfigStore - of the same hive - HKEY_CURRENT_USER - just for an example on my machine:

Number of subkeys: 2
(1) Children
(2) Parents

Number of values: 7
(1) GameDVR_Enabled
(2) GameDVR_FSEBehaviorMode
(3) Win32_AutoGameModeDefaultProfile
(4) Win32_GameModeRelatedProcesses
(5) GameDVR_HonorUserFSEBehaviorMode
(6) GameDVR_DXGIHonorFSEWindowsCompatible
(7) GameDVR_EFSEFeatureFlags

In addition, initialized a non-initialized variables, arrays and etc, moreover added double colons before the some function names to emphasize that they are part of Windows API and added "return 0;" statement to the "int __cdecl _tmain()" function for correctness.