### PR TITLE
Fix reversed descriptions for Direct2D Morphology effect's Erode/Dilate

### DIFF
--- a/desktop-src/Direct2D/morphology.md
+++ b/desktop-src/Direct2D/morphology.md
@@ -69,8 +69,8 @@ m_d2dContext->EndDraw();
 
 | Name                           | Description                                                    |
 |--------------------------------|----------------------------------------------------------------|
-| D2D1\_MORPHOLOGY\_MODE\_ERODE  | The maximum value from each RGB channel in the kernel is used. |
-| D2D1\_MORPHOLOGY\_MODE\_DILATE | The minimum value from each RGB channel in the kernel is used. |
+| D2D1\_MORPHOLOGY\_MODE\_ERODE  | The minimum value from each RGB channel in the kernel is used. |
+| D2D1\_MORPHOLOGY\_MODE\_DILATE | The maximum value from each RGB channel in the kernel is used. |
 
 
 


### PR DESCRIPTION
(See also the matching PR over in the `sdk-api` repository: https://github.com/MicrosoftDocs/sdk-api/pull/1794)

Erode performs a `min` calculation, while Dilate performs a `max` calculation. These descriptions are currently reversed.

See also: https://en.wikipedia.org/wiki/Erosion_(morphology)

> In other words the erosion of a point is the **minimum** of the points in its neighborhood

And https://en.wikipedia.org/wiki/Dilation_(morphology)

> Thus, dilation is a particular case of order statistics filters, returning the **maximum** value within a moving window