### PR TITLE
Update wm-sethotkey.md

### DIFF
--- a/desktop-src/inputdev/wm-sethotkey.md
+++ b/desktop-src/inputdev/wm-sethotkey.md
@@ -38,12 +38,6 @@ The low byte of the low-order word specifies the virtual-key code to associate w
 
 The high byte of the low-order word can be one or more of the following values from CommCtrl.h.
 
-The high-order word of *wParam* is ignored.
-
-Setting *wParam* to **NULL** removes the hot key associated with a window.
-
-
-
 | Value                                                                                                                                                                                                                         | Meaning                 |
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
 | <span id="HOTKEYF_ALT"></span><span id="hotkeyf_alt"></span><dl> <dt>**HOTKEYF\_ALT**</dt> <dt>0x04</dt> </dl>             | ALT key<br/>      |
@@ -52,7 +46,9 @@ Setting *wParam* to **NULL** removes the hot key associated with a window.
 | <span id="HOTKEYF_SHIFT"></span><span id="hotkeyf_shift"></span><dl> <dt>**HOTKEYF\_SHIFT**</dt> <dt>0x01</dt> </dl>       | SHIFT key<br/>    |
 
 
+The high-order word of *wParam* is ignored.
 
+Setting *wParam* to **NULL** removes the hot key associated with a window.
  
 
 </dd> <dt>

--- a/desktop-src/inputdev/wm-sethotkey.md
+++ b/desktop-src/inputdev/wm-sethotkey.md
@@ -34,9 +34,11 @@ Sent to a window to associate a hot key with the window. When the user presses t
 *wParam* 
 </dt> <dd>
 
-The low-order word specifies the virtual-key code to associate with the window.
+The low byte of the low-order word specifies the virtual-key code to associate with the window.
 
-The high-order word can be one or more of the following values from CommCtrl.h.
+The high byte of the low-order word can be one or more of the following values from CommCtrl.h.
+
+The high-order word of *wParam* is ignored.
 
 Setting *wParam* to **NULL** removes the hot key associated with a window.
 


### PR DESCRIPTION
Fixed description of *wParam*. Both the key code and the modifiers should be placed in the low-order word. The high-order word of *wParam* is ignored by the system.

According to the current description, the code below should work, but it isn't:

```c++
SendMessage(windowHandle, WM_SETHOTKEY, MAKEWPARAM(key, modifiers), 0);
```

The correct invocation that actually works:

```c++
SendMessage(windowHandle, WM_SETHOTKEY, MAKEWPARAM(MAKEWORD(key, modifiers), 0), 0);
```

And here is another, very similar page, that has the correct description of *wParam*: https://learn.microsoft.com/en-us/windows/win32/controls/hkm-sethotkey.