### PR TITLE
Update named-pipe-server-using-overlapped-i-o.md

### DIFF
--- a/desktop-src/ipc/named-pipe-server-using-overlapped-i-o.md
+++ b/desktop-src/ipc/named-pipe-server-using-overlapped-i-o.md
@@ -60,7 +60,7 @@ int _tmain(VOID)
 { 
    DWORD i, dwWait, cbRet, dwErr; 
    BOOL fSuccess; 
-   LPTSTR lpszPipename = TEXT("\\\\.\\pipe\\mynamedpipe"); 
+   LPCTSTR lpszPipename = TEXT("\\\\.\\pipe\\mynamedpipe"); 
  
 // The initial loop creates several instances of a named pipe 
 // along with an event object for each instance.  An 


### PR DESCRIPTION
fix variable type error