### PR TITLE
More info in `power-setting-guids.md`

### DIFF
--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -94,6 +94,8 @@ The **Data** member has no information and can be ignored.
 
 The state of the lid has changed (open vs. closed). The callback won't be called until a lid device is found and its current state is known.
 
+The **Data** member is a **DWORD** that indicates the current lid state:
+
 0x0 - The lid is closed.
 
 0x1 - The lid is opened.

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -75,9 +75,9 @@ The **Data** member is a **DWORD** with a value from the **USER_ACTIVITY_PRESENC
 
 **PowerUserPresent** (0) - The user is present in any local or remote session on the system.
 
-**PowerUserNotPresent** (1)
+**PowerUserNotPresent** (1) - The user is not present in any local or remote session on the system.
 
-**PowerUserInactive** (2) - The user is not present in any local or remote session on the system.
+**PowerUserInactive** (2) - The user is not active in any local or remote session on the system.
 
 ---
 

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -68,7 +68,7 @@ This notification is sent only services and other programs running in session 0.
 
 **Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:** This notification is available starting with Windows 8 and Windows Server 2012.
 
-The **Data** member is a **DWORD** with one of the following values from the **USER_ACTIVITY_PRESENCE** enumeration:
+The **Data** member is a **DWORD** with a value from the **USER_ACTIVITY_PRESENCE** enumeration:
 
 **PowerUserPresent** (0) - The user is present in any local or remote session on the system.
 
@@ -191,7 +191,7 @@ The user status associated with the application's session has changed.
 
 This notification is sent only to user-mode applications running in an interactive session. Services and other programs running in session 0 should register for **GUID\_GLOBAL\_USER\_PRESENCE**.
 
-The **Data** member is a **DWORD** with one of the following values from the **USER_ACTIVITY_PRESENCE** enumeration:
+The **Data** member is a **DWORD** with a value from the **USER_ACTIVITY_PRESENCE** enumeration:
 
 **PowerUserPresent** (0) - The user is providing input to the session.
 

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -177,7 +177,7 @@ The **Data** member is a **DWORD** with a value from the **MONITOR_DISPLAY_STATE
 **PowerMonitorDim** (2) - The display is dimmed.
 
 > [!Note]
-> All applications that run in an interactive user-mode session should use this setting. When kernel-mode applications register for monitoring the status, they should use **GUID\_CONSOLE\_DISPLAY\_STATUS** instead.
+> All applications that run in an interactive user-mode session should use this setting. When kernel-mode applications register for monitoring the status, they should use **GUID\_CONSOLE\_DISPLAY\_STATE** instead.
 
 ---
 

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -72,6 +72,8 @@ The **Data** member is a **DWORD** with one of the following values from the **U
 
 **PowerUserPresent** (0) - The user is present in any local or remote session on the system.
 
+**PowerUserNotPresent** (1)
+
 **PowerUserInactive** (2) - The user is not present in any local or remote session on the system.
 
 ---
@@ -192,6 +194,8 @@ This notification is sent only to user-mode applications running in an interacti
 The **Data** member is a **DWORD** with one of the following values from the **USER_ACTIVITY_PRESENCE** enumeration:
 
 **PowerUserPresent** (0) - The user is providing input to the session.
+
+**PowerUserNotPresent** (1)
 
 **PowerUserInactive** (2) - The user activity timeout has elapsed with no interaction from the user.
 

--- a/desktop-src/Power/power-setting-guids.md
+++ b/desktop-src/Power/power-setting-guids.md
@@ -56,6 +56,9 @@ The **Data** member is a **DWORD** with a value from the **MONITOR_DISPLAY_STATE
 
 **PowerMonitorDim** (2) - The display is dimmed.
 
+> [!Note]
+> See also **GUID\_SESSION\_DISPLAY\_STATUS**.
+
 ---
 
 <span id="GUID_GLOBAL_USER_PRESENCE"></span>


### PR DESCRIPTION
 This is a *possible* correction, after the unresolved questions in #1772 weren't addressed.

- Please verify it for correctness.
- It would also be nice, if `PowerUserNotPresent` could get a description. I can't provide it.

The unresolved questions were:

> - `GUID_GLOBAL_USER_PRESENCE` and `GUID_SESSION_USER_PRESENCE`: What's with the other values from the `USER_ACTIVITY_PRESENCE` enum? Are they also possible values? Probably only `PowerUserNotPresent`.
> - `GUID_LIDSWITCH_STATE_CHANGE`: Of what data type is the `Data` member? `DWORD` as for most other GUIDs or is reading beyond the `UCHAR` from the [`POWERBROADCAST_SETTING`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-powerbroadcast_setting) struct invalid?

EDIT: We also need a clarification I can't provide: With `GUID_CONSOLE_DISPLAY_STATE` (and probably also `GUID_SESSION_DISPLAY_STATUS`), I get an initial event that informs me about the current monitor state, although the monitor state didn't change. *Is that initial change-unrelated message guaranteed to be sent* (so one can reliably ignore the first message)?