### PR TITLE
needs <stdio.h>

### DIFF
--- a/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
+++ b/desktop-src/ToolHelp/taking-a-snapshot-and-viewing-processes.md
@@ -17,6 +17,7 @@ A simple error-reporting function, `printError`, displays the reason for any fai
 #include <windows.h>
 #include <tlhelp32.h>
 #include <tchar.h>
+#include <stdio.h>
 
 //  Forward declarations:
 BOOL GetProcessList( );


### PR DESCRIPTION
otherwise VS2017 and VS2022 build results in compilation errors like error C3861: 'printf': identifier not found