### PR TITLE
Msi/productcode.md: Mention registry key usage

### DIFF
--- a/desktop-src/Msi/productcode.md
+++ b/desktop-src/Msi/productcode.md
@@ -14,6 +14,8 @@ A product upgrade that updates a product into an entirely new product must also 
 
 The **ProductCode** is advertised as a product property, and is the primary method of specifying the product. This property is REQUIRED.
 
+The product code is used as the name of the product's [uninstall registry key](uninstall-registry-key.md).
+
 ## Requirements
 
 


### PR DESCRIPTION
Mention use of product code as name of a registry key (and thus that it can be found via the registry).
Link to docs page explaining that key and its subkeys.

I waffle as to whether this info belongs here, or in https://learn.microsoft.com/en-us/windows/win32/msi/product-codes