### PR TITLE
winsock: clarify the usage of BSD socket errors

### DIFF
--- a/desktop-src/WinSock/error-codes-errno-h-errno-and-wsagetlasterror-2.md
+++ b/desktop-src/WinSock/error-codes-errno-h-errno-and-wsagetlasterror-2.md
@@ -53,7 +53,7 @@ if (r == -1       /* (but see below) */
 
 
 
-Although error constants consistent with Berkeley Sockets 4.3 are provided for compatibility purposes, applications are strongly encouraged to use the WSA error code definitions. This is because error codes returned by certain Windows Sockets functions fall into the standard range of error codes as defined by Microsoft C©. Thus, a better version of the preceding source code fragment is:
+The styles above need the redefinition of BSD socket error constants to WSA error constants in order to work correctly. Although error constants consistent with Berkeley Sockets 4.3 are provided for compatibility purposes, applications are strongly encouraged to use the WSA error code definitions. This is because error codes returned by certain Windows Sockets functions fall into the standard range of error codes as defined by Microsoft C©. Thus, a better version of the preceding source code fragment is:
 
 
 ```C++


### PR DESCRIPTION
- Clarify that the two style examples would also need the redefinition of BSD socket error constants to WSA error constants in order to work correctly.

The documentation says BSD socket error constants can be redefined to be the same as WSA error constants for compatibility, but it was not clear to me that it applies to the two examples "BSD Style" and "Preferred Style".

Also, the documentation says the redefinition is highly discouraged so I would consider renaming so-called "Preferred" style to something else.

Closes #xxxx