### PR TITLE
Correct copy/paste error in Final-State-Based Multicast Programming page

### DIFF
--- a/desktop-src/WinSock/final-state-based-multicast-programming.md
+++ b/desktop-src/WinSock/final-state-based-multicast-programming.md
@@ -25,7 +25,7 @@ The following table describes the Windows Sockets IOCTLs used for multicast prog
 
 Note that the **SIOCSMSFILTER** and **SIOCGMSFILTER** IOCTLS are available on Windows Vista and later.
 
-Using these IOCTLs for multicast programming has performance benefits when working with large source lists. For more information about the parameters and settings associated with using SIO\_GET\_MULTICAST\_FILTER or SIO\_SET\_MULTICAST\_FILTER, consult the [**GROUP\_FILTER**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-group_filter) reference page. For more information about the parameters and settings associated with using SIO\_GET\_MULTICAST\_FILTER or SIO\_SET\_MULTICAST\_FILTER, consult the [**ip\_msfilter**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-ip_msfilter) reference page.
+Using these IOCTLs for multicast programming has performance benefits when working with large source lists. For more information about the parameters and settings associated with using SIOCSMSFILTER or SIOCSMSFILTER, consult the [**GROUP\_FILTER**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-group_filter) reference page. For more information about the parameters and settings associated with using SIO\_GET\_MULTICAST\_FILTER or SIO\_SET\_MULTICAST\_FILTER, consult the [**ip\_msfilter**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-ip_msfilter) reference page.
 
  
 

--- a/desktop-src/WinSock/final-state-based-multicast-programming.md
+++ b/desktop-src/WinSock/final-state-based-multicast-programming.md
@@ -25,7 +25,7 @@ The following table describes the Windows Sockets IOCTLs used for multicast prog
 
 Note that the **SIOCSMSFILTER** and **SIOCGMSFILTER** IOCTLS are available on Windows Vista and later.
 
-Using these IOCTLs for multicast programming has performance benefits when working with large source lists. For more information about the parameters and settings associated with using SIOCSMSFILTER or SIOCSMSFILTER, consult the [**GROUP\_FILTER**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-group_filter) reference page. For more information about the parameters and settings associated with using SIO\_GET\_MULTICAST\_FILTER or SIO\_SET\_MULTICAST\_FILTER, consult the [**ip\_msfilter**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-ip_msfilter) reference page.
+Using these IOCTLs for multicast programming has performance benefits when working with large source lists. For more information about the parameters and settings associated with using SIOCGMSFILTER or SIOCSMSFILTER, consult the [**GROUP\_FILTER**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-group_filter) reference page. For more information about the parameters and settings associated with using SIO\_GET\_MULTICAST\_FILTER or SIO\_SET\_MULTICAST\_FILTER, consult the [**ip\_msfilter**](/windows/desktop/api/Ws2ipdef/ns-ws2ipdef-ip_msfilter) reference page.
 
  
 


### PR DESCRIPTION
Duplicate mentions of SIO_[GS]ET_MULTICAST_FILTER should have been to SIOC[GS]MSFILTER in first mentions.