### PR TITLE
Remove null pointer checks that have no effect in using-raw-input.

### DIFF
--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -95,10 +95,6 @@ case WM_INPUT:
 
     GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize, sizeof(RAWINPUTHEADER));
     LPBYTE lpb = new BYTE[dwSize];
-    if (lpb == NULL) 
-    {
-        return 0;
-    } 
 
     if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER)) != dwSize)
          OutputDebugString (TEXT("GetRawInputData does not return correct size !\n")); 


### PR DESCRIPTION
Remove null pointer checks that have no effect.
When `new BYTE[dwSize]` failed, it will throws an exception instead of get null pointer in this context. Condition `lpb == NULL` is never true.

[cppreference](https://en.cppreference.com/w/cpp/memory/new/operator_new)