### PR TITLE
Update ace-inheritance-rules.md

### DIFF
--- a/desktop-src/SecAuthZ/ace-inheritance-rules.md
+++ b/desktop-src/SecAuthZ/ace-inheritance-rules.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # ACE Inheritance Rules
 
-The system propagates inheritable [*access control entries*](/windows/desktop/SecGloss/a-gly) (ACEs) to child objects according to a set of inheritance rules. The system places inherited ACEs in the [*discretionary access control list*](/windows/desktop/SecGloss/d-gly) (DACL) of the child according to the preferred [order of ACEs in a DACL](order-of-aces-in-a-dacl.md). The system sets the INHERITED\_ACE flag in all inherited ACEs.
+The system propagates inheritable [*access control entries*](/windows/desktop/SecGloss/a-gly) (ACEs) to child objects according to a set of inheritance rules. The system places inherited ACEs in the [*discretionary access control list*](/windows/desktop/SecGloss/d-gly) (DACL) of the child according to the preferred [order of ACEs in a DACL](order-of-aces-in-a-dacl.md). 
 
 The ACEs inherited by container and noncontainer child objects differ, depending on the combinations of inheritance flags. These inheritance rules work the same for both DACLs and [*system access control lists*](/windows/desktop/SecGloss/s-gly) (SACLs).
 

--- a/desktop-src/SecAuthZ/ace-inheritance-rules.md
+++ b/desktop-src/SecAuthZ/ace-inheritance-rules.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # ACE Inheritance Rules
 
-The system propagates inheritable [*access control entries*](/windows/desktop/SecGloss/a-gly) (ACEs) to child objects according to a set of inheritance rules. The system places inherited ACEs in the [*discretionary access control list*](/windows/desktop/SecGloss/d-gly) (DACL) of the child according to the preferred [order of ACEs in a DACL](order-of-aces-in-a-dacl.md). 
+The system automatically propagates inheritable [*access control entries*](/windows/desktop/SecGloss/a-gly) (ACEs) to child objects according to a set of inheritance rules. The system places inherited ACEs in the [*discretionary access control list*](/windows/desktop/SecGloss/d-gly) (DACL) of the child according to the preferred [order of ACEs in a DACL](order-of-aces-in-a-dacl.md). 
 
 The ACEs inherited by container and noncontainer child objects differ, depending on the combinations of inheritance flags. These inheritance rules work the same for both DACLs and [*system access control lists*](/windows/desktop/SecGloss/s-gly) (SACLs).
 


### PR DESCRIPTION
This statement "The system sets the INHERITED\_ACE flag in all inherited ACEs" is false.  The INHERITED flag is set for any ACE which was auto propagated.

It should be removed or updated to:

"The system sets the INHERITED\_ACE flag in all auto propagated inherited ACEs."