### PR TITLE
WM_POWERBROADCAST: Add RegisterSuspendResumeNotification link

### DIFF
--- a/desktop-src/Power/wm-powerbroadcast.md
+++ b/desktop-src/Power/wm-powerbroadcast.md
@@ -82,3 +82,4 @@ The following messages are not supported on any of the operating systems specifi
 
 * [WM\_POWERBROADCAST Messages](wm-powerbroadcast-messages.md)
 * [Power Management Messages](power-management-messages.md)
+* [RegisterSuspendResumeNotification](/windows/win32/api/winuser/nf-winuser-registersuspendresumenotification)


### PR DESCRIPTION
Applications need to call this function first in order to enable delivery of `PBT_APMSUSPEND`, `PBT_APMRESUMEAUTOMATIC` & `PBT_APMRESUMESUSPEND` events. It's therefore natural to add a link to `RegisterSuspendResumeNotification` in the `WM_POWERBROADCAST` docs.

The documentation should ideally also be updated to mention that `PBT_APMSUSPEND`, `PBT_APMRESUMEAUTOMATIC` & `PBT_APMRESUMESUSPEND` events are not delivered by default. This is at least the behavior I'm observing when testing on Win10 and Win11. However, I would prefer if someone from Microsoft could do this, since they have a better picture of the intended behavior.