### PR TITLE
Update creating-a-child-process-with-redirected-input-and-output.md

### DIFF
--- a/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
+++ b/desktop-src/ProcThread/creating-a-child-process-with-redirected-input-and-output.md
@@ -35,7 +35,7 @@ HANDLE g_hInputFile = NULL;
 void CreateChildProcess(void); 
 void WriteToPipe(void); 
 void ReadFromPipe(void); 
-void ErrorExit(PTSTR); 
+void ErrorExit(PCTSTR); 
  
 int _tmain(int argc, TCHAR *argv[]) 
 { 
@@ -212,7 +212,7 @@ void ReadFromPipe(void)
    } 
 } 
  
-void ErrorExit(PTSTR lpszFunction) 
+void ErrorExit(PCTSTR lpszFunction) 
 
 // Format a readable error message, display a message box, 
 // and exit from the application.


### PR DESCRIPTION
replace type *PTSTR* in `void ErrorExit(PTSTR); (line 38)' and `void ErrorExit(PTSTR lpszFunction) (line 215)' of the *Creating a Child Process with Redirected Input and Output* document with *PCSTR*