### PR TITLE
Update props-system-storageproviderstatus.md

### DIFF
--- a/desktop-src/properties/props-system-storageproviderstatus.md
+++ b/desktop-src/properties/props-system-storageproviderstatus.md
@@ -12,7 +12,7 @@ ms.date: 05/31/2018
 
 ```
 propertyDescription
-   name = System.StorageProviderStatus
+   name = System.StorageProviderState
    shellPKey = PKEY_StorageProviderState
    formatID = FCEFF153-E839-4CF3-A9E7-EA22832094B8
    propID = 110

--- a/desktop-src/properties/props-system-storageproviderstatus.md
+++ b/desktop-src/properties/props-system-storageproviderstatus.md
@@ -6,14 +6,14 @@ ms.topic: article
 ms.date: 05/31/2018
 ---
 
-# System.StorageProviderStatus
+# System.StorageProviderState
 
 ## Windows 10, version 1703, Windows 10, version 1607, Windows 10, version 1511, Windows 10, version 1507, Windows 8.1
 
 ```
 propertyDescription
    name = System.StorageProviderStatus
-   shellPKey = PKEY_StorageProviderStatus
+   shellPKey = PKEY_StorageProviderState
    formatID = FCEFF153-E839-4CF3-A9E7-EA22832094B8
    propID = 110
    SearchInfo


### PR DESCRIPTION
The string is wrong, it should be StorageProviderState rather than StorageProviderStatus.
After using the correct string, RetrievePropertiesAsync can return right values. Otherwise, it keeps returning 0 despite of the real status of files.