### PR TITLE
Document `DYNAMIC_FUNCTION_TABLE`

### DIFF
--- a/desktop-src/DevNotes/dynamic_function_table_type.md
+++ b/desktop-src/DevNotes/dynamic_function_table_type.md
@@ -1,0 +1,165 @@
+---
+description: Node in the dynamic function table linked list
+title: DYNAMIC_FUNCTION_TABLE structure
+ms.topic: reference
+ms.date: 09/17/2024
+topic_type: 
+- APIRef
+- kbSyntax
+api_name: 
+- DYNAMIC_FUNCTION_TABLE
+api_type: 
+- HeaderDef
+api_location: 
+- None
+---
+
+# DYNAMIC_FUNCTION_TABLE structure
+
+The **DYNAMIC_FUNCTION_TABLE** structure is an entry in a linked list which is used by a debugger to discover all of the dynamic function tables in a target process. The root node in this linked list is returned from [**RtlGetFunctionTableListHead**](rtlgetfunctiontablelisthead.md)
+
+## Syntax
+
+```C++
+typedef struct _DYNAMIC_FUNCTION_TABLE {
+    LIST_ENTRY ListEntry;
+    PRUNTIME_FUNCTION FunctionTable;
+    LARGE_INTEGER Reserved1;
+    ULONG64 MinimumAddress;
+    ULONG64 MaximumAddress;
+    ULONG64 BaseAddress;
+    PVOID Reserved2[2];
+    PWSTR OutOfProcessCallbackDll;
+    FUNCTION_TABLE_TYPE Type;
+    ULONG EntryCount;
+} DYNAMIC_FUNCTION_TABLE, * PDYNAMIC_FUNCTION_TABLE;
+```
+
+## Members
+
+<dt>
+
+**ListEntry**
+
+</dt> 
+
+<dd>
+
+[**LIST_ENTRY**](/windows/win32/api/ntdef/ns-ntdef-list_entry) structure used to point at next and previous entries in the list.
+
+</dd>
+
+<dt>
+
+**FunctionTable**
+
+</dt> 
+
+<dd>
+
+For function tables which are not `RF_CALLBACK`, this points at an array of [**RUNTIME_FUNCTION**](/windows/win32/api/winnt/ns-winnt-runtime_function) structures.
+
+</dd>
+
+<dt>
+
+**Reserved1**
+
+</dt> 
+
+<dd>
+
+Reserved.
+
+</dd>
+
+<dt>
+
+**MinimumAddress**
+
+</dt> 
+
+<dd>
+
+Smallest instruction address described by this table.
+
+</dd>
+
+<dt>
+
+**MaximumAddress**
+
+</dt> 
+
+<dd>
+
+Largest instruction address described by this table.
+
+</dd>
+
+<dt>
+
+**BaseAddress**
+
+</dt> 
+
+<dd>
+
+The base address to use when computing full virtual addresses from relative virtual addresses of function table entries.
+
+</dd>
+
+<dt>
+
+**Reserved2**
+
+</dt> 
+
+<dd>
+
+Reserved.
+
+</dd>
+
+<dt>
+
+**OutOfProcessCallbackDll**
+
+</dt> 
+
+<dd>
+
+For function tables which are `RF_CALLBACK`, this contains an optional pointer to a string that specifies the path of a DLL that provides function table entries from outside of the target process.
+
+When a debugger unwinds to a function in the range of addresses managed by the callback function, it loads this DLL and calls the **OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK_EXPORT_NAME**
+function, whose type is **POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK**. For more information, see the definitions of these items in WinNT.h.
+
+</dd>
+
+<dt>
+
+**Type**
+
+</dt> 
+
+<dd>
+
+A member of the [FUNCTION_TABLE_TYPE](function_table_type_enum.md) enumeration.
+
+</dd>
+
+<dt>
+
+**EntryCount**
+
+</dt> 
+
+<dd>
+
+The number of entries in the `FunctionTable` array.
+
+</dd>
+
+## Remarks
+
+This struct has no associated import library or header file. The structure may be changed or removed from Windows without further notice.

--- a/desktop-src/DevNotes/dynamic_function_table_type.md
+++ b/desktop-src/DevNotes/dynamic_function_table_type.md
@@ -132,7 +132,7 @@ Reserved.
 For function tables which are `RF_CALLBACK`, this contains an optional pointer to a string that specifies the path of a DLL that provides function table entries from outside of the target process.
 
 When a debugger unwinds to a function in the range of addresses managed by the callback function, it loads this DLL and calls the **OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK_EXPORT_NAME**
-function, whose type is **POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK**. For more information, see the definitions of these items in WinNT.h.
+function, whose type is [**POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK**](pout_of_process_function_table_callback.md).
 
 </dd>
 

--- a/desktop-src/DevNotes/function_table_type_enum.md
+++ b/desktop-src/DevNotes/function_table_type_enum.md
@@ -1,0 +1,52 @@
+---
+description: Describes the type of function table which a DYNAMIC_FUNCTION_TABLE represents
+title: FUNCTION_TABLE_TYPE enumeration
+ms.topic: reference
+ms.date: 09/17/2024
+topic_type: 
+- APIRef
+- kbSyntax
+api_name: 
+- FUNCTION_TABLE_TYPE
+api_type: 
+- HeaderDef
+api_location: 
+- None
+---
+
+# FUNCTION_TABLE_TYPE enumeration
+
+Describes the type of function table which a [**DYNAMIC\_FUNCTION\_TABLE**](dynamic_function_table_type.md) represents.
+
+## Syntax
+
+```C++
+typedef enum _FUNCTION_TABLE_TYPE {
+    RF_SORTED,
+    RF_UNSORTED,
+    RF_CALLBACK,
+    RF_KERNEL_DYNAMIC
+} FUNCTION_TABLE_TYPE;
+```
+
+## Constants
+
+### RF_SORTED
+
+Entries in `FunctionTable` are sorted by their address. These tables were added using [**RtlAddFunctionTable**](/windows/win32/api/winnt/nf-winnt-rtladdfunctiontable).
+
+### RF_UNSORTED
+
+Entries in `FunctionTable` are unsorted. These tables were added using [**RtlAddFunctionTable**](/windows/win32/api/winnt/nf-winnt-rtladdfunctiontable).
+
+### RF_CALLBACK
+
+The `FunctionTable` array is not allocated up front. Instead, values are provided via a callback. These table entries were added to the list using [**RtlInstallFunctionTableCallback**](/windows/desktop/api/WinNT/nf-winnt-rtlinstallfunctiontablecallback).
+
+### RF_KERNEL_DYNAMIC
+
+Entries in `FunctionTable` are sorted by their address and installed by [**RtlAddGrowableFunctionTable**](/windows/desktop/api/WinNT/nf-winnt-rtladdgrowablefunctiontable).
+
+## Remarks
+
+This enum has no associated import library or header file. Additional values may be added in the future without further notice.

--- a/desktop-src/DevNotes/pout_of_process_function_table_callback.md
+++ b/desktop-src/DevNotes/pout_of_process_function_table_callback.md
@@ -1,0 +1,60 @@
+---
+description: Pointer to a function that is used by a debugger to obtain function table entries from a provider that was registered using RtlAddFunctionTable.
+title: POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK callback function
+ms.topic: reference
+ms.date: 09/17/2024
+keywords:
+- POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK,OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK
+topic_type: 
+- APIRef
+api_name: 
+- POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK
+api_location:
+- winnt.h
+api_type:
+- HeaderDef
+---
+
+# POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK callback function
+
+Pointer to a function that is used by a debugger to obtain function table entries from a provider that was registered using [**RtlAddFunctionTable**](/windows/win32/api/winnt/nf-winnt-rtladdfunctiontable). This must be exported from a DLL and named **OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK_EXPORT_NAME**. It will be invoked by a debugger from within the debugger's process.
+
+## Syntax
+
+```C++
+typedef
+DWORD
+OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK (
+    _In_ HANDLE Process,
+    _In_ PVOID TableAddress,
+    _Out_ PDWORD Entries,
+    _Outptr_result_buffer_(*Entries) PRUNTIME_FUNCTION* Functions
+    );
+typedef OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK *POUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK;
+```
+
+## Parameters
+
+### Process \[in\]
+
+Handle to the target process.
+
+### TableAddress \[in\]
+
+Address of the [**DYNAMIC_FUNCTION_TABLE**](dynamic_function_table_type.md) in the target process.
+
+### Entries \[out\]
+
+Returned count of entries in the *Functions* array.
+
+### Functions \[out\]
+
+Returned pointer to an array of [**RUNTIME_FUNCTION**](/windows/win32/api/winnt/ns-winnt-runtime_function) entries. This array must be allocated using [**HeapAlloc**](/windows/win32/api/heapapi/nf-heapapi-heapalloc) on the heap returned from [**GetProcessHeap**](/windows/win32/api/heapapi/nf-heapapi-getprocessheap).
+
+## Return value
+
+**NTSTATUS** code indicating if the function was able to successfully obtain the *Functions* array. *STATUS_SUCCESS* \(0x0\) indicates success.
+
+## Remarks
+
+Out of process function table dlls must be registered in `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\KnownFunctionTableDlls` to be loaded by the Visual Studio or Windows debuggers.

--- a/desktop-src/DevNotes/rtlgetfunctiontablelisthead.md
+++ b/desktop-src/DevNotes/rtlgetfunctiontablelisthead.md
@@ -36,7 +36,7 @@ This function has no parameters.
 
 ## Return value
 
-Returns a pointer to the head of the function table list.
+Returns a pointer to the head of the function table linked list. Nodes in this list are of type [**DYNAMIC\_FUNCTION\_TABLE**](dynamic_function_table_type.md). A debugger can walk all the entries in this list to find all of the function tables in a target process.
 
 ## Remarks
 


### PR DESCRIPTION
This PR provides documentation for `DYNAMIC_FUNCTION_TABLE` to describe how a debugger should discover all the dynamic function tables in a target process.