### PR TITLE
Update dpi-and-device-independent-pixels.md

### DIFF
--- a/desktop-src/LearnWin32/dpi-and-device-independent-pixels.md
+++ b/desktop-src/LearnWin32/dpi-and-device-independent-pixels.md
@@ -135,8 +135,8 @@ Here is an alternate way to get the DPI setting if you are not using Direct2D:
 void InitializeDPIScale(HWND hwnd)
 {
     HDC hdc = GetDC(hwnd);
-    g_DPIScaleX = GetDeviceCaps(hdc, LOGPIXELSX) / USER_DEFAULT_SCREEN_DPI;
-    g_DPIScaleY = GetDeviceCaps(hdc, LOGPIXELSY) / USER_DEFAULT_SCREEN_DPI;
+    g_DPIScaleX = (float)GetDeviceCaps(hdc, LOGPIXELSX) / USER_DEFAULT_SCREEN_DPI;
+    g_DPIScaleY = (float)GetDeviceCaps(hdc, LOGPIXELSY) / USER_DEFAULT_SCREEN_DPI;
     ReleaseDC(hwnd, hdc);
 }
 ```


### PR DESCRIPTION
Both of  the value `GetDeviceCaps` returns and `USER_DEFAULT_SCREEN_DPI` are `int`, integer division result is truncated.

If at 144 DPI, the division result will be truncated to 1.0f, but expect 1.5f.