### PR TITLE
Update using-objid-nativeom-to-expose-a-native-object-model-interface…

### DIFF
--- a/desktop-src/WinAuto/using-objid-nativeom-to-expose-a-native-object-model-interface-for-a-window.md
+++ b/desktop-src/WinAuto/using-objid-nativeom-to-expose-a-native-object-model-interface-for-a-window.md
@@ -1,5 +1,5 @@
 ---
-title: Use OBJID\_NATIVEOM to expose a native interface for a window
+title: Use OBJID_NATIVEOM to expose a native interface for a window
 description: This technique allows clients to get a custom object for a window. Servers can use this to expose a pointer to a custom document object for a window.
 ms.assetid: 91713fe5-f03f-464e-88ee-9d8d66d5b19d
 ms.topic: article


### PR DESCRIPTION
…-for-a-window.md

Remove unnecessary backslash in title of "Use OBJID_NATIVEOM to expose a native interface for a window".

The backslash gets stripped out of most places where the title is used (e.g., the article's HTML & the URL slug), but you can see the errant backslash in docs seach results.