### PR TITLE
winuser: remove non-sense extended styles example

### DIFF
--- a/desktop-src/winmsg/extended-window-styles.md
+++ b/desktop-src/winmsg/extended-window-styles.md
@@ -9,23 +9,7 @@ ms.date: 05/31/2018
 
 # Extended Window Styles
 
-The following are the extended window styles.
-
-## Example
-
-```C++
-
-virtual    BOOL    Create(HWND hWndParent, WCHAR* pwszClassName,
-                            WCHAR* pwszWindowName, UINT uID, HICON hIcon,
-                            DWORD dwStyle = WS_OVERLAPPEDWINDOW,
-                            DWORD dwExStyle = WS_EX_APPWINDOW,
-                            int x = CW_USEDEFAULT, int y = CW_USEDEFAULT,
-                            int cx = CW_USEDEFAULT, int cy = CW_USEDEFAULT);
-```
-
-This code was taken from a sample in the [Windows classic samples](https://github.com/microsoft/Windows-classic-samples) GitHub repo.
-
-
+The following are the extended window styles, these can be used along with the [**CreateWindowExA**](/windows/win32/api/winuser/nf-winuser-createwindowexa)/[**CreateWindowExW**](/windows/win32/api/winuser/nf-winuser-createwindowexw) functions.
 
 
 


### PR DESCRIPTION
Problem: Current example is just a method copied from one of the classes in the Win32 samples repo,
but it doesn't make sense without the other context over in that repo.

Solution: Remove that example, and add instead link to the relevant window creation functions