### PR TITLE
Update lParam description of WM_NCACTIVATE message

### DIFF
--- a/desktop-src/winmsg/wm-ncactivate.md
+++ b/desktop-src/winmsg/wm-ncactivate.md
@@ -33,9 +33,9 @@ Indicates when a title bar or icon needs to be changed to indicate an active or 
 *lParam* 
 </dt> <dd>
 
-When a [visual style](../controls/themes-overview.md) is active for this window, this parameter is not used.
+If this parameter is set to -1, [**DefWindowProc**](/windows/desktop/api/winuser/nf-winuser-defwindowproca) does not repaint the nonclient area to reflect the state change.
 
-When a visual style is not active for this window, this parameter is a handle to an optional update region for the nonclient area of the window. If this parameter is set to -1, [**DefWindowProc**](/windows/desktop/api/winuser/nf-winuser-defwindowproca) does not repaint the nonclient area to reflect the state change.
+In other case. if *wParam* is **TRUE**, it indicates the **HWND** handle of the previously active window. If *wParam* is **FALSE**, it indicates the **HWND** handle of the window that is going to be activated. This can be **NULL** if the window that was previously active (or is going to be activated) is from other application.
 
 </dd> </dl>
 


### PR DESCRIPTION
Since I have knowledge, the lParam was an HWND of the other window involved in the activation/deactivation process. I don't know the Windows internals so the description might be wrong, but this is what in the practice is going on.