### PR TITLE
Update semantic table for HLSL

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-semantics.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-semantics.md
@@ -245,7 +245,7 @@ A few of the Direct3D 10 and later semantics map directly to Direct3D 9 semantic
 | SV\_Target | COLOR |
 
 > [!]
-> Note to Direct3D 9 developers: For Direct3D 9 targets, shader semantics must map to valid Direct3D 9 semantics. For backwards compatibility, FXC treats POSITION0 (and its variant names) as SV\_Position. FXC treats COLOR as SV\_TARGET. DXC and newer compilers consider POSITION[n] and COLOR as user-defined semantics.
+> Note to Direct3D 9 developers: For Direct3D 9 targets, shader semantics must map to valid Direct3D 9 semantics. For backwards compatibility, FXC treats POSITION0 (and its variant names) as SV\_Position. FXC treats COLOR as SV\_TARGET. DXC and newer compilers consider POSITION\[n\] and COLOR as user-defined semantics.
 
 - [Mapping to Direct3D 9 Semantics](#mapping-to-direct3d-9-semantics)
 - [Direct3D 9 VPOS and Direct3D 10 SV\_Position](#direct3d-9-vpos-and-direct3d-10-sv_position)

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-semantics.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-semantics.md
@@ -98,7 +98,7 @@ These semantics have meaning when attached to a vertex-shader parameter. These s
 |-|-|-|
 | COLOR\[n\] | Diffuse or specular color | float4 |
 | FOG | Vertex fog | float |
-| POSITION\[n\] | Position of a vertex in homogenous space. Compute position in screen-space by dividing (x,y,z) by w. Every vertex shader must write out a parameter with this semantic. | float4 |
+| POSITION\[n\] | Position of a vertex in homogenous space. Compute position in screen-space by dividing (x,y,z) by w. Every vertex shader must write out a parameter with this semantic. **NOTE: This semantic is available in Direct3D 9. For Direct3D 10 and later, use SV_Position instead.**| float4 |
 | PSIZE | Point size | float |
 | TESSFACTOR\[n\] | Tessellation factor | float |
 
@@ -245,7 +245,7 @@ A few of the Direct3D 10 and later semantics map directly to Direct3D 9 semantic
 | SV\_Target | COLOR |
 
 > [!]
-> Note to Direct3D 9 developers: For Direct3D 9 targets, shader semantics must map to valid Direct3D 9 semantics. For backwards compatibility POSITION0 (and its variant names) is treated as SV\_Position, COLOR is treated as SV\_TARGET.
+> Note to Direct3D 9 developers: For Direct3D 9 targets, shader semantics must map to valid Direct3D 9 semantics. For backwards compatibility, FXC treats POSITION0 (and its variant names) as SV\_Position. FXC treats COLOR as SV\_TARGET. DXC and newer compilers consider POSITION[n] and COLOR as user-defined semantics.
 
 - [Mapping to Direct3D 9 Semantics](#mapping-to-direct3d-9-semantics)
 - [Direct3D 9 VPOS and Direct3D 10 SV\_Position](#direct3d-9-vpos-and-direct3d-10-sv_position)


### PR DESCRIPTION
The current HLSL compiler (DXC) does not handle backward compatibility the way the documents outlines it.

COLOR is not considered to be system semantic, and POSITION is not expected to be either.

As we want to fix those inconsistencies at the language/compiler level, we might want to update this documentation which is the main one showing up when searching for HLSL semantics on a search engine.