### PR TITLE
Fix incorrect cleanup order and error handling for global atom table …

### DIFF
--- a/desktop-src/dataxchg/using-dynamic-data-exchange.md
+++ b/desktop-src/dataxchg/using-dynamic-data-exchange.md
@@ -90,10 +90,10 @@ if ((atomApplication = GlobalAddAtom("Server")) != 0)
             WM_DDE_ACK, 
             (WPARAM) hwndServerDDE, 
             MAKELONG(atomApplication, atomTopic)); 
-        GlobalDeleteAtom(atomApplication); 
+        GlobalDeleteAtom(atomTopic); 
     } 
  
-    GlobalDeleteAtom(atomTopic); 
+    GlobalDeleteAtom(atomApplication); 
 } 
  
 if ((atomApplication == 0) || (atomTopic == 0)) 


### PR DESCRIPTION
…entries

The code example checks if `GlobalAddAtom()` fails and appears to intend to only call `GlobalDeleteAtom()` on atoms which were successfully allocated. However, the logic was flawed and would try to delete an atom which had failed to be allocated. This change corrects the error handling.