### PR TITLE
Update ldrdllnotification.md

### DIFF
--- a/desktop-src/DevNotes/ldrdllnotification.md
+++ b/desktop-src/DevNotes/ldrdllnotification.md
@@ -63,16 +63,17 @@ The reason that the notification callback function was called. This parameter ca
 
 A pointer to a constant **LDR\_DLL\_NOTIFICATION** union that contains notification data. This union has the following definition:
 
-``` syntax
+```C++
 typedef union _LDR_DLL_NOTIFICATION_DATA {
     LDR_DLL_LOADED_NOTIFICATION_DATA Loaded;
     LDR_DLL_UNLOADED_NOTIFICATION_DATA Unloaded;
 } LDR_DLL_NOTIFICATION_DATA, *PLDR_DLL_NOTIFICATION_DATA;
+typedef const LDR_DLL_NOTIFICATION_DATA *PCLDR_DLL_NOTIFICATION_DATA;
 ```
 
 The **LDR\_DLL\_LOADED\_NOTIFICATION\_DATA** structure has the following definition:
 
-``` syntax
+```C++
 typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA {
     ULONG Flags;                    //Reserved.
     PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.
@@ -84,7 +85,7 @@ typedef struct _LDR_DLL_LOADED_NOTIFICATION_DATA {
 
 The **LDR\_DLL\_UNLOADED\_NOTIFICATION\_DATA** structure has the following definition:
 
-``` syntax
+```C++
 typedef struct _LDR_DLL_UNLOADED_NOTIFICATION_DATA {
     ULONG Flags;                    //Reserved.
     PCUNICODE_STRING FullDllName;   //The full path name of the DLL module.


### PR DESCRIPTION
- Add missing `PCLDR_DLL_NOTIFICATION_DATA` type definition, which is presenting in `LdrDllNotification` declaration in `Syntax` section:
```C++
VOID CALLBACK LdrDllNotification(
  _In_     ULONG                       NotificationReason,
  _In_     PCLDR_DLL_NOTIFICATION_DATA NotificationData,
  _In_opt_ PVOID                       Context
);
```

- The programming language used in sample code fragment should be `C++`