### PR TITLE
Clean up superfluous semicolons

### DIFF
--- a/desktop-src/Controls/create-a-simple-combo-box.md
+++ b/desktop-src/Controls/create-a-simple-combo-box.md
@@ -282,7 +282,7 @@ HRESULT DemoApp::Initialize()
     wcex.cbClsExtra    = 0;
     wcex.cbWndExtra    = sizeof(LONG_PTR);
     wcex.hInstance     = HINST_THISCOMPONENT;
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);;
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = NULL;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wcex.lpszClassName = TEXT("DemoApp");
@@ -492,7 +492,3 @@ LRESULT CALLBACK DemoApp::WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM
 
 [ComboBox](combo-boxes.md)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/Controls/create-directory-listing-in-a-single-selection-list-box.md
+++ b/desktop-src/Controls/create-directory-listing-in-a-single-selection-list-box.md
@@ -81,7 +81,7 @@ INT_PTR CALLBACK DlgDelFileProc(HWND hDlg, UINT message,
                     iRet = MessageBox(hDlg, achTemp, L"Deleting Files", 
                         MB_YESNO | MB_ICONEXCLAMATION);
                     if (iRet == IDNO)
-                        return TRUE;;
+                        return TRUE;
 
                     // Delete the file.
                     fResult = DeleteFile(pszFileToDelete); 
@@ -146,7 +146,3 @@ INT_PTR CALLBACK DlgDelFileProc(HWND hDlg, UINT message,
 
 [Using List Boxes](using-list-boxes.md)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/CoreAudio/render-spatial-sound-using-spatial-audio-objects.md
+++ b/desktop-src/CoreAudio/render-spatial-sound-using-spatial-audio-objects.md
@@ -1,7 +1,7 @@
 ---
+title: Render Spatial Sound Using Spatial Audio Objects
 description: This article presents some simple examples that illustrate how to implement spatial sound using static spatial audio objects, dynamic spatial audio objects, and spatial audio objects that use Microsoft's Head Relative Transfer Function (HRTF).
 ms.assetid: C99C342E-0BD9-486A-92AA-F8DCB72C1B00
-title: Render Spatial Sound Using Spatial Audio Objects
 ms.topic: article
 ms.date: 05/31/2018
 ---
@@ -325,7 +325,7 @@ pv.vt = VT_BLOB;
 pv.blob.cbSize = sizeof(streamParams);
 pv.blob.pBlobData = (BYTE *)&streamParams;
 
-Microsoft::WRL::ComPtr<ISpatialAudioObjectRenderStream> spatialAudioStream;;
+Microsoft::WRL::ComPtr<ISpatialAudioObjectRenderStream> spatialAudioStream;
 hr = spatialAudioClient->ActivateSpatialAudioStream(&pv, __uuidof(spatialAudioStream), (void**)&spatialAudioStream);
 ```
 
@@ -799,7 +799,3 @@ DirectX::XMMATRIX CalculateEmitterConeOrientationMatrix(Windows::Foundation::Num
 
 [**ISpatialAudioObject**](/windows/desktop/api/spatialaudioclient/nn-spatialaudioclient-ispatialaudioobject)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/WinInet/asynchronous-example-application.md
+++ b/desktop-src/WinInet/asynchronous-example-application.md
@@ -841,7 +841,7 @@ Return Value:
         Error = GetLastError();
 
         LogSysError(Error, L"WriteFile");
-        goto Exit;;
+        goto Exit;
     }
 
     
@@ -1821,13 +1821,3 @@ Return Value:
     return;
 }
 ```
-
-
-
- 
-
- 
-
-
-
-

--- a/desktop-src/activity_coordinator/activity-coordinator-example-project.md
+++ b/desktop-src/activity_coordinator/activity-coordinator-example-project.md
@@ -1,7 +1,7 @@
 ---
+title: Activity Coordinator example project
 description: This simple example for the Activity Coordinator demonstrates how the API can be leveraged to retrain a model in the background when system conditions are met.
 ms.assetid: 722acf59-ee17-4033-b191-cb0bf53e22ae
-title: Activity Coordinator example project
 ms.topic: article
 ms.date: 04/28/2022
 ---
@@ -211,7 +211,7 @@ wmain(
         policy.get(),
         DeferredWorkEventCallback,
         &workerContext,
-        &subscription));;
+        &subscription));
 
     // Destroy the policy because we no longer need it.
 

--- a/desktop-src/directcomp/how-to--animate-a-visual.md
+++ b/desktop-src/directcomp/how-to--animate-a-visual.md
@@ -391,7 +391,7 @@ HRESULT DemoApp::Initialize()
         wcex.cbClsExtra    = 0;
         wcex.cbWndExtra    = sizeof(LONG_PTR);
         wcex.hInstance     = HINST_THISCOMPONENT;
-        wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);;
+        wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
         wcex.lpszMenuName  = NULL;
         wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
         wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
@@ -981,7 +981,3 @@ HRESULT DemoApp::GetImageFilenames(TCHAR szDir[MAX_PATH])
 
 [Animation](animation.md)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/directcomp/how-to--animate-a-visual.md
+++ b/desktop-src/directcomp/how-to--animate-a-visual.md
@@ -394,7 +394,7 @@ HRESULT DemoApp::Initialize()
         wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
         wcex.lpszMenuName  = NULL;
         wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
-        wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
+        wcex.lpszClassName = L"DirectCompDemoApp";
 
         RegisterClassEx(&wcex);
 

--- a/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
+++ b/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
@@ -419,7 +419,7 @@ HRESULT DemoApp::Initialize()
     wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = NULL;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
-    wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
+    wcex.lpszClassName = L"DirectCompDemoApp";
 
     RegisterClassEx(&wcex);
 

--- a/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
+++ b/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
@@ -416,7 +416,7 @@ HRESULT DemoApp::Initialize()
     wcex.cbClsExtra    = 0;
     wcex.cbWndExtra    = sizeof(LONG_PTR);
     wcex.hInstance     = HINST_THISCOMPONENT;
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);;
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = NULL;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
@@ -1021,7 +1021,3 @@ HRESULT DemoApp::MyCreateGDIRenderedDCompSurface(HBITMAP hBitmap,
 
 [Effects](effects.md)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/directcomp/how-to--build-a-visual-tree.md
+++ b/desktop-src/directcomp/how-to--build-a-visual-tree.md
@@ -440,7 +440,7 @@ HRESULT DemoApp::Initialize()
     wcex.cbClsExtra    = 0;
     wcex.cbWndExtra    = sizeof(LONG_PTR);
     wcex.hInstance     = HINST_THISCOMPONENT;
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);;
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = NULL;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wcex.lpszClassName = L"DirectCompDemoApp";

--- a/desktop-src/directcomp/initialize-directcomposition.md
+++ b/desktop-src/directcomp/initialize-directcomposition.md
@@ -544,7 +544,7 @@ HRESULT DemoApp::Initialize()
     wcex.cbClsExtra    = 0;
     wcex.cbWndExtra    = sizeof(LONG_PTR);
     wcex.hInstance     = HINST_THISCOMPONENT;
-    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);;
+    wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = nullptr;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
     wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
@@ -981,7 +981,3 @@ HRESULT DemoApp::MyCreateGDIRenderedDCompSurface(HBITMAP hBitmap,
 
 [**SafeRelease**](/windows/desktop/medfound/saferelease)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/lwef/mpthreat-localized-info.md
+++ b/desktop-src/lwef/mpthreat-localized-info.md
@@ -32,7 +32,7 @@ typedef struct tagMPTHREAT_LOCALIZED_INFO {
   MP_MIDL_STRING LPWSTR SeverityName;
   MP_MIDL_STRING LPWSTR SeverityDescription;
   MP_MIDL_STRING LPWSTR ShortDescription;
-  MP_MIDL_STRING LPWSTR DefaultActionName;;
+  MP_MIDL_STRING LPWSTR DefaultActionName;
   MP_MIDL_STRING LPWSTR Advice;
   MP_MIDL_STRING LPWSTR ThreatUrl;
 } MPTHREAT_LOCALIZED_INFO, *PMPTHREAT_LOCALIZED_INFO;
@@ -152,14 +152,3 @@ A URL to a webpage containing information about the threat.
 | Minimum supported client<br/> | Windows 8 \[desktop apps only\]<br/>                                            |
 | Minimum supported server<br/> | Windows Server 2012 \[desktop apps only\]<br/>                                  |
 | Header<br/>                   | <dl> <dt>MpClient.h</dt> </dl> |
-
-
-
- 
-
- 
-
-
-
-
-

--- a/desktop-src/shell/building-thumbnail-providers.md
+++ b/desktop-src/shell/building-thumbnail-providers.md
@@ -1,6 +1,6 @@
 ---
-description: As of Windows Vista, greater use is made of file-specific thumbnail images than in earlier versions of Windows.
 title: Building Thumbnail Handlers
+description: As of Windows Vista, greater use is made of file-specific thumbnail images than in earlier versions of Windows.
 ms.topic: article
 ms.date: 05/31/2018
 ms.assetid: 218264a9-ed26-4049-a721-232943f6ec53
@@ -9,7 +9,6 @@ api_type:
 api_location: 
 topic_type: 
  - kbArticle
-
 ---
 
 # Building Thumbnail Handlers
@@ -212,7 +211,7 @@ IFACEMETHODIMP CRecipeThumbProvider::GetThumbnail(UINT cx,
             hr = WICCreate32BitsPerPixelHBITMAP(pImageStream, 
                                                 cx, 
                                                 phbmp, 
-                                                pdwAlpha);;
+                                                pdwAlpha);
 
             pImageStream->Release();
         }
@@ -236,7 +235,3 @@ IFACEMETHODIMP CRecipeThumbProvider::GetThumbnail(UINT cx,
 
 [**IID\_PPV\_ARGS**](/windows/win32/api/combaseapi/nf-combaseapi-iid_ppv_args)
 </dt> </dl>
-
- 
-
- 

--- a/desktop-src/wpd_sdk/adding-a-resource-to-an-object.md
+++ b/desktop-src/wpd_sdk/adding-a-resource-to-an-object.md
@@ -1,7 +1,7 @@
 ---
+title: Adding a Resource to an Object
 description: Adding a Resource to an Object
 ms.assetid: 81476f50-5ea0-4e02-9e38-2b1dfcc32c4f
-title: Adding a Resource to an Object
 ms.topic: article
 ms.date: 05/31/2018
 ---
@@ -109,7 +109,7 @@ if (SUCCEEDED(hr))
     OpenFileNameInfo.hwndOwner      = NULL;
     OpenFileNameInfo.lpstrFile      = wszFilePath;
     OpenFileNameInfo.nMaxFile       = ARRAYSIZE(wszFilePath);
-    OpenFileNameInfo.lpstrFilter    = L"JPEG (*.JPG)\0*.JPG\0JPEG (*.JPEG)\0*.JPEG\0JPG (*.JPE)\0*.JPE\0JPG (*.JFIF)\0*.JFIF\0\0";;
+    OpenFileNameInfo.lpstrFilter    = L"JPEG (*.JPG)\0*.JPG\0JPEG (*.JPEG)\0*.JPEG\0JPG (*.JPE)\0*.JPE\0JPG (*.JFIF)\0*.JFIF\0\0";
     OpenFileNameInfo.nFilterIndex   = 1;
     OpenFileNameInfo.Flags          = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
     OpenFileNameInfo.lpstrDefExt    = L"JPG";
@@ -296,10 +296,3 @@ if (SUCCEEDED(hr))
 
 [**Programming Guide**](programming-guide.md)
 </dt> </dl>
-
- 
-
- 
-
-
-

--- a/desktop-src/wsw/filerepserviceexample.md
+++ b/desktop-src/wsw/filerepserviceexample.md
@@ -1533,7 +1533,7 @@ HRESULT CRequest::AcceptChannel(HRESULT hr, WS_ASYNC_OPERATION* next, WS_CALLBAC
     next->function = CRequest::ReceiveFirstMessageCallback;  
     
     PrintVerbose(L"Leaving CRequest::AcceptChannel");
-    return WsAcceptChannel(server->GetListener(), channel, asyncContext, error);;
+    return WsAcceptChannel(server->GetListener(), channel, asyncContext, error);
 }
 
 // Special case for the first message received to keep the bookkeeping of active channels in order. 
@@ -3643,11 +3643,3 @@ WsFileRepService.exe: Service.obj CFileRep.obj CFileRepServer.obj CFileRepClient
 
 [FileRepToolExample](filereptoolexample.md)
 </dt> </dl>
-
- 
-
- 
-
-
-
-


### PR DESCRIPTION
Summary:
- Remove extraneous semicolons in code snippets
- Move `title` metadata to the top
- Elide excess trailing empty lines (at the end of the page) which renders as a huge empty space