### PR TITLE
comp-swapchain-examples: Correct simple variable use in `for` loop

### DIFF
--- a/desktop-src/comp_swapchain/comp-swapchain-examples.md
+++ b/desktop-src/comp_swapchain/comp-swapchain-examples.md
@@ -1818,7 +1818,7 @@ void DXGIOrPresentationAPIExample()
 
     // Present 50 times.
     constexpr UINT numPresents = 50;
-    for (UINT i = 0; i < 50; i++)
+    for (UINT i = 0; i < numPresents; i++)
     {
         // Advance our present time 1/10th of a second in the future.
         presentTime.value += 1'000'000;


### PR DESCRIPTION
The commented line sets up a specific constant of `50` in a variable `numPresents`, but then goes ahead and repeats the same constant `50` again instead of using `numPresents`.