### PR TITLE
Resolve confusing code, total of 20 writes or 20 writes per thread

### DIFF
--- a/desktop-src/Sync/using-mutex-objects.md
+++ b/desktop-src/Sync/using-mutex-objects.md
@@ -26,7 +26,7 @@ If a mutex is abandoned, the thread that owned the mutex did not properly releas
 #define THREADCOUNT 2
 
 HANDLE ghMutex; 
-
+DWORD dwCount = 0;
 DWORD WINAPI WriteToDatabase( LPVOID );
 
 int main( void )
@@ -86,7 +86,7 @@ DWORD WINAPI WriteToDatabase( LPVOID lpParam )
     // lpParam not used in this example
     UNREFERENCED_PARAMETER(lpParam);
 
-    DWORD dwCount=0, dwWaitResult; 
+    DWORD dwWaitResult; 
 
     // Request ownership of mutex.
 


### PR DESCRIPTION
The code example is slightly confusing. 
Currently, each thread writes to the DB 20 times, i.e, a total 40 writes to the DB.
I think the example is supposed to illustrate how two threads together can do 20 writes to a DB (interleavingly)