### PR TITLE
Update dx-graphics-hlsl-packing-rules.md

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-packing-rules.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-packing-rules.md
@@ -131,7 +131,7 @@ You could pack an array more aggressively. For instance, given an array of float
 
 
 ```
-float4 array[16];
+float array[64];
 ```
 
 
@@ -140,7 +140,7 @@ You could choose to pack it like this, without any spaces in the array:
 
 
 ```
-static float2 aggressivePackArray[32] = (float2[32])array;  
+float4 aggressivelyPackedArray[16];  
 ```
 
 


### PR DESCRIPTION
I don't understand the example as given and believe it is written in error. The documentation earlier in this page states 'every element in an array is stored in a four-component vector.' So why is the problematic example stated as float4[16] when that already is a completely packed array of 64 floats? Also, the modification isn't clear - why is it declaring a 'static' array and trying to cast the original array? float2[32] contains enough space for 128 floats due to each float2 getting padded out to the size of a float4. I think it is clearer to simply offer a rewritten definition of the array.