### PR TITLE
Fixed "The WM_NCHITTEST Message" link in "Mouse Input Overview"

### DIFF
--- a/desktop-src/inputdev/about-mouse-input.md
+++ b/desktop-src/inputdev/about-mouse-input.md
@@ -38,7 +38,7 @@ This section covers the following topics:
 -   [Mouse Messages](#mouse-messages)
     -   [Client Area Mouse Messages](#client-area-mouse-messages)
     -   [Nonclient Area Mouse Messages](#nonclient-area-mouse-messages)
-    -   [The WM\_NCHITTEST Message](/windows)
+    -   [The WM\_NCHITTEST Message](#the-wm_nchittest-message)
 -   [Mouse Sonar](#mouse-sonar)
 -   [Mouse Vanish](#mouse-vanish)
 -   [The Mouse Wheel](#the-mouse-wheel)


### PR DESCRIPTION
Fixed the "The WM_NCHITTEST Message" link. Previously it pointed to main Windows documentation page.