### PR TITLE
Clarify that the mip map level doesn't do anything if it's beyond the number of mip levels the texture had

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplelevel.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-to-samplelevel.md
@@ -82,7 +82,7 @@ This function is similar to [Sample](dx-graphics-hlsl-to-sample.md) except that 
 </tr>
 <tr class="even">
 <td><p><span id="LOD"></span><span id="lod"></span><em>LOD</em></p></td>
-<td><p>[in] A number that specifies the mipmap level. If the value is = 0, the zero'th (biggest map) is used. The fractional value (if supplied) is used to interpolate between two mipmap levels.</p></td>
+<td><p>[in] A number that specifies the mipmap level (internally clamped to the smallest map level). If the value is = 0, the zero'th (biggest map) is used. The fractional value (if supplied) is used to interpolate between two mipmap levels.</p></td>
 </tr>
 <tr class="odd">
 <td><p><span id="Offset"></span><span id="offset"></span><span id="OFFSET"></span><em>Offset</em></p></td>


### PR DESCRIPTION
As a beginner to DirecX, I started wondering whether sampling for a mip level that wasn't in the texture would actually make DirectX generate them on the spot simply for the sake of sampling (like, sample the parent level 4 times and average it), but it's not like that, and that information isn't easily deductible IMO, specifying this should clarify it.