### PR TITLE
Clarify that supportedArchitectures applies to .NET Framework

### DIFF
--- a/desktop-src/SbsCs/application-manifests.md
+++ b/desktop-src/SbsCs/application-manifests.md
@@ -498,7 +498,7 @@ This element has no attributes.
 
 ### supportedArchitectures
 
-For IL-only .NET executables, specifies a list of native processor architectures the application is compatible with. Can contain one or more of the following values, separated by spaces:
+For IL-only .NET Framework executables, specifies a list of native processor architectures the application is compatible with. Can contain one or more of the following values, separated by spaces:
 
 * **amd64**
 * **arm64**


### PR DESCRIPTION
Minor wording update to make it clear that `supportedArchitectures` affects .NET Framework runtime activation. The bare ".NET" tends to be interpreted as .NET Core / .NET 5+ these days.