### PR TITLE
Update client-impersonation.md to reflect RegDisablePredefinedCache note

### DIFF
--- a/desktop-src/SecAuthZ/client-impersonation.md
+++ b/desktop-src/SecAuthZ/client-impersonation.md
@@ -22,6 +22,7 @@ The Microsoft Windows API provides the following functions to begin an impersona
 
 For most of these impersonations, the impersonating thread can revert to its own security context by calling the [**RevertToSelf**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-reverttoself) function. The exception is the RPC impersonation, in which the RPC server application calls [**RpcRevertToSelf**](/windows/desktop/api/rpcdce/nf-rpcdce-rpcreverttoself) or [**RpcRevertToSelfEx**](/windows/desktop/api/rpcdce/nf-rpcdce-rpcreverttoselfex) to revert to its own security context.
 
+Note: If you are impersonating a user from a win32 service, and you are calling APIs that rely on user environment variables, you may need to call [**RegDisablePredefinedCache**](/windows/win32/api/winreg/nf-winreg-regdisablepredefinedcache) before you do the impersonation. 
  
 
  

--- a/desktop-src/SecAuthZ/client-impersonation.md
+++ b/desktop-src/SecAuthZ/client-impersonation.md
@@ -22,7 +22,7 @@ The Microsoft Windows API provides the following functions to begin an impersona
 
 For most of these impersonations, the impersonating thread can revert to its own security context by calling the [**RevertToSelf**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-reverttoself) function. The exception is the RPC impersonation, in which the RPC server application calls [**RpcRevertToSelf**](/windows/desktop/api/rpcdce/nf-rpcdce-rpcreverttoself) or [**RpcRevertToSelfEx**](/windows/desktop/api/rpcdce/nf-rpcdce-rpcreverttoselfex) to revert to its own security context.
 
-Note: If you are impersonating a user from a win32 service, and you are calling APIs that rely on user environment variables, you may need to call [**RegDisablePredefinedCache**](/windows/win32/api/winreg/nf-winreg-regdisablepredefinedcache) before you do the impersonation. 
+Note: If you're impersonating a user from a Win32 service, and you're calling APIs that rely on user environment variables, you may need to call [**RegDisablePredefinedCache**](/windows/win32/api/winreg/nf-winreg-regdisablepredefinedcache) before you do the impersonation. 
  
 
  


### PR DESCRIPTION
add a note to potentially call RegDisablePredefinedCache  during impersonation within a service if calling APIs that modify environment variables.