### PR TITLE
Clarify constant int sizes in templated HLSL matrix declaration

### DIFF
--- a/desktop-src/direct3dhlsl/dx-graphics-hlsl-matrix.md
+++ b/desktop-src/direct3dhlsl/dx-graphics-hlsl-matrix.md
@@ -27,7 +27,7 @@ You can declare matrix variables by using the [scalar type](dx-graphics-hlsl-sca
 TypeRowsCols Name
 ```
 
-Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the components, `Rows` is an integer between 1 and 4 inclusive indicating the number of rows, `Cols` is an integer between 1 and 4 inclusive indicating the number of columns and `Name` is an ASCII string that uniquely identifies the variable name.
+Where `Type` is the [scalar type](dx-graphics-hlsl-scalar.md) of each of the components, `Rows` is a constant integer expression between 1 and 4 inclusive indicating the number of rows, `Cols` is a constant integer expression between 1 and 4 inclusive indicating the number of columns and `Name` is an ASCII string that uniquely identifies the variable name.
 
 Examples:
 


### PR DESCRIPTION
The Rows and Cols parameters in a template matrix declaration needs to be a constant expression. The docs didn't mention this before though HLSL compilers produce errors for it.