### PR TITLE
pe-format: MIPS Updates

### DIFF
--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -140,7 +140,10 @@ The Machine field has one of the following values, which specify the CPU type. A
 | IMAGE\_FILE\_MACHINE\_MIPSFPU16 <br/> | 0x466 <br/>  | MIPS16 with FPU <br/>                                                             |
 | IMAGE\_FILE\_MACHINE\_POWERPC <br/>   | 0x1f0 <br/>  | Power PC little endian <br/>                                                      |
 | IMAGE\_FILE\_MACHINE\_POWERPCFP <br/> | 0x1f1 <br/>  | Power PC with floating point support <br/>                                        |
+| IMAGE\_FILE\_MACHINE\_R3000BE <br/>   | 0x160 <br/>  | MIPS big endian <br/>                                                             |
+| IMAGE\_FILE\_MACHINE\_R3000 <br/>     | 0x162 <br/>  | MIPS little endian <br/>                                                          |
 | IMAGE\_FILE\_MACHINE\_R4000 <br/>     | 0x166 <br/>  | MIPS little endian <br/>                                                          |
+| IMAGE\_FILE\_MACHINE\_R10000 <br/>    | 0x168 <br/>  | MIPS little endian <br/>                                                          |
 | IMAGE\_FILE\_MACHINE\_RISCV32 <br/>   | 0x5032 <br/> | RISC-V 32-bit address space <br/>                                                 |
 | IMAGE\_FILE\_MACHINE\_RISCV64 <br/>   | 0x5064 <br/> | RISC-V 64-bit address space <br/>                                                 |
 | IMAGE\_FILE\_MACHINE\_RISCV128 <br/>  | 0x5128 <br/> | RISC-V 128-bit address space <br/>                                                |

--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -140,10 +140,10 @@ The Machine field has one of the following values, which specify the CPU type. A
 | IMAGE\_FILE\_MACHINE\_MIPSFPU16 <br/> | 0x466 <br/>  | MIPS16 with FPU <br/>                                                             |
 | IMAGE\_FILE\_MACHINE\_POWERPC <br/>   | 0x1f0 <br/>  | Power PC little endian <br/>                                                      |
 | IMAGE\_FILE\_MACHINE\_POWERPCFP <br/> | 0x1f1 <br/>  | Power PC with floating point support <br/>                                        |
-| IMAGE\_FILE\_MACHINE\_R3000BE <br/>   | 0x160 <br/>  | MIPS big endian <br/>                                                             |
-| IMAGE\_FILE\_MACHINE\_R3000 <br/>     | 0x162 <br/>  | MIPS little endian <br/>                                                          |
-| IMAGE\_FILE\_MACHINE\_R4000 <br/>     | 0x166 <br/>  | MIPS little endian <br/>                                                          |
-| IMAGE\_FILE\_MACHINE\_R10000 <br/>    | 0x168 <br/>  | MIPS little endian <br/>                                                          |
+| IMAGE\_FILE\_MACHINE\_R3000BE <br/>   | 0x160 <br/>  | MIPS I compatible 32-bit big endian <br/>                                         |
+| IMAGE\_FILE\_MACHINE\_R3000 <br/>     | 0x162 <br/>  | MIPS I compatible 32-bit little endian <br/>                                      |
+| IMAGE\_FILE\_MACHINE\_R4000 <br/>     | 0x166 <br/>  | MIPS III compatible 64-bit little endian <br/>                                    |
+| IMAGE\_FILE\_MACHINE\_R10000 <br/>    | 0x168 <br/>  | MIPS IV compatible 64-bit little endian <br/>                                     |
 | IMAGE\_FILE\_MACHINE\_RISCV32 <br/>   | 0x5032 <br/> | RISC-V 32-bit address space <br/>                                                 |
 | IMAGE\_FILE\_MACHINE\_RISCV64 <br/>   | 0x5064 <br/> | RISC-V 64-bit address space <br/>                                                 |
 | IMAGE\_FILE\_MACHINE\_RISCV128 <br/>  | 0x5128 <br/> | RISC-V 128-bit address space <br/>                                                |


### PR DESCRIPTION
Hi,

This PR updated pe-format `Machine Types` for MIPS using known values from https://learn.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants and added clarification text for those values.

We further request Microsoft assistance on two matters:

1. **Allocation of new values**: We would like Microsoft to allocate Machine Type following values to cover more existing architectures:
- `IMAGE_FILE_MACHINE_R4000BE`: MIPS III compatible 64-bit big endian, our educated guess of allocation to that value is `0x164`, this is necessary to cover 64-bit big endian MIPS systems.
- `IMAGE_FILE_MACHINE_MIPS32R6BE`, `IMAGE_FILE_MACHINE_MIPS32R6LE`, `IMAGE_FILE_MACHINE_MIPS64R6BE`, `IMAGE_FILE_MACHINE_MIPS64R6LE`: MIPS Release 6 32/64 bit big/little endian. MIPS Release 6 is no longer backwards compatible with previous releases of the architecture, thus it is necessary to mark them with new machine type. No new relocation type is required.

2. **Clarification on header endianness**: From online sources and observations made on existing Big Endian PE images, we learned that in Microsoft's implementation, headers in PE image are always stored as little-endian byte order regardless of targeting architecture endianness. We would like Microsoft to confirm this behaviour and document it in pe-format if possible.

This PR has similar nature to #1017, please handle it accordingly.

Thanks