### PR TITLE
Fix typo in wWinMain parameter in managing-application-state-.md

### DIFF
--- a/desktop-src/LearnWin32/managing-application-state-.md
+++ b/desktop-src/LearnWin32/managing-application-state-.md
@@ -267,7 +267,7 @@ public:
 To create the window, call `BaseWindow::Create`:
 
 ```C++
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int nCmdShow)
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
 {
     MainWindow win;
 

--- a/desktop-src/LearnWin32/managing-application-state-.md
+++ b/desktop-src/LearnWin32/managing-application-state-.md
@@ -267,7 +267,7 @@ public:
 To create the window, call `BaseWindow::Create`:
 
 ```C++
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR pCmdLine, int nCmdShow)
+int WINAPI wWinMain(HINSTANCE, HINSTANCE, PWSTR, int nCmdShow)
 {
     MainWindow win;
 


### PR DESCRIPTION
Fix minor typo in `wWinMain` parameter list in code example of `learnwin32/managing-application-state-.md`