### PR TITLE
Add HLSL vector/matrix template declaration option

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-matrix.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-matrix.md
@@ -17,83 +17,62 @@ api_location:
 
 # Matrix Type
 
-A matrix is a special data type that contains between one and sixteen components. Every component of a matrix must be of the same type.
+A matrix is a data type that contains between one and sixteen [scalar](dx-graphics-hlsl-scalar.md) components in a two dimensional grid. Every component of a matrix must be of the same type.
 
+## Type Declaration
 
+You can declare matrix variables by using the [scalar type](dx-graphics-hlsl-scalar.md) name of the matrix's contents with the number of rows and columns it contains:
 
-|                         |
-|-------------------------|
-| **TypeComponents Name** |
-
-
-
- 
-
-## Components
-
-
-
-| Item                                                                                                                             | Description                                                                                                                                                                                                                                                                                       |
-|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="TypeComponents"></span><span id="typecomponents"></span><span id="TYPECOMPONENTS"></span>**TypeComponents**<br/> | A single name that contains three parts. The first part is one of the [scalar](dx-graphics-hlsl-data-types.md) types. The second part is the number of rows. The third part is the number of columns. The number of rows and columns is a positive integer between 1 and 4 inclusive.<br/> |
-| <span id="Name"></span><span id="name"></span><span id="NAME"></span>**Name**<br/>                                         | An ASCII string that uniquely identifies the variable name.<br/>                                                                                                                                                                                                                            |
-
-
-
- 
-
-## Examples
-
-Here are some examples:
-
-
+```syntax
+TypeRowsCols Name
 ```
-int1x1    iMatrix;   // integer matrix with 1 row,  1 column
-int4x1    iMatrix;   // integer matrix with 4 rows, 1 column
-int1x4    iMatrix;   // integer matrix with 1 row, 4 columns
-double3x3 dMatrix;   // double matrix with 3 rows, 3 columns
 
-float2x2 fMatrix = { 0.0f, 0.1, // row 1
-                     2.1f, 2.2f // row 2
+Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the components, `Rows` is an integer between 1 and 4 inclusive indicating the number of rows, `Cols` is an integer between 1 and 4 inclusive indicating the number of columns and `Name` is an ASCII string that uniquely identifies the variable name.
+
+Examples:
+
+```hlsl
+int1x1    iMatrix;   // integer matrix with 1 row,  1 column, 1 single component
+int4x1    iMatrix;   // integer matrix with 4 rows, 1 column, 4 total components
+int1x4    iMatrix;   // integer matrix with 1 row, 4 columns, 4 total components
+double3x3 dMatrix;   // double matrix with 3 rows, 3 columns, 9 total components
+
+float3x2 fMatrix = { 0.0f, 0.1f, // row 1
+                     2.1f, 2.2f, // row 2
+                     4.1f, 4.2f  // row 3
                    };   
 ```
 
+## Template-style Declaration
 
+An alternate declaration syntax uses the `matrix` keyword and template arguments to indicate scalar type, number of rows and number of columns:
 
-A matrix can be declared using this syntax also:
-
-
+```syntax
+matrix <Type=float, Rows=4, Cols=4> Name
 ```
-matrix <Type, Number> VariableName
-```
 
+Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the components, `Rows` is an integer between 1 and 4 inclusive indicating the number of rows, `Cols` is an integer between 1 and 4 inclusive indicating the number of columns, but they are specified within template-style angle brackets. `Name` is an ASCII string that uniquely identifies the variable name.
 
+Note that the template parameter defaults allow specifying 4-column matrtices of a given type and row count by leaving off the last parameter, a 4x4 matrix of a given type by leaving off the last two template parameters or 4x4 float matrices by leaving off all three.
 
-The matrix type uses the angle brackets to specify the type, the number of rows, and the number of columns. This example creates a floating-point matrix, with two rows and two columns. Any of the scalar data types can be used.
+Examples:
 
-Here is an example:
-
-
-```
-matrix <float, 2, 2> fMatrix = { 0.0f, 0.1, // row 1
-                                 2.1f, 2.2f // row 2
+```hlsl
+matrix <int, 1, 1>   iMatrix = { 1 }; 
+matrix <float, 2, 3> fMatrix = { 0.0f, 0.1f, 0.2f, // row 1
+                                 2.1f, 2.2f, 2.3f  // row 2
                                };
+matrix<int16_t, 1>   sMatrix = { 1, 2, 3, 4 }; // Defaults to 1x4 int16 matrix
+matrix<float16_t>    hMatrix = { 0.0f, 0.1f, 0.2f, 0.3f, // Defaults to 4x4 float16 matrix
+                                 1.0f, 1.1f, 1.2f, 1.3f,
+                                 2.0f, 2.1f, 2.2f, 2.3f,
+                                 3.0f, 3.1f, 3.2f, 3.3f }; 
+matrix               fMatrix = { 0.0f, 0.1f, 0.2f, 0.3f, // Defaults to 4x4 float matrix
+                                 1.0f, 1.1f, 1.2f, 1.3f,
+                                 2.0f, 2.1f, 2.2f, 2.3f,
+                                 3.0f, 3.1f, 3.2f, 3.3f }; 
 ```
-
-
 
 ## See also
 
-<dl> <dt>
-
 [Data Types (DirectX HLSL)](dx-graphics-hlsl-data-types.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-vector.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-vector.md
@@ -16,80 +16,47 @@ ms.date: 05/31/2018
 
 # Vector Type
 
-A vector contains between one and four scalar components; every component of a vector must be of the same type.
+A vector is a data type that contains between one and four [scalar](dx-graphics-hlsl-scalar.md) components. Every component of a vector must be of the same type.
 
+## Type Declaration
 
+You can declare vector variables by using the [scalar type](dx-graphics-hlsl-scalar.md) name of the vector's contents with the number of components it contains:
 
-|                     |
-|---------------------|
-| **TypeNumber Name** |
-
-
-
- 
-
-
-```
+```syntax
 TypeComponents Name
 ```
 
+Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the components, `Components` is an integer between 1 and 4 inclusive indicating the number of components and `Name` is an ASCII string that uniquely identifies the variable name.
 
+Examples:
 
-## Components
-
-
-
-| Item                                                                                                                             | Description                                                                                                                                                                                                           |
-|----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="TypeComponents"></span><span id="typecomponents"></span><span id="TYPECOMPONENTS"></span>**TypeComponents**<br/> | A single name that contains two parts. The first part is one of the [scalar](dx-graphics-hlsl-data-types.md) types. The second part is the number of components, which must be between 1 and 4 inclusive.<br/> |
-| <span id="Name"></span><span id="name"></span><span id="NAME"></span>**Name**<br/>                                         | An ASCII string that uniquely identifies the variable name.<br/>                                                                                                                                                |
-
-
-
- 
-
-## Examples
-
-Here are some examples:
-
-
-```
+```hlsl
 bool    bVector;   // scalar containing 1 Boolean
 int1    iVector = 1;
 float3  fVector = { 0.2f, 0.3f, 0.4f };
 ```
 
+## Template-style Declaration
 
+An alternate declaration syntax uses the `vector` keyword and template arguments to indicate scalar type and number of components:
 
-A vector can be declared using this syntax also:
-
-
+```syntax
+vector <Type=float, Components=4> Name
 ```
-vector <Type, Number> VariableName
-```
 
+Where again `Type` is the scalar type of each of the components, `Components` is an integer between 1 and 4 inclusive indicating the number of components, but they are specified within template-style angle brackets. `Name` is an ASCII string that uniquely identifies the variable name,
 
+Note that the template parameter defaults allow specifying 4-component vectors of a given type by leaving off the last parameter or 4-component float vectors by leaving off both.
 
 Here are some examples:
 
-
-```
+```hlsl
 vector <int,    1> iVector = 1;
-vector <double, 4> dVector = { 0.2, 0.3, 0.4, 0.5 };
+vector <double, 4> dVector = { 0.2f, 0.3f, 0.4f, 0.5f };
+vector <float16_t> hVector = { 0.1f, 0.2f, 0.3f, 0.4f };     // Defaults to 4-component float16 vector
+vector             fVector = { -0.4f, -0.3f, -0.2f, -0.1f }; // Defaults to 4-component float vector
 ```
 
 ## See also
 
-<dl> <dt>
-
 [Data Types (DirectX HLSL)](dx-graphics-hlsl-data-types.md)
-</dt> </dl>
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-vector.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-vector.md
@@ -31,9 +31,9 @@ Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the com
 Examples:
 
 ```hlsl
-bool    bVector;   // scalar containing 1 Boolean
-int1    iVector = 1;
-float3  fVector = { 0.2f, 0.3f, 0.4f };
+int     iScalar;     // integer scalar
+int1    iVector = 1; // vector containing one integer
+float3  fVector = { 0.2f, 0.3f, 0.4f }; // vector containing three floats
 ```
 
 ## Template-style Declaration


### PR DESCRIPTION
Refactors vector and matrix docs pages to allow more self-referencing of concepts, clear up some confusing parts, adds examples, and finally adds the default values of the template parameters that allows them to be excluded to get the defaults, which was the actual motivator of this change.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/2034