### PR TITLE
Update table-of-geographical-locations.md

### DIFF
--- a/desktop-src/Intl/table-of-geographical-locations.md
+++ b/desktop-src/Intl/table-of-geographical-locations.md
@@ -225,7 +225,7 @@ This topic lists the available geographical locations with identifiers (data typ
 | 0x105                                  | 261                                        | Yemen                                        | Republic of Yemen                                     |
 | 0x107                                  | 263                                        | Zambia                                       | Republic of Zambia                                    |
 | 0x108                                  | 264                                        | Zimbabwe                                     | Republic of Zimbabwe                                  |
-| 0x10d                                  | 269                                        | Serbia              | Serbia                        |
+| 0x10d                                  | 269                                        | Serbia and Montenegro (Former)             | Serbia                        |
 | 0x10e                                  | 270                                        | Montenegro                                   | Montenegro                                            |
 | 0x10f                                  | 271                                        | Serbia                                       | Serbia                                                |
 | 0x111                                  | 273                                        | Curaçao                                      |                                                       |


### PR DESCRIPTION
GeoID 269 is not serbia it is Serbia and Montenegro (Former)

You can get this by setting set-winhomelocation -geoid 269 and then doing a get-winhomelocation. This entry has added confusion between the 269 geoid and 271