### PR TITLE
Clarify DWORD usage on Configuring HTTP Server API Error Logging

### DIFF
--- a/desktop-src/Http/configuring-http-server-api-error-logging.md
+++ b/desktop-src/Http/configuring-http-server-api-error-logging.md
@@ -51,20 +51,6 @@ Registry configuration values are described in the following table.
 
 | Registry Value | Description | 
 |----------------|-------------|
-| <span id="EnableErrorLogging"></span><span id="enableerrorlogging"></span><span id="ENABLEERRORLOGGING"></span>EnableErrorLogging<br /> | A <strong>DWORD</strong> that can be set to <strong>TRUE</strong> to enable error logging, or <strong>FALSE</strong> to disable it. The default value is <strong>TRUE</strong>.<br /> | 
-| ErrorLogFileTruncateSize<br> | A **DWORD** that specifies the maximum size of an error log file, in bytes. The default value is one MB (0x100000).<br> **Note:** The specified value cannot be smaller than the default value.<br> | 
-| ErrorLoggingDir<br> | A **String** that specifies the folder under which the HTTP Server API places its logging files. <br> The HTTP Server API creates a subfolder named "HTTPERR" under the specified folder into which the log files are placed. This subfolder and the log files receive the same permission settings, which means that Administrator and Local System Accounts have full access, while other users do not have access.<br> If a folder is not specified in the registry, the default folder is the following:<br> "%SystemRoot%\System32\LogFiles"<br> **Note:** The ErrorLoggingDir string value must be a fully qualified path, but it can contain "%SystemRoot%".<br> | 
-
-
-
-
- 
-
- 
-
- 
-
-
-
-
-
+| EnableErrorLogging | A **DWORD** that can be set to **1** (means **True**) to enable error logging, or **0** (means **False**) to disable it. The default value is **1**. | 
+| ErrorLogFileTruncateSize | A **DWORD** that specifies the maximum size of an error log file, in bytes. The default value is one MB (0x100000).<br> **Note:** The specified value cannot be smaller than the default value.<br> | 
+| ErrorLoggingDir | A **String** that specifies the folder under which the HTTP Server API places its logging files. <br> The HTTP Server API creates a subfolder named "HTTPERR" under the specified folder into which the log files are placed. This subfolder and the log files receive the same permission settings, which means that Administrator and Local System Accounts have full access, while other users do not have access.<br> If a folder is not specified in the registry, the default folder is the following:<br> "%SystemRoot%\System32\LogFiles"<br> **Note:** The ErrorLoggingDir string value must be a fully qualified path, but it can contain "%SystemRoot%".<br> | 


### PR DESCRIPTION
Currently on the main page: [Configuring HTTP Server API Error Logging](https://learn.microsoft.com/en-us/windows/win32/http/configuring-http-server-api-error-logging) for configuring ``EnableErrorLogging``, saying to create a ``DWORD`` key and set the value to TRUE or FALSE which is wrong as for DWORD the value should be number. I already set the key EnableErrorLogging with the value 1 or 0 and is working as expected.

I changed the description to be more clear and helpful. 

From: 
![image](https://github.com/user-attachments/assets/d36167d8-0e7d-4de0-a3af-77b073baf4af)

To:
![image](https://github.com/user-attachments/assets/f3e5260b-5ffb-4991-adb9-e307193e1b5b)
