### PR TITLE
Fix build error "cannot convert from const wchar_t[13] to LPTSTR"

### DIFF
--- a/desktop-src/Debug/retrieving-the-last-error-code.md
+++ b/desktop-src/Debug/retrieving-the-last-error-code.md
@@ -17,7 +17,7 @@ The following example includes an error-handling function that prints the error 
 #include <windows.h>
 #include <strsafe.h>
 
-void ErrorExit(LPTSTR lpszFunction) 
+void ErrorExit(LPCTSTR lpszFunction) 
 { 
     // Retrieve the system error message for the last-error code
 


### PR DESCRIPTION
Fix build error "cannot convert from const wchar_t[13] to LPTSTR" in the example by updating type LPTSTR to LPCTSTR.