### PR TITLE
Fix grammatical typo in desktop-src/desktop-programming.md

### DIFF
--- a/desktop-src/desktop-programming.md
+++ b/desktop-src/desktop-programming.md
@@ -50,7 +50,7 @@ For more information, see [Modernize your desktop apps](/windows/apps/desktop/mo
 
 ## C++/WinRT
 
-Optionally, you can configure your development computer to use [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/). C++/WinRT is an entirely standard modern C++17 language projection enables you to easily consume Windows Runtime APIs Windows Runtime (WinRT) APIs from your C++ Win32 desktop application. C++/WinRT is implemented as a header-file-based library.
+Optionally, you can configure your development computer to use [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/). C++/WinRT is an entirely standard modern C++17 language projection that enables you to easily consume Windows Runtime APIs Windows Runtime (WinRT) APIs from your C++ Win32 desktop application. C++/WinRT is implemented as a header-file-based library.
 
 To configure your project for C++/WinRT:
 


### PR DESCRIPTION
Adds missing "that", properly joining the restrictive clause to the beginning of the sentence.