### PR TITLE
Fix "Initializing the symbol handler" example to respect the documentation for `SymInitialize`

### DIFF
--- a/desktop-src/Debug/initializing-the-symbol-handler.md
+++ b/desktop-src/Debug/initializing-the-symbol-handler.md
@@ -17,11 +17,20 @@ Specifying **NULL** as the second parameter of [**SymInitialize**](/windows/desk
 
 ```C++
 DWORD  error;
+HANDLE hCurrentProcess;
 HANDLE hProcess;
 
 SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
 
-hProcess = GetCurrentProcess();
+hCurrentProcess = GetCurrentProcess();
+
+if (!DuplicateHandle(hCurrentProcess, hCurrentProcess, hCurrentProcess, &hProcess, 0, FALSE, DUPLICATE_SAME_ACCESS))
+{
+    // DuplicateHandle failed
+    error = GetLastError();
+    printf("DuplicateHandle returned error : %d\n", error);
+    return FALSE;
+}
 
 if (!SymInitialize(hProcess, NULL, TRUE))
 {


### PR DESCRIPTION
[The documentation for `SymInitialize` says:](https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-syminitialize)

> Do not use the handle returned by [GetCurrentProcess](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess). The handle used must be unique to avoid sharing a session with another component, and using [GetCurrentProcess](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess) can have unexpected results when multiple components are attempting to use dbghelp to inspect the current process. Using [GetCurrentProcess](https://learn.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess) when debugging another process will also cause functions like [SymLoadModuleEx](https://learn.microsoft.com/en-us/windows/desktop/api/dbghelp/nf-dbghelp-symloadmoduleex) to have unexpected results.

However, the linked example then proceeds to use the `GetCurrentProcess`. This PR fixes the example by creating a new handle to the same process via `DuplicateHandle`.