### PR TITLE
Fix CheckAccessFullyMapped documentation

### DIFF
--- a/desktop-src/direct3dhlsl/checkaccessfullymapped.md
+++ b/desktop-src/direct3dhlsl/checkaccessfullymapped.md
@@ -68,7 +68,7 @@ This function is supported in the following types of shaders:
 
 | Vertex | Hull | Domain | Geometry | Pixel | Compute |
 |--------|------|--------|----------|-------|---------|
-|        |      |        |          | x     | x       |
+| x      | x    | x      | x        | x     | x       |
 
 
 


### PR DESCRIPTION
CheckAccessFullyMapped is available in all types of shaders.

Previously, this document claimed it was limited to just pixel and compute shaders.