### PR TITLE
Fixed code in creating-a-socket-for-the-client.md

### DIFF
--- a/desktop-src/WinSock/creating-a-socket-for-the-client.md
+++ b/desktop-src/WinSock/creating-a-socket-for-the-client.md
@@ -19,7 +19,7 @@ After initialization, a **SOCKET** object must be instantiated for use by the cl
                     hints;
 
     ZeroMemory( &hints, sizeof(hints) );
-    hints.ai_family   = AF_INET;
+    hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
     ```


### PR DESCRIPTION
Since the instruction says "the Internet address family is unspecified so that either an IPv6 or IPv4 address can be returned", `hints.ai_family` should be "AF_UNSPEC".