### PR TITLE
Update calling-srsetrestorepoint.md

### DIFF
--- a/desktop-src/sr/calling-srsetrestorepoint.md
+++ b/desktop-src/sr/calling-srsetrestorepoint.md
@@ -1,6 +1,6 @@
 ---
 title: Calling SRSetRestorePoint
-description: An application can create a restore point before it causes a significant system change, such as an install, uninstall, or feature update.
+description: An application can create a restore point before it causes a significant system change, such as an installation, uninstallation, or update.
 ms.assetid: 77981e75-8c3f-4ecc-82f4-e88d68df661a
 ms.topic: article
 ms.date: 05/31/2018
@@ -8,29 +8,25 @@ ms.date: 05/31/2018
 
 # Calling SRSetRestorePoint
 
-An application can create a restore point before it causes a significant system change, such as an install, uninstall, or feature update.
+An application can create a restore point before it causes a significant system change, such as an installation, uninstallation, or update.
 
-Installers should create a restore point just prior to installation by calling the [**SRSetRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srsetrestorepointa) function with the **dwEventType** member of the [**RESTOREPOINTINFO**](/windows/win32/api/srrestoreptapi/ns-srrestoreptapi-restorepointinfoa) structure set to BEGIN\_SYSTEM\_CHANGE. To notify System Restore that the installation has been completed, call **SRSetRestorePoint** with **dwEventType** set to END\_SYSTEM\_CHANGE.
+Installers should create a restore point before installation by calling the [**SRSetRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srsetrestorepointa) function with the `dwEventType` member of the [`RESTOREPOINTINFO`](/windows/win32/api/srrestoreptapi/ns-srrestoreptapi-restorepointinfoa) structure set to `BEGIN_SYSTEM_CHANGE`. To notify System Restore that the installation has been completed, call **SRSetRestorePoint** with `dwEventType` set to `END_SYSTEM_CHANGE`.
 
-If the user cancels the application installation, the installer may remove the restore point it created when the installation began. Removing the restore point is optional and can prevent the user from recovering from unintentional changes made by the installer during the cancellation. If the installer is to remove a restore point, it can call the [**SRRemoveRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srremoverestorepoint) function, or call [**SRSetRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srsetrestorepointa) with **dwRestorePointType** set to CANCELLED\_OPERATION, **dwEventType** set to END\_SYSTEM\_CHANGE, and **llSequenceNumber** set to the value returned by the initial call to **SRSetRestorePoint**.
+If the user cancels the application installation, the installer may remove the restore point it created when the installation began. Removing the restore point is optional and can prevent the user from recovering from unintentional changes made by the installer during the cancellation. If the installer is to remove a restore point, it can call the [**SRRemoveRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srremoverestorepoint) function, or call [**SRSetRestorePoint**](/windows/desktop/api/SRRestorePtAPI/nf-srrestoreptapi-srsetrestorepointa) with `dwRestorePointType` set to `CANCELLED_OPERATION`, `dwEventType` set to `END_SYSTEM_CHANGE`, and `llSequenceNumber` set to the value returned by the initial call to **SRSetRestorePoint**.
 
-**Windows 8:  **
+Starting with Windows 8, developers can write applications that create the DWORD value **SystemRestorePointCreationFrequency** under the `HKLM\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore` registry key. The value of this registry key can change the frequency of restore point creation. By default, this key doesn't exist.
 
-A new registry key enables application developers to change the frequency of restore-point creation.
+When an application calls the **SRSetRestorePoint** function to create a restore point, one of the following happens depending on the contents of the key:
 
-Applications should create this key to use it because it will not preexist in the system. The following will apply by default if the key does not exist. If an application calls the **SRSetRestorePoint** function to create a restore point, Windows skips creating this new restore point if any restore points have been created in the last 24 hours. System Restore sets the **IISequenceNumber** member of the [**STATEMGRSTATUS**](/windows/win32/api/srrestoreptapi/ns-srrestoreptapi-statemgrstatus) structure to the sequence number for the restore point created previously in the day and sets the value of the **nStatus** member to **ERROR\_SUCCESS**. The **SRSetRestorePoint** function returns **TRUE**.
+- If the key does not exist (default) and any restore points have been created in the last 24 hours, Windows skips creating this new restore point. System Restore sets the `IISequenceNumber` member of the [`STATEMGRSTATUS`](/windows/win32/api/srrestoreptapi/ns-srrestoreptapi-statemgrstatus) structure to the sequence number for the restore point created previously in the day and sets the value of the `nStatus` member to `ERROR_SUCCESS`. The **SRSetRestorePoint** function returns `TRUE`.
 
-Developers can write applications that create the **DWORD** value **SystemRestorePointCreationFrequency** under the registry key **HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\SystemRestore**. The value of this registry key can change the frequency of restore point creation. The value of this registry key can change the frequency of restore point creation.
+- If the registry key value is 0, system restore does not skip creating the new restore point.
 
-If the application calls **SRSetRestorePoint** to create a restore point, and the registry key value is 0, system restore does not skip creating the new restore point.
-
-If the application calls **SRSetRestorePoint** to create a restore point, and the registry key value is the integer N, system restore skips creating a new restore point if any restore points were created in the previous N minutes.
-
-**Windows 8:  **
+- If the registry key value is the integer N, system restore skips creating a new restore point if any restore points were created in the previous N minutes.
 
 System Restore running on Windows 8 monitors files in the boot volume that are relevant for system restore only. Snapshots of the boot volume created by System Restore running on Windows 8 may be deleted if the snapshot is subsequently exposed by an earlier version of Windows. Note that although there is only one system volume, there is one boot volume for each operating system in a multi-boot system.
 
-Developers can write applications that create the **DWORD** value **ScopeSnapshots** under the registry key **HKLM\\Software\\Microsoft\\Windows NT\\CurrentVersion\\SystemRestore**. If this registry key value is 0, System Restore creates snapshots of the boot volume in the same way as in earlier versions of Windows. If this value is deleted, System Restore running on Windows 8 resumes creating snapshots that monitor files in the boot volume that are relevant for system restore only.
+Developers can write applications that create the DWORD value **ScopeSnapshots** under `HKLM\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore` the registry key. If this registry key value is 0, System Restore creates snapshots of the boot volume in the same way as in earlier versions of Windows. If this value is deleted, System Restore running on Windows 8 resumes creating snapshots that monitor files in the boot volume that are relevant for system restore only.
 
 For an example, see [Using System Restore](using-system-restore.md).
 

--- a/desktop-src/sr/calling-srsetrestorepoint.md
+++ b/desktop-src/sr/calling-srsetrestorepoint.md
@@ -26,7 +26,7 @@ When an application calls the **SRSetRestorePoint** function to create a restore
 
 System Restore running on Windows 8 monitors files in the boot volume that are relevant for system restore only. Snapshots of the boot volume created by System Restore running on Windows 8 may be deleted if the snapshot is subsequently exposed by an earlier version of Windows. Note that although there is only one system volume, there is one boot volume for each operating system in a multi-boot system.
 
-Developers can write applications that create the DWORD value **ScopeSnapshots** under `HKLM\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore` the registry key. If this registry key value is 0, System Restore creates snapshots of the boot volume in the same way as in earlier versions of Windows. If this value is deleted, System Restore running on Windows 8 resumes creating snapshots that monitor files in the boot volume that are relevant for system restore only.
+Developers can write applications that create the DWORD value **ScopeSnapshots** under the `HKLM\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore` registry key. If this registry key value is 0, System Restore creates snapshots of the boot volume in the same way as in earlier versions of Windows. If this value is deleted, System Restore running on Windows 8 resumes creating snapshots that monitor files in the boot volume that are relevant for system restore only.
 
 For an example, see [Using System Restore](using-system-restore.md).
 


### PR DESCRIPTION
Brought the page up to Microsoft's standards of writing.

The page suffers from several problems summarized on the diagram below. A detailed description of how this PR fixes them follows.

![Edit summaries](https://github.com/MicrosoftDocs/win32/assets/17097175/64cf7b71-d39b-40a9-be06-101be23d672f)

1. Two malformed pieces of text that read `**Windows 8: **` are scattered across the page. Because most of the page talks about Windows 8 anyway, this PR proposes removing said malformed texts altogether.
2. One of the sentences in paragraph six was duplicated. The PR removes the duplicate.
3. The article talks about `HKLM\Software\Microsoft\Windows NT\CurrentVersion\SystemRestore` for two paragraphs before even mentioning the key! It is absurd to keep the name of the key secret for three paragraphs. This PR fixes that problem.
4. This PR converts three loose sentences to items of a bulleted list, eliminating verbosity and redundancy in the process.
5. Typo fix: "Install" is a verb, "installation" is a noun
6. Typo fix "Uninstall" is a verb, "uninstallation" is a noun.
7. Change "feature update" to "update" because:
   - System Restore is useful for reverting the effects of most update.
   - System Restore is specifically powerless about feature updates of Windows 10 versions 1511 through 1903. They take place while the operating system is offline.
8. The boldface style is not used sparingly, giving the whole article a jarring appearance. This PR fixes the problem.

On the whole, this PR brings the article up to Microsoft's standards of writing.