### PR TITLE
Update taskschedulerschema-delay-registrationtriggertype-element.md

### DIFF
--- a/desktop-src/TaskSchd/taskschedulerschema-delay-registrationtriggertype-element.md
+++ b/desktop-src/TaskSchd/taskschedulerschema-delay-registrationtriggertype-element.md
@@ -55,7 +55,7 @@ The following XML defines a registration trigger delay that allows a 5 minute de
     <Enabled></Enabled>
     <Repetition></Repetition>
     <ExecutionTimeLimit></ExecutionTimeLimit>
-    <Delay>PT5M<Delay>
+    <Delay>PT5M</Delay>
  </BootTrigger>
 ```
 


### PR DESCRIPTION
Fix XML closing tag in TaskScheduler documentation example, Delay wasn't closed.