### PR TITLE
Fix Unicode byte order mark documentation

### DIFF
--- a/desktop-src/Intl/using-byte-order-marks.md
+++ b/desktop-src/Intl/using-byte-order-marks.md
@@ -1,5 +1,5 @@
 ---
-description: Always prefix a Unicode plain text file with a byte order mark, which informs an application receiving the file that the file is byte-ordered.
+description: Unicode text files may be encoded in several formats, including UTF-8, UTF-16, and UTF-32. Each of these formats can be prefixed with a byte order mark (BOM).
 ms.assetid: d9f1ef5c-6367-4183-9c07-01c73cb4debc
 title: Using Byte Order Marks
 ms.topic: article
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Using Byte Order Marks
 
-Always prefix a Unicode plain text file with a byte order mark, which informs an application receiving the file that the file is byte-ordered. Available byte order marks are listed in the following table. Because Unicode plain text is a sequence of 16-bit code values, it is sensitive to the byte ordering used when the text is written.
+Unicode text files may be encoded in several formats, including UTF-8, UTF-16, and UTF-32. Each of these formats can be prefixed with a byte order mark (BOM) that indicates the byte ordering used when the text was written. Available byte order marks are listed in the following table. For UTF-8, the byte order mark is optional, since the bytes may only be in one order. For UTF-16 and UTF-32, the byte order mark is required because those formats are sensitive to the byte ordering.
 
 > [!Note]  
 > A byte order mark is not a control character that selects the byte order of the text.
@@ -30,7 +30,7 @@ Always prefix a Unicode plain text file with a byte order mark, which informs an
  
 
 > [!Note]  
-> Microsoft uses UTF-16, little endian byte order.
+> Legacy Microsoft products either use Windows-1252 or UCS-2 (fixed-with UTF-16), little endian byte order, for "Unicode". For new applications, UTF-8 is recommended.
 
  
 


### PR DESCRIPTION
Hello, I came across this article and noticed several problems with it. https://learn.microsoft.com/en-us/windows/win32/intl/using-byte-order-marks

- The statement "Unicode plain text is a sequence of 16-bit code values" is incorrect. Unicode can be encoded in several encodings including UTF-8, UTF-16, and UTF-32. Unicode itself is a mapping of numbers to code points, many of which cannot fit into 16 bits.

- The statement "Microsoft uses UTF-16, little endian byte order." is incorrect. Some legacy Microsoft products such as Visual Studio use Windows-1252 by default. Some legacy Microsoft products use the name "Unicode" to refer to UCS-2, which is similar to UTF-16 but is restricted to the Basic Multilingual Plane and is a fixed-width 16-bit encoding. Modern Microsoft products such as Visual Studio Code and .NET use UTF-8 by default, and over 98% of websites use UTF-8, so note that this is recommended for new applications.

- The statement "which informs an application receiving the file that the file is byte-ordered" is nonsense. All bytes in a file are in some order, there is no such thing as a file with unordered bytes. The byte order mark is useful for UTF-16 and UTF-32 to indicate whether their byte order is little endian or big endian, not whether they are byte-ordered in general.

This PR attempts to fix these problems. If further tweaks are required to the text, let me know and I can update the PR.