### PR TITLE
OpenGL: Reconcile the "GLX and WGL/Windows" article with "Translating the GLX Library"

### DIFF
--- a/desktop-src/OpenGL/glx-and-wgl-win32.md
+++ b/desktop-src/OpenGL/glx-and-wgl-win32.md
@@ -7,7 +7,7 @@ keywords:
 - GLX functions OpenGL
 - WGL functions,compared to GLX functions
 ms.topic: article
-ms.date: 05/31/2018
+ms.date: 07/06/2024
 ---
 
 # GLX and WGL/Windows
@@ -16,31 +16,30 @@ Some of the WGL functions and Windows functions are more or less analogous to GL
 
 
 
-| GLX Functions             | WGL/Windows Functions                                                                                                                                       |
+| GLX/Xlib function         | WGL/Windows function                                                                                                                                        |
 |---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **glXChooseVisual**       | [**ChoosePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-choosepixelformat)                                                                                                              |
-| **glXCopyContext**        |                                                                                                                                                             |
-| **glXCreateContext**      | [**wglCreateContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcreatecontext)                                                                                                                |
-| **glXCreateGLXPixmap**    | [**CreateDIBitmap**](/windows/desktop/api/wingdi/nf-wingdi-createdibitmap) / [**CreateDIBSection**](/windows/desktop/api/wingdi/nf-wingdi-createdibsection)                                                                     |
-| **glXDestroyContext**     | [**wglDeleteContext**](/windows/desktop/api/wingdi/nf-wingdi-wgldeletecontext)                                                                                                                |
-| **glXDestroyGLXPixmap**   | [**DeleteObject**](/windows/desktop/api/wingdi/nf-wingdi-deleteobject)                                                                                                                        |
-| **glXGetConfig**          | [**DescribePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-describepixelformat)                                                                                                          |
-| **glXGetCurrentContext**  | [**wglGetCurrentContext**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentcontext)                                                                                                        |
-| **glXGetCurrentDrawable** | [**wglGetCurrentDC**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentdc)                                                                                                                  |
-| **glXIsDirect**           |                                                                                                                                                             |
-| **glXMakeCurrent**        | [**wglMakeCurrent**](/windows/desktop/api/wingdi/nf-wingdi-wglmakecurrent)                                                                                                                    |
-| **glXQueryExtension**     | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                                                                           |
-| **glXQueryVersion**       | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                                                                           |
-| **glXSwapBuffers**        | [**SwapBuffers**](/windows/desktop/api/wingdi/nf-wingdi-swapbuffers)                                                                                                                          |
-| **glXUseXFont**           | [**wglUseFontBitmaps**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontbitmapsa) / [**wglUseFontOutlines**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontoutlinesa)                                                           |
-| **glXWaitGL**             |                                                                                                                                                             |
-| **glXWaitX**              |                                                                                                                                                             |
-| **XGetVisualInfo**        | [**GetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-getpixelformat)                                                                                                                    |
+| **glXChooseVisual**       | [**ChoosePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-choosepixelformat)                                                                            |
+| **glXCopyContext**        | [**wglCopyContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcopycontext)                                                                                  |
+| **glXCreateContext**      | [**wglCreateContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcreatecontext), [**wglShareLists**](/windows/desktop/api/wingdi/nf-wingdi-wglsharelists)    |
+| **glXCreateGLXPixmap**    | [**CreateDIBitmap**](/windows/desktop/api/wingdi/nf-wingdi-createdibitmap) / [**CreateDIBSection**](/windows/desktop/api/wingdi/nf-wingdi-createdibsection) |
+| **glXDestroyContext**     | [**wglDeleteContext**](/windows/desktop/api/wingdi/nf-wingdi-wgldeletecontext)                                                                              |
+| **glXDestroyGLXPixmap**   | [**DeleteObject**](/windows/desktop/api/wingdi/nf-wingdi-deleteobject)                                                                                      |
+| **glXGetConfig**          | [**DescribePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-describepixelformat)                                                                        |
+| **glXGetCurrentContext**  | [**wglGetCurrentContext**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentcontext)                                                                      |
+| **glXGetCurrentDrawable** | [**wglGetCurrentDC**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentdc)                                                                                |
+| **glXGetProcAddress**     | [**wglGetProcAddress**](/windows/desktop/api/wingdi/nf-wingdi-wglgetprocaddress)                                                                            |
+| **glXIsDirect**           | Not applicable.                                                                                                                                             |
+| **glXMakeCurrent**        | [**wglMakeCurrent**](/windows/desktop/api/wingdi/nf-wingdi-wglmakecurrent)                                                                                  |
+| **glXQueryExtension**     | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                                  |
+| **glXQueryVersion**       | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                                  |
+| **glXSwapBuffers**        | [**SwapBuffers**](/windows/desktop/api/wingdi/nf-wingdi-swapbuffers)                                                                                        |
+| **glXUseXFont**           | [**wglUseFontBitmaps**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontbitmapsa) / [**wglUseFontOutlines**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontoutlinesa) |
+| **glXWaitGL**             | Not applicable.                                                                                                                                             |
+| **glXWaitX**              | Not applicable.                                                                                                                                             |
 | **XCreateWindow**         | [**CreateWindow**](/windows/win32/api/winuser/nf-winuser-createwindowa) / [**CreateWindowEx**](/windows/win32/api/winuser/nf-winuser-createwindowexa) and [**GetDC**](/windows/desktop/api/winuser/nf-winuser-getdc) / [**BeginPaint**](/windows/desktop/api/winuser/nf-winuser-beginpaint) |
-| **XSync**                 | [**GdiFlush**](/windows/desktop/api/wingdi/nf-wingdi-gdiflush)                                                                                                                                |
-|                           | [**SetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-setpixelformat)                                                                                                                    |
-|                           | [**wglGetProcAddress**](/windows/desktop/api/wingdi/nf-wingdi-wglgetprocaddress)                                                                                                              |
-|                           | [**wglShareLists**](/windows/desktop/api/wingdi/nf-wingdi-wglsharelists)                                                                                                                      |
+| **XGetVisualInfo**        | [**GetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-getpixelformat)                                                                                  |
+| **XSync**                 | [**GdiFlush**](/windows/desktop/api/wingdi/nf-wingdi-gdiflush)                                                                                              |
+| Not applicable.           | [**SetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-setpixelformat)                                                                                  |
 
 
 

--- a/desktop-src/OpenGL/rendering-context-functions.md
+++ b/desktop-src/OpenGL/rendering-context-functions.md
@@ -5,7 +5,7 @@ ms.assetid: e03ec03d-2a85-49de-a2be-fe81a5ec5f7f
 keywords:
 - WGL functions,rendering contexts
 ms.topic: article
-ms.date: 05/31/2018
+ms.date: 07/06/2024
 ---
 
 # Rendering Context Functions
@@ -14,13 +14,13 @@ Five WGL functions manage rendering contexts, as described in the following tabl
 
 
 
-| WGL Function                                         | Description                                                                                  |
-|------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| WGL Function                                                                           | Description                                                                                  |
+|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
 | [**wglCreateContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcreatecontext)         | Creates a new rendering context.                                                             |
-| [**WglMakeCurrent**](/windows/desktop/api/wingdi/nf-wingdi-wglmakecurrent)             | Sets a thread's current rendering context.                                                   |
-| [**WglGetCurrentContext**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentcontext) | Obtains a handle to a thread's current rendering context.                                    |
-| [**WglGetCurrentDC**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentdc)           | Obtains a handle to the device context associated with a thread's current rendering context. |
-| [**WglDeleteContext**](/windows/desktop/api/wingdi/nf-wingdi-wgldeletecontext)         | Deletes a rendering context.                                                                 |
+| [**wglMakeCurrent**](/windows/desktop/api/wingdi/nf-wingdi-wglmakecurrent)             | Sets a thread's current rendering context.                                                   |
+| [**wglGetCurrentContext**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentcontext) | Obtains a handle to a thread's current rendering context.                                    |
+| [**wglGetCurrentDC**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentdc)           | Obtains a handle to the device context associated with a thread's current rendering context. |
+| [**wglDeleteContext**](/windows/desktop/api/wingdi/nf-wingdi-wgldeletecontext)         | Deletes a rendering context.                                                                 |
 
 
 

--- a/desktop-src/OpenGL/translating-the-glx-library.md
+++ b/desktop-src/OpenGL/translating-the-glx-library.md
@@ -9,7 +9,7 @@ keywords:
 - GLX library OpenGL
 - Xlib functions OpenGL
 ms.topic: article
-ms.date: 04/28/2024
+ms.date: 07/06/2024
 ---
 
 # Translating the GLX Library
@@ -18,25 +18,28 @@ OpenGL X Window System programs use the OpenGL Extension with the X Window Syste
 
 
 
-| GLX/Xlib function         | Windows function                                                                                                                                       |
+| GLX/Xlib function         | WGL/Windows function                                                                                                                                   |
 |---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **glXChooseVisual**       | [**ChoosePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-choosepixelformat)                                                                       |
 | **glXCopyContext**        | [**wglCopyContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcopycontext)                                                                             |
-| **glXCreateContext**      | [**wglCreateContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcreatecontext)                                                                         |
-| **glXCreateGLXPixmap**    | [**CreateDIBitmap**](/windows/desktop/api/wingdi/nf-wingdi-createdibitmap)[**CreateDIBSection**](/windows/desktop/api/wingdi/nf-wingdi-createdibsection) |
+| **glXCreateContext**      | [**wglCreateContext**](/windows/desktop/api/wingdi/nf-wingdi-wglcreatecontext), [**wglShareLists**](/windows/desktop/api/wingdi/nf-wingdi-wglsharelists) |
+| **glXCreateGLXPixmap**    | [**CreateDIBitmap**](/windows/desktop/api/wingdi/nf-wingdi-createdibitmap) / [**CreateDIBSection**](/windows/desktop/api/wingdi/nf-wingdi-createdibsection) |
 | **glXDestroyContext**     | [**wglDeleteContext**](/windows/desktop/api/wingdi/nf-wingdi-wgldeletecontext)                                                                         |
 | **glXDestroyGLXPixmap**   | [**DeleteObject**](/windows/desktop/api/wingdi/nf-wingdi-deleteobject)                                                                                 |
 | **glXGetConfig**          | [**DescribePixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-describepixelformat)                                                                   |
 | **glXGetCurrentContext**  | [**wglGetCurrentContext**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentcontext)                                                                 |
 | **glXGetCurrentDrawable** | [**wglGetCurrentDC**](/windows/desktop/api/wingdi/nf-wingdi-wglgetcurrentdc)                                                                           |
+| **glXGetProcAddress**     | [**wglGetProcAddress**](/windows/desktop/api/wingdi/nf-wingdi-wglgetprocaddress)                                                                       |
 | **glXIsDirect**           | Not applicable.                                                                                                                                        |
 | **glXMakeCurrent**        | [**wglMakeCurrent**](/windows/desktop/api/wingdi/nf-wingdi-wglmakecurrent)                                                                             |
 | **glXQueryExtension**     | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                             |
 | **glXQueryVersion**       | [**GetVersion**](/windows/desktop/api/sysinfoapi/nf-sysinfoapi-getversion)                                                                             |
 | **glXSwapBuffers**        | [**SwapBuffers**](/windows/desktop/api/wingdi/nf-wingdi-swapbuffers)                                                                                   |
-| **glXUseXFont**           | [**wglUseFontBitmaps**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontbitmapsa)                                                                      |
+| **glXUseXFont**           | [**wglUseFontBitmaps**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontbitmapsa) / [**wglUseFontOutlines**](/windows/desktop/api/wingdi/nf-wingdi-wglusefontoutlinesa) |
+| **glXWaitGL**             | Not applicable.                                                                                                                                        |
+| **glXWaitX**              | Not applicable.                                                                                                                                        |
+| **XCreateWindow**         | [**CreateWindow**](/windows/win32/api/winuser/nf-winuser-createwindowa) / [**CreateWindowEx**](/windows/win32/api/winuser/nf-winuser-createwindowexa) and [**GetDC**](/windows/desktop/api/winuser/nf-winuser-getdc) / [**BeginPaint**](/windows/desktop/api/winuser/nf-winuser-beginpaint) |
 | **XGetVisualInfo**        | [**GetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-getpixelformat)                                                                             |
-| **XCreateWindow**         | [**CreateWindow**](/windows/win32/api/winuser/nf-winuser-createwindowa), [**CreateWindowEx**](/windows/win32/api/winuser/nf-winuser-createwindowexa), [**GetDC**](/windows/desktop/api/winuser/nf-winuser-getdc), [**BeginPaint**](/windows/desktop/api/winuser/nf-winuser-beginpaint) |
 | **XSync**                 | [**GdiFlush**](/windows/desktop/api/wingdi/nf-wingdi-gdiflush)                                                                                         |
 | Not applicable.           | [**SetPixelFormat**](/windows/desktop/api/wingdi/nf-wingdi-setpixelformat)                                                                             |
 


### PR DESCRIPTION
Both articles contain the same table, which maps GLX/Xlib and WGL/Windows functions.
Maybe it would make sense to leave only one table and put a link instead of the second one, but I wasn't sure.

Follows #1835.