### PR TITLE
Fix YAML parsing errors

### DIFF
--- a/desktop-src/FWP/wmi/netadaptercimprov/msft-netadapterpowermanagement-wakepattern-magicpacket.md
+++ b/desktop-src/FWP/wmi/netadaptercimprov/msft-netadapterpowermanagement-wakepattern-magicpacket.md
@@ -1,7 +1,7 @@
 ---
-description: 'MSFT\_NetAdapterPowerManagement\_WakePattern\_MagicPacket defines settings for 'Wake on Magic Packet'.'
+description: "MSFT\_NetAdapterPowerManagement\_WakePattern\_MagicPacket defines settings for 'Wake on Magic Packet'."
 ms.assetid: '77d76532-7345-48ca-9aa3-4ff387d8d444'
-title: 'MSFT\_NetAdapterPowerManagement\_WakePattern\_MagicPacket class'
+title: "MSFT\_NetAdapterPowerManagement\_WakePattern\_MagicPacket class"
 
 
 ms.author: windowssdkdev

--- a/desktop-src/FWP/wmi/netadaptercimprov/msft-netadapterpowermanagement-wakepattern-wildcard.md
+++ b/desktop-src/FWP/wmi/netadaptercimprov/msft-netadapterpowermanagement-wakepattern-wildcard.md
@@ -1,7 +1,7 @@
 ---
-description: 'MSFT\_NetAdapterPowerManagement\_WakePattern\_WildCard defines settings for 'Wake on any Packet'.'
+description: "MSFT\_NetAdapterPowerManagement\_WakePattern\_WildCard defines settings for 'Wake on any Packet'."
 ms.assetid: '9acf5453-117c-4621-90ca-eb55ad8b69d9'
-title: 'MSFT\_NetAdapterPowerManagement\_WakePattern\_WildCard class'
+title: "MSFT\_NetAdapterPowerManagement\_WakePattern\_WildCard class"
 
 
 ms.author: windowssdkdev

--- a/desktop-src/FWP/wmi/nettcpipprov/cim-nexthoproute.md
+++ b/desktop-src/FWP/wmi/nettcpipprov/cim-nexthoproute.md
@@ -1,7 +1,7 @@
 ---
-description: 'Represents one of a series of 'hops' to reach a network destination. A route is administratively defined, or calculated/learned by a particular routing process.'
+description: "Represents one of a series of 'hops' to reach a network destination. A route is administratively defined, or calculated/learned by a particular routing process."
 ms.assetid: '2c1d0fdd-0914-4c81-a1ff-d8104c5c734d'
-title: 'CIM\_NextHopRoute class'
+title: "CIM\_NextHopRoute class"
 
 
 ms.author: windowssdkdev

--- a/desktop-src/FWP/wmi/nettcpipprov/cim-routeusesendpoint.md
+++ b/desktop-src/FWP/wmi/nettcpipprov/cim-routeusesendpoint.md
@@ -1,7 +1,7 @@
 ---
-description: 'RouteUsesEndpoint depicts the relationship between a next hop route and the local Endpoint that is used to transmit the traffic to the \\'next hop\\'.'
+description: "RouteUsesEndpoint depicts the relationship between a next hop route and the local Endpoint that is used to transmit the traffic to the \\'next hop\\'."
 ms.assetid: '800282ae-45a7-4be8-a02b-c6b553348caa'
-title: 'CIM\_RouteUsesEndpoint class'
+title: "CIM\_RouteUsesEndpoint class"
 
 
 ms.author: windowssdkdev


### PR DESCRIPTION
Some strings in the YAML part of the markdown files are invalid, because of the usage of single quotes, which should be replaced by double quotes.

For instance, single quotes were used inside single quotes. Moreover, double quotes allow the `\_` to be "parsed".