### PR TITLE
Update accepting-a-connection.md

### DIFF
--- a/desktop-src/WinSock/accepting-a-connection.md
+++ b/desktop-src/WinSock/accepting-a-connection.md
@@ -74,8 +74,3 @@ Next Step: [Receiving and Sending Data on the Server](receiving-and-sending-data
 
 [Listening on a Socket](listening-on-a-socket.md)
 </dt> </dl>
-
- 
-
- 
-p

--- a/desktop-src/WinSock/accepting-a-connection.md
+++ b/desktop-src/WinSock/accepting-a-connection.md
@@ -53,13 +53,11 @@ Once the socket is listening for a connection, the program must handle connectio
     > [!Note]  
     > On Unix systems, a common programming technique for servers was for an application to listen for connections. When a connection was accepted, the parent process would call the **fork** function to create a new child process to handle the client connection, inheriting the socket from the parent. This programming technique is not supported on Windows, since the **fork** function is not supported. This technique is also not usually suitable for high-performance servers, since the resources needed to create a new process are much greater than those needed for a thread.
 
-Once the [**accept**](/windows/desktop/api/Winsock2/nf-winsock2-accept) function is called, the ListenSocket is no longer needed for this example. The [**closesocket**](/windows/desktop/api/winsock/nf-winsock-closesocket) function is called to close the socket.
+Once the [**accept**](/windows/win32/api/Winsock2/nf-winsock2-accept) function is called, the `ListenSocket` is no longer needed for this example. The [**closesocket**](/windows/win32/api/winsock/nf-winsock-closesocket) function is called to close the socket.
 
-
-```C++
+```cpp
     // No longer need server socket
     closesocket(ListenSocket);
-
 ```
 
 Next Step: [Receiving and Sending Data on the Server](receiving-and-sending-data-on-the-server.md)
@@ -80,3 +78,4 @@ Next Step: [Receiving and Sending Data on the Server](receiving-and-sending-data
  
 
  
+p

--- a/desktop-src/WinSock/accepting-a-connection.md
+++ b/desktop-src/WinSock/accepting-a-connection.md
@@ -53,7 +53,14 @@ Once the socket is listening for a connection, the program must handle connectio
     > [!Note]  
     > On Unix systems, a common programming technique for servers was for an application to listen for connections. When a connection was accepted, the parent process would call the **fork** function to create a new child process to handle the client connection, inheriting the socket from the parent. This programming technique is not supported on Windows, since the **fork** function is not supported. This technique is also not usually suitable for high-performance servers, since the resources needed to create a new process are much greater than those needed for a thread.
 
-     
+Once the [**accept**](/windows/desktop/api/Winsock2/nf-winsock2-accept) function is called, the ListenSocket is no longer needed for this example. The [**closesocket**](/windows/desktop/api/winsock/nf-winsock-closesocket) function is called to close the socket.
+
+
+```C++
+    // No longer need server socket
+    closesocket(ListenSocket);
+
+```
 
 Next Step: [Receiving and Sending Data on the Server](receiving-and-sending-data-on-the-server.md)
 


### PR DESCRIPTION
Added a missing line of code to close the server socket after the accept() call. It is in "[Complete Winsock Server Code](https://learn.microsoft.com/en-us/windows/win32/winsock/complete-server-code)" but not in the tutorial. This is the appopriate place to add the explanation to this line of code.