### PR TITLE
Replace '❓' with '❔' in DirectX format support

### DIFF
--- a/desktop-src/direct3ddxgi/format-support-for-direct3d-11-0-feature-level-hardware.md
+++ b/desktop-src/direct3ddxgi/format-support-for-direct3d-11-0-feature-level-hardware.md
@@ -79,7 +79,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_TYPELESS<sup>PCS</sup> (1)
 | Target | Support |
@@ -130,7 +130,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_FLOAT<sup>FCS</sup> (2)
 | Target | Support |
@@ -161,7 +161,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -170,8 +170,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -181,7 +181,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_UINT<sup>FCS</sup> (3)
 | Target | Support |
@@ -206,13 +206,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -221,8 +221,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -232,7 +232,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_SINT<sup>FCS</sup> (4)
 | Target | Support |
@@ -263,7 +263,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -272,8 +272,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -283,7 +283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32\_TYPELESS<sup>PCS</sup> (5)
 | Target | Support |
@@ -350,14 +350,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Texture3D | ✔️ Hardware support required. |
 | TextureCube | ✔️ Hardware support required. |
 | Shader ld | ✔️ Hardware support required. |
-| Shader sample (any filter) | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader sample (any filter) | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader sample\_c (comparison filter) | ❌ Disallowed or not available. |
 | Shader sample (mono 1\_bit\_filter) | ❌ Disallowed or not available. |
-| Shader gather4 | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader gather4 | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | 〰️ Required if a related optional feature is supported. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -375,7 +375,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -408,9 +408,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
@@ -426,7 +426,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -459,7 +459,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -477,7 +477,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -538,7 +538,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_FLOAT<sup>FCS</sup> (10)
 | Target | Support |
@@ -569,7 +569,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -579,17 +579,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_UNORM<sup>FCS</sup> (11)
 | Target | Support |
@@ -620,7 +620,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -630,7 +630,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -640,7 +640,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_UINT<sup>FCS</sup> (12)
 | Target | Support |
@@ -665,13 +665,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -681,7 +681,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -691,7 +691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_SNORM<sup>FCS</sup> (13)
 | Target | Support |
@@ -722,7 +722,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -732,7 +732,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -742,7 +742,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_SINT<sup>FCS</sup> (14)
 | Target | Support |
@@ -773,7 +773,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -783,7 +783,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -793,7 +793,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_TYPELESS<sup>PCS</sup> (15)
 | Target | Support |
@@ -844,7 +844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_FLOAT<sup>FCS</sup> (16)
 | Target | Support |
@@ -875,7 +875,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -885,7 +885,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -895,7 +895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_UINT<sup>FCS</sup> (17)
 | Target | Support |
@@ -920,13 +920,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -936,7 +936,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -946,7 +946,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_SINT<sup>FCS</sup> (18)
 | Target | Support |
@@ -977,7 +977,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -987,7 +987,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -997,7 +997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G8X24\_TYPELESS<sup>PCS</sup> (19)
 | Target | Support |
@@ -1089,7 +1089,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1252,7 +1252,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10A2\_UNORM<sup>FCS</sup> (24)
 | Target | Support |
@@ -1283,7 +1283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1293,17 +1293,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10A2\_UINT<sup>FCS</sup> (25)
 | Target | Support |
@@ -1328,13 +1328,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1344,7 +1344,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1354,7 +1354,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10\_XR\_BIAS\_A2\_UNORM<sup>FCS</sup> (89)
 | Target | Support |
@@ -1401,11 +1401,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R11G11B10\_FLOAT<sup>FNS</sup> (26)
 | Target | Support |
@@ -1436,7 +1436,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1446,7 +1446,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1456,7 +1456,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_TYPELESS<sup>PCS</sup> (27)
 | Target | Support |
@@ -1507,7 +1507,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UNORM<sup>FCS</sup> (28)
 | Target | Support |
@@ -1538,7 +1538,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1548,17 +1548,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UNORM\_SRGB<sup>FCS</sup> (29)
 | Target | Support |
@@ -1599,17 +1599,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UINT<sup>FCS</sup> (30)
 | Target | Support |
@@ -1634,13 +1634,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1650,7 +1650,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1660,7 +1660,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_SNORM<sup>FCS</sup> (31)
 | Target | Support |
@@ -1691,7 +1691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1701,7 +1701,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1711,7 +1711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_SINT<sup>FCS</sup> (32)
 | Target | Support |
@@ -1742,7 +1742,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1752,7 +1752,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1762,7 +1762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_TYPELESS<sup>PCS</sup> (33)
 | Target | Support |
@@ -1813,7 +1813,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_FLOAT<sup>FCS</sup> (34)
 | Target | Support |
@@ -1844,7 +1844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1854,7 +1854,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1864,7 +1864,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_UNORM<sup>FCS</sup> (35)
 | Target | Support |
@@ -1895,7 +1895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1905,7 +1905,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1915,7 +1915,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_UINT<sup>FCS</sup> (36)
 | Target | Support |
@@ -1940,13 +1940,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1956,7 +1956,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1966,7 +1966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_SNORM<sup>FCS</sup> (37)
 | Target | Support |
@@ -1997,7 +1997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2007,7 +2007,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2017,7 +2017,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_SINT<sup>FCS</sup> (38)
 | Target | Support |
@@ -2048,7 +2048,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2058,7 +2058,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2068,7 +2068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_TYPELESS<sup>PCS</sup> (39)
 | Target | Support |
@@ -2119,7 +2119,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_D32\_FLOAT<sup>FCS</sup> (40)
 | Target | Support |
@@ -2160,7 +2160,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2170,7 +2170,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_FLOAT<sup>FCS</sup> (41)
 | Target | Support |
@@ -2211,7 +2211,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2221,7 +2221,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_UINT<sup>FCS</sup> (42)
 | Target | Support |
@@ -2246,7 +2246,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
@@ -2262,7 +2262,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2272,7 +2272,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_SINT<sup>FCS</sup> (43)
 | Target | Support |
@@ -2313,7 +2313,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2323,7 +2323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R24G8\_TYPELESS<sup>PCS</sup> (44)
 | Target | Support |
@@ -2415,7 +2415,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2578,7 +2578,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_UNORM<sup>FCS</sup> (49)
 | Target | Support |
@@ -2609,7 +2609,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2619,7 +2619,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2629,7 +2629,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_UINT<sup>FCS</sup> (50)
 | Target | Support |
@@ -2654,13 +2654,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2670,7 +2670,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2680,7 +2680,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_SNORM<sup>FCS</sup> (51)
 | Target | Support |
@@ -2711,7 +2711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2721,7 +2721,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2731,7 +2731,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_SINT<sup>FCS</sup> (52)
 | Target | Support |
@@ -2762,7 +2762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2772,7 +2772,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2782,7 +2782,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_TYPELESS<sup>PCS</sup> (53)
 | Target | Support |
@@ -2833,7 +2833,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_FLOAT<sup>FCS</sup> (54)
 | Target | Support |
@@ -2864,7 +2864,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2874,7 +2874,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2884,7 +2884,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_D16\_UNORM<sup>FCS</sup> (55)
 | Target | Support |
@@ -2925,7 +2925,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2935,7 +2935,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_UNORM<sup>FCS</sup> (56)
 | Target | Support |
@@ -2966,7 +2966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2976,7 +2976,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2986,7 +2986,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_UINT<sup>FCS</sup> (57)
 | Target | Support |
@@ -3011,13 +3011,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3027,7 +3027,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3037,7 +3037,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_SNORM<sup>FCS</sup> (58)
 | Target | Support |
@@ -3068,7 +3068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3078,7 +3078,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3088,7 +3088,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_SINT<sup>FCS</sup> (59)
 | Target | Support |
@@ -3119,7 +3119,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3129,7 +3129,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3139,7 +3139,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_TYPELESS<sup>PCS</sup> (60)
 | Target | Support |
@@ -3190,7 +3190,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_UNORM<sup>FCS</sup> (61)
 | Target | Support |
@@ -3221,7 +3221,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3231,7 +3231,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3241,7 +3241,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_UINT<sup>FCS</sup> (62)
 | Target | Support |
@@ -3266,13 +3266,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
 | RenderTarget | ✔️ Hardware support required. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
-| Output Merger Logic Op | ❓ Hardware support optional; format might be hardware accelerated. |
+| Output Merger Logic Op | ❔ Hardware support optional; format might be hardware accelerated. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3282,7 +3282,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3292,7 +3292,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_SNORM<sup>FCS</sup> (63)
 | Target | Support |
@@ -3323,7 +3323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3333,7 +3333,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3343,7 +3343,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_SINT<sup>FCS</sup> (64)
 | Target | Support |
@@ -3374,7 +3374,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3384,7 +3384,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3394,7 +3394,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_A8\_UNORM<sup>FNS</sup> (65)
 | Target | Support |
@@ -3425,7 +3425,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3435,7 +3435,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3445,7 +3445,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R9G9B9E5\_SHAREDEXP<sup>FNC</sup> (67)
 | Target | Support |
@@ -3496,7 +3496,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_B8G8\_UNORM<sup>FNC</sup> (68)
 | Target | Support |
@@ -3649,7 +3649,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC1\_UNORM <sup>FCC</sup> (71)
 | Target | Support |
@@ -3700,7 +3700,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC1\_UNORM\_SRGB <sup>FCC</sup> (72)
 | Target | Support |
@@ -3751,7 +3751,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_TYPELESS<sup>PCC</sup> (73)
 | Target | Support |
@@ -3802,7 +3802,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_UNORM <sup>FCC</sup> (74)
 | Target | Support |
@@ -3853,7 +3853,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_UNORM\_SRGB <sup>FCC</sup> (75)
 | Target | Support |
@@ -3904,7 +3904,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_TYPELESS<sup>PCC</sup> (76)
 | Target | Support |
@@ -3955,7 +3955,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_UNORM <sup>FCC</sup> (77)
 | Target | Support |
@@ -4006,7 +4006,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_UNORM\_SRGB <sup>FCC</sup> (78)
 | Target | Support |
@@ -4057,7 +4057,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_TYPELESS<sup>PCC</sup> (79)
 | Target | Support |
@@ -4108,7 +4108,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_UNORM <sup>FCC</sup> (80)
 | Target | Support |
@@ -4159,7 +4159,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_SNORM <sup>FCC</sup> (81)
 | Target | Support |
@@ -4210,7 +4210,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_TYPELESS<sup>PCC</sup> (82)
 | Target | Support |
@@ -4261,7 +4261,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_UNORM <sup>FCC</sup> (83)
 | Target | Support |
@@ -4312,7 +4312,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_SNORM <sup>FCC</sup> (84)
 | Target | Support |
@@ -4363,15 +4363,15 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B5G6R5\_UNORM<sup>FNS</sup> (85)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4392,9 +4392,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4414,15 +4414,15 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B5G5R5A1\_UNORM<sup>FNS</sup> (86)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4436,16 +4436,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4453,11 +4453,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -4465,7 +4465,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8\_TYPELESS<sup>PCS</sup> (90)
 | Target | Support |
@@ -4516,7 +4516,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8_UNORM<sup>FCS</sup> (87)
 | Target | Support |
@@ -4545,9 +4545,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
-| UAV Typed Store | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
-| UAV Typed Load | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
+| Typed UAV | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
+| UAV Typed Store | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
+| UAV Typed Load | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. Disallowed or not available for Direct3D 11. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4557,17 +4557,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8\_UNORM\_SRGB<sup>FCS</sup> (91)
 | Target | Support |
@@ -4608,17 +4608,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_TYPELESS<sup>PCS</sup> (92)
 | Target | Support |
@@ -4669,7 +4669,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_UNORM<sup>FCS</sup> (88)
 | Target | Support |
@@ -4710,17 +4710,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_UNORM\_SRGB<sup>FCS</sup> (93)
 | Target | Support |
@@ -4761,7 +4761,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -4771,7 +4771,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_TYPELESS<sup>PCC</sup> (94)
 | Target | Support |
@@ -4822,7 +4822,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_UF16 <sup>FCC</sup> (95)
 | Target | Support |
@@ -4873,7 +4873,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_SF16 <sup>FCC</sup> (96)
 | Target | Support |
@@ -4924,7 +4924,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_TYPELESS<sup>PCC</sup> (97)
 | Target | Support |
@@ -4975,7 +4975,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_UNORM <sup>FCC</sup> (98)
 | Target | Support |
@@ -5026,7 +5026,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_UNORM\_SRGB <sup>FCC</sup> (99)
 | Target | Support |
@@ -5077,13 +5077,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_AYUV<sup>V</sup> (100)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5123,9 +5123,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5134,7 +5134,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5174,9 +5174,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5185,7 +5185,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 64 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5225,9 +5225,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5287,7 +5287,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5327,9 +5327,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5338,7 +5338,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5378,9 +5378,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5480,9 +5480,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5491,7 +5491,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5531,9 +5531,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5542,7 +5542,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5582,9 +5582,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5593,7 +5593,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5633,9 +5633,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5644,7 +5644,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5695,7 +5695,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5746,7 +5746,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5797,7 +5797,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5849,8 +5849,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -5864,16 +5864,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -5881,11 +5881,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -5893,7 +5893,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## Related topics
 

--- a/desktop-src/direct3ddxgi/format-support-for-direct3d-11-1-feature-level-hardware.md
+++ b/desktop-src/direct3ddxgi/format-support-for-direct3d-11-1-feature-level-hardware.md
@@ -79,7 +79,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_TYPELESS<sup>PCS</sup> (1)
 | Target | Support |
@@ -130,7 +130,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_FLOAT<sup>FCS</sup> (2)
 | Target | Support |
@@ -161,7 +161,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -170,8 +170,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -181,7 +181,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_UINT<sup>FCS</sup> (3)
 | Target | Support |
@@ -212,7 +212,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -221,8 +221,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -232,7 +232,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32A32\_SINT<sup>FCS</sup> (4)
 | Target | Support |
@@ -263,7 +263,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -272,8 +272,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -283,7 +283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32B32\_TYPELESS<sup>PCS</sup> (5)
 | Target | Support |
@@ -350,14 +350,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Texture3D | ✔️ Hardware support required. |
 | TextureCube | ✔️ Hardware support required. |
 | Shader ld | ✔️ Hardware support required. |
-| Shader sample (any filter) | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader sample (any filter) | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader sample\_c (comparison filter) | ❌ Disallowed or not available. |
 | Shader sample (mono 1\_bit\_filter) | ❌ Disallowed or not available. |
-| Shader gather4 | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader gather4 | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | 〰️ Required if a related optional feature is supported. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -375,7 +375,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -408,7 +408,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ✔️ Hardware support required. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -426,7 +426,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -459,7 +459,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -477,7 +477,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -538,7 +538,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_FLOAT<sup>FCS</sup> (10)
 | Target | Support |
@@ -569,7 +569,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -579,17 +579,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_UNORM<sup>FCS</sup> (11)
 | Target | Support |
@@ -620,7 +620,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -630,7 +630,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -640,7 +640,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_UINT<sup>FCS</sup> (12)
 | Target | Support |
@@ -671,7 +671,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -681,7 +681,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -691,7 +691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_SNORM<sup>FCS</sup> (13)
 | Target | Support |
@@ -722,7 +722,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -732,7 +732,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -742,7 +742,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16B16A16\_SINT<sup>FCS</sup> (14)
 | Target | Support |
@@ -773,7 +773,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -783,7 +783,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -793,7 +793,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_TYPELESS<sup>PCS</sup> (15)
 | Target | Support |
@@ -844,7 +844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_FLOAT<sup>FCS</sup> (16)
 | Target | Support |
@@ -875,7 +875,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -885,7 +885,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -895,7 +895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_UINT<sup>FCS</sup> (17)
 | Target | Support |
@@ -926,7 +926,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -936,7 +936,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -946,7 +946,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G32\_SINT<sup>FCS</sup> (18)
 | Target | Support |
@@ -977,7 +977,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -987,7 +987,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -997,7 +997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32G8X24\_TYPELESS<sup>PCS</sup> (19)
 | Target | Support |
@@ -1089,7 +1089,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1252,7 +1252,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10A2\_UNORM<sup>FCS</sup> (24)
 | Target | Support |
@@ -1283,7 +1283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1293,17 +1293,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10A2\_UINT<sup>FCS</sup> (25)
 | Target | Support |
@@ -1334,7 +1334,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1344,7 +1344,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1354,7 +1354,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R10G10B10\_XR\_BIAS\_A2\_UNORM<sup>FCS</sup> (89)
 | Target | Support |
@@ -1401,11 +1401,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R11G11B10\_FLOAT<sup>FNS</sup> (26)
 | Target | Support |
@@ -1436,7 +1436,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1446,7 +1446,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1456,7 +1456,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_TYPELESS<sup>PCS</sup> (27)
 | Target | Support |
@@ -1507,7 +1507,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UNORM<sup>FCS</sup> (28)
 | Target | Support |
@@ -1538,7 +1538,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1548,17 +1548,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UNORM\_SRGB<sup>FCS</sup> (29)
 | Target | Support |
@@ -1599,17 +1599,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_UINT<sup>FCS</sup> (30)
 | Target | Support |
@@ -1640,7 +1640,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1650,7 +1650,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1660,7 +1660,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_SNORM<sup>FCS</sup> (31)
 | Target | Support |
@@ -1691,7 +1691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1701,7 +1701,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1711,7 +1711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8B8A8\_SINT<sup>FCS</sup> (32)
 | Target | Support |
@@ -1742,7 +1742,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1752,7 +1752,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1762,7 +1762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_TYPELESS<sup>PCS</sup> (33)
 | Target | Support |
@@ -1813,7 +1813,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_FLOAT<sup>FCS</sup> (34)
 | Target | Support |
@@ -1844,7 +1844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1854,7 +1854,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1864,7 +1864,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_UNORM<sup>FCS</sup> (35)
 | Target | Support |
@@ -1895,7 +1895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1905,7 +1905,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1915,7 +1915,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_UINT<sup>FCS</sup> (36)
 | Target | Support |
@@ -1946,7 +1946,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1956,7 +1956,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1966,7 +1966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_SNORM<sup>FCS</sup> (37)
 | Target | Support |
@@ -1997,7 +1997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2007,7 +2007,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2017,7 +2017,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16G16\_SINT<sup>FCS</sup> (38)
 | Target | Support |
@@ -2048,7 +2048,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2058,7 +2058,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2068,7 +2068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_TYPELESS<sup>PCS</sup> (39)
 | Target | Support |
@@ -2119,7 +2119,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_D32\_FLOAT<sup>FCS</sup> (40)
 | Target | Support |
@@ -2160,7 +2160,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2170,7 +2170,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_FLOAT<sup>FCS</sup> (41)
 | Target | Support |
@@ -2211,7 +2211,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2221,7 +2221,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_UINT<sup>FCS</sup> (42)
 | Target | Support |
@@ -2262,7 +2262,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2272,7 +2272,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R32\_SINT<sup>FCS</sup> (43)
 | Target | Support |
@@ -2313,7 +2313,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2323,7 +2323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R24G8\_TYPELESS<sup>PCS</sup> (44)
 | Target | Support |
@@ -2415,7 +2415,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2578,7 +2578,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_UNORM<sup>FCS</sup> (49)
 | Target | Support |
@@ -2609,7 +2609,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2619,7 +2619,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2629,7 +2629,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_UINT<sup>FCS</sup> (50)
 | Target | Support |
@@ -2660,7 +2660,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2670,7 +2670,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2680,7 +2680,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_SNORM<sup>FCS</sup> (51)
 | Target | Support |
@@ -2711,7 +2711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2721,7 +2721,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2731,7 +2731,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_SINT<sup>FCS</sup> (52)
 | Target | Support |
@@ -2762,7 +2762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2772,7 +2772,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2782,7 +2782,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_TYPELESS<sup>PCS</sup> (53)
 | Target | Support |
@@ -2833,7 +2833,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_FLOAT<sup>FCS</sup> (54)
 | Target | Support |
@@ -2864,7 +2864,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2874,7 +2874,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2884,7 +2884,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_D16\_UNORM<sup>FCS</sup> (55)
 | Target | Support |
@@ -2925,7 +2925,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2935,7 +2935,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_UNORM<sup>FCS</sup> (56)
 | Target | Support |
@@ -2966,7 +2966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2976,7 +2976,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2986,7 +2986,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_UINT<sup>FCS</sup> (57)
 | Target | Support |
@@ -3017,7 +3017,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3027,7 +3027,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3037,7 +3037,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_SNORM<sup>FCS</sup> (58)
 | Target | Support |
@@ -3068,7 +3068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3078,7 +3078,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3088,7 +3088,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R16\_SINT<sup>FCS</sup> (59)
 | Target | Support |
@@ -3119,7 +3119,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3129,7 +3129,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3139,7 +3139,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_TYPELESS<sup>PCS</sup> (60)
 | Target | Support |
@@ -3190,7 +3190,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_UNORM<sup>FCS</sup> (61)
 | Target | Support |
@@ -3221,7 +3221,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3231,7 +3231,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3241,7 +3241,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_UINT<sup>FCS</sup> (62)
 | Target | Support |
@@ -3272,7 +3272,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3282,7 +3282,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3292,7 +3292,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_SNORM<sup>FCS</sup> (63)
 | Target | Support |
@@ -3323,7 +3323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3333,7 +3333,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3343,7 +3343,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8\_SINT<sup>FCS</sup> (64)
 | Target | Support |
@@ -3374,7 +3374,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3384,7 +3384,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3394,7 +3394,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_A8\_UNORM<sup>FNS</sup> (65)
 | Target | Support |
@@ -3425,7 +3425,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3435,7 +3435,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3445,7 +3445,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R9G9B9E5\_SHAREDEXP<sup>FNC</sup> (67)
 | Target | Support |
@@ -3496,7 +3496,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_R8G8\_B8G8\_UNORM<sup>FNC</sup> (68)
 | Target | Support |
@@ -3649,7 +3649,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC1\_UNORM <sup>FCC</sup> (71)
 | Target | Support |
@@ -3700,7 +3700,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC1\_UNORM\_SRGB <sup>FCC</sup> (72)
 | Target | Support |
@@ -3751,7 +3751,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_TYPELESS<sup>PCC</sup> (73)
 | Target | Support |
@@ -3802,7 +3802,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_UNORM <sup>FCC</sup> (74)
 | Target | Support |
@@ -3853,7 +3853,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC2\_UNORM\_SRGB <sup>FCC</sup> (75)
 | Target | Support |
@@ -3904,7 +3904,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_TYPELESS<sup>PCC</sup> (76)
 | Target | Support |
@@ -3955,7 +3955,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_UNORM <sup>FCC</sup> (77)
 | Target | Support |
@@ -4006,7 +4006,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC3\_UNORM\_SRGB <sup>FCC</sup> (78)
 | Target | Support |
@@ -4057,7 +4057,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_TYPELESS<sup>PCC</sup> (79)
 | Target | Support |
@@ -4108,7 +4108,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_UNORM <sup>FCC</sup> (80)
 | Target | Support |
@@ -4159,7 +4159,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC4\_SNORM <sup>FCC</sup> (81)
 | Target | Support |
@@ -4210,7 +4210,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_TYPELESS<sup>PCC</sup> (82)
 | Target | Support |
@@ -4261,7 +4261,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_UNORM <sup>FCC</sup> (83)
 | Target | Support |
@@ -4312,7 +4312,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC5\_SNORM <sup>FCC</sup> (84)
 | Target | Support |
@@ -4363,15 +4363,15 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B5G6R5\_UNORM<sup>FNS</sup> (85)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4392,9 +4392,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4414,15 +4414,15 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B5G5R5A1\_UNORM<sup>FNS</sup> (86)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4436,16 +4436,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4453,11 +4453,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -4465,7 +4465,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8\_TYPELESS<sup>PCS</sup> (90)
 | Target | Support |
@@ -4516,7 +4516,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8_UNORM<sup>FCS</sup> (87)
 | Target | Support |
@@ -4545,9 +4545,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Store | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Load | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| Typed UAV | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Store | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Load | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4557,17 +4557,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8A8\_UNORM\_SRGB<sup>FCS</sup> (91)
 | Target | Support |
@@ -4608,17 +4608,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_TYPELESS<sup>PCS</sup> (92)
 | Target | Support |
@@ -4669,7 +4669,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_UNORM<sup>FCS</sup> (88)
 | Target | Support |
@@ -4710,17 +4710,17 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_B8G8R8X8\_UNORM\_SRGB<sup>FCS</sup> (93)
 | Target | Support |
@@ -4761,7 +4761,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -4771,7 +4771,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_TYPELESS<sup>PCC</sup> (94)
 | Target | Support |
@@ -4822,7 +4822,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_UF16 <sup>FCC</sup> (95)
 | Target | Support |
@@ -4873,7 +4873,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC6H\_SF16 <sup>FCC</sup> (96)
 | Target | Support |
@@ -4924,7 +4924,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_TYPELESS<sup>PCC</sup> (97)
 | Target | Support |
@@ -4975,7 +4975,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_UNORM <sup>FCC</sup> (98)
 | Target | Support |
@@ -5026,7 +5026,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_BC7\_UNORM\_SRGB <sup>FCC</sup> (99)
 | Target | Support |
@@ -5077,13 +5077,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## DXGI_FORMAT_AYUV<sup>V</sup> (100)
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5123,9 +5123,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5134,7 +5134,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5174,9 +5174,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5185,7 +5185,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 64 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5225,9 +5225,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5287,7 +5287,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5327,9 +5327,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5338,7 +5338,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5378,9 +5378,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5480,9 +5480,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5491,7 +5491,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5531,9 +5531,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5542,7 +5542,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5582,9 +5582,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5593,7 +5593,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5633,9 +5633,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5644,7 +5644,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5695,7 +5695,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5746,7 +5746,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5797,7 +5797,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5849,8 +5849,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -5864,16 +5864,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -5881,11 +5881,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -5893,7 +5893,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Video Processor Output | ❌ Disallowed or not available. |
 | Shared Resource | ❌ Disallowed or not available. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
-| Tiled Resource | ❓ Hardware support optional; format might be hardware accelerated. |
+| Tiled Resource | ❔ Hardware support optional; format might be hardware accelerated. |
 
 ## Related topics
 

--- a/desktop-src/direct3ddxgi/hardware-support-for-direct3d-12-0-formats.md
+++ b/desktop-src/direct3ddxgi/hardware-support-for-direct3d-12-0-formats.md
@@ -170,8 +170,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -221,8 +221,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -272,8 +272,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -350,14 +350,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Texture3D | ✔️ Hardware support required. |
 | TextureCube | ✔️ Hardware support required. |
 | Shader ld | ✔️ Hardware support required. |
-| Shader sample (any filter) | ❓ Hardware support optional; format might be hardware accelerated.|
+| Shader sample (any filter) | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shader sample\_c (comparison filter) | ❌ Disallowed or not available. |
 | Shader sample (mono 1\_bit\_filter) | ❌ Disallowed or not available. |
-| Shader gather4 | ❓ Hardware support optional; format might be hardware accelerated.|
+| Shader gather4 | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated.|
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated.|
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
 | Blendable RenderTarget | 〰️ Required if a related optional feature is supported. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -375,7 +375,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -408,7 +408,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ✔️ Hardware support required. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -426,7 +426,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -459,7 +459,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto-Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -477,7 +477,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -579,13 +579,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
@@ -620,7 +620,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -630,7 +630,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -681,7 +681,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -722,7 +722,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -732,7 +732,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -783,7 +783,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -875,7 +875,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -885,7 +885,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -926,7 +926,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -936,7 +936,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -977,7 +977,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -987,7 +987,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1089,7 +1089,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1283,7 +1283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1293,13 +1293,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1334,7 +1334,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1344,7 +1344,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1401,7 +1401,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1436,7 +1436,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1446,7 +1446,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1548,13 +1548,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1599,13 +1599,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1650,7 +1650,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1691,7 +1691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1701,7 +1701,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1752,7 +1752,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1844,7 +1844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1854,7 +1854,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1895,7 +1895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1905,7 +1905,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1946,7 +1946,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1956,7 +1956,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1997,7 +1997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2007,7 +2007,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2048,7 +2048,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2058,7 +2058,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2160,7 +2160,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2211,7 +2211,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2262,7 +2262,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2313,7 +2313,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2415,7 +2415,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2609,7 +2609,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2619,7 +2619,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2660,7 +2660,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2670,7 +2670,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2711,7 +2711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2721,7 +2721,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2762,7 +2762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2772,7 +2772,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2874,7 +2874,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2925,7 +2925,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2966,7 +2966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2976,7 +2976,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3027,7 +3027,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3068,7 +3068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3078,7 +3078,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3129,7 +3129,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3231,7 +3231,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3282,7 +3282,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3323,7 +3323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3333,7 +3333,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3384,7 +3384,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3425,7 +3425,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3435,7 +3435,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -4370,8 +4370,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4392,9 +4392,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4421,8 +4421,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4436,16 +4436,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated.|
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated.|
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4453,11 +4453,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -4545,9 +4545,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Store | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Load | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| Typed UAV | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Store | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Load | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4557,13 +4557,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -4608,13 +4608,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -4710,14 +4710,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ✔️ Hardware support required. |
@@ -4761,7 +4761,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -5083,7 +5083,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5123,9 +5123,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5134,7 +5134,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5174,9 +5174,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5185,7 +5185,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 64 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5225,9 +5225,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5287,7 +5287,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5327,9 +5327,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5338,7 +5338,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5378,9 +5378,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5480,9 +5480,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5491,7 +5491,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5531,9 +5531,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5542,7 +5542,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5582,9 +5582,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5593,7 +5593,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5633,9 +5633,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated.|
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated.|
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated.|
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated.|
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5644,7 +5644,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5695,7 +5695,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5746,7 +5746,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5797,7 +5797,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated.|
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated.|
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5849,8 +5849,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated.|
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated.|
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -5864,16 +5864,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4\_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto-Generation | ❓ Hardware support optional; format might be hardware accelerated.|
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
+| Mipmap Auto-Generation | ❔ Hardware support optional; format might be hardware accelerated.|
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated.|
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated.|
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -5881,11 +5881,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated.|
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated.|
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated.|
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated.|
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated.|
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated.|
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |

--- a/desktop-src/direct3ddxgi/hardware-support-for-direct3d-12-1-formats.md
+++ b/desktop-src/direct3ddxgi/hardware-support-for-direct3d-12-1-formats.md
@@ -170,8 +170,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -221,8 +221,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -272,8 +272,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -350,14 +350,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Texture3D | ✔️ Hardware support required. |
 | TextureCube | ✔️ Hardware support required. |
 | Shader ld | ✔️ Hardware support required. |
-| Shader sample (any filter) | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader sample (any filter) | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader sample_c (comparison filter) | ❌ Disallowed or not available. |
 | Shader sample (mono 1_bit_filter) | ❌ Disallowed or not available. |
-| Shader gather4 | ❓ Hardware support optional; format might be hardware accelerated. |
+| Shader gather4 | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shader gather4_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto- Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto- Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | 〰️ Required if a related optional feature is supported. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -375,7 +375,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -408,7 +408,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto- Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ✔️ Hardware support required. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -426,7 +426,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -459,7 +459,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
 | Mipmap Auto- Generation | ❌ Disallowed or not available. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Blendable RenderTarget | ❌ Disallowed or not available. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
@@ -477,7 +477,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
 | 8x Multisample RenderTarget | 〰️ Required if a related optional feature is supported. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -579,13 +579,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
@@ -620,7 +620,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -630,7 +630,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -681,7 +681,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -722,7 +722,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -732,7 +732,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -783,7 +783,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -875,7 +875,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -885,7 +885,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -926,7 +926,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -936,7 +936,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -977,7 +977,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -987,7 +987,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1089,7 +1089,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1283,7 +1283,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1293,13 +1293,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1334,7 +1334,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1344,7 +1344,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1401,7 +1401,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1436,7 +1436,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1446,7 +1446,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1548,13 +1548,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1599,13 +1599,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -1650,7 +1650,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1691,7 +1691,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1701,7 +1701,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1752,7 +1752,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1844,7 +1844,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1854,7 +1854,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1895,7 +1895,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1905,7 +1905,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1946,7 +1946,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -1956,7 +1956,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -1997,7 +1997,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2007,7 +2007,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2048,7 +2048,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2058,7 +2058,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2160,7 +2160,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2211,7 +2211,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2262,7 +2262,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2313,7 +2313,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2415,7 +2415,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2609,7 +2609,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2619,7 +2619,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2660,7 +2660,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2670,7 +2670,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2711,7 +2711,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2721,7 +2721,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2762,7 +2762,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2772,7 +2772,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2874,7 +2874,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2925,7 +2925,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -2966,7 +2966,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -2976,7 +2976,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3027,7 +3027,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3068,7 +3068,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3078,7 +3078,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3129,7 +3129,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3231,7 +3231,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3282,7 +3282,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3323,7 +3323,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3333,7 +3333,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3384,7 +3384,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ❌ Disallowed or not available. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -3425,7 +3425,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Structured UAV and SRV | ❌ Disallowed or not available. |
 | Typed UAV | ✔️ Hardware support required. |
 | UAV Typed Store | ✔️ Hardware support required. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -3435,7 +3435,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -4370,8 +4370,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4392,9 +4392,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4421,8 +4421,8 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | - | - |
 | Bits Per Element (BPE) | 16 |
 | Format Support | ✔️ Hardware support required. |
-| Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
-| Input Assembler Vertex Buffer | ❓ Hardware support optional; format might be hardware accelerated. |
+| Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
+| Input Assembler Vertex Buffer | ❔ Hardware support optional; format might be hardware accelerated. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
 | Stream Output Buffer | ❌ Disallowed or not available. |
 | Texture1D | ✔️ Hardware support required. |
@@ -4436,16 +4436,16 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Shader gather4 | ✔️ Hardware support required. |
 | Shader gather4_c | ❌ Disallowed or not available. |
 | Mipmap | ✔️ Hardware support required. |
-| Mipmap Auto- Generation | ❓ Hardware support optional; format might be hardware accelerated. |
-| RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Blendable RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
+| Mipmap Auto- Generation | ❔ Hardware support optional; format might be hardware accelerated. |
+| RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Blendable RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
 | Output Merger Logic Op | ❌ Disallowed or not available. |
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Store | ❓ Hardware support optional; format might be hardware accelerated. |
-| UAV Typed Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Typed UAV | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Store | ❔ Hardware support optional; format might be hardware accelerated. |
+| UAV Typed Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4453,11 +4453,11 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | UAV Atomic Signed Min/Max | ❌ Disallowed or not available. |
 | UAV Atomic Unsigned Min/Max | ❌ Disallowed or not available. |
 | CPU Lockable | ✔️ Hardware support required. |
-| 4x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| 8x Multisample RenderTarget | ❓ Hardware support optional; format might be hardware accelerated. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| 4x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| 8x Multisample RenderTarget | ❔ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
-| Multisample Load | ❓ Hardware support optional; format might be hardware accelerated. |
+| Multisample Load | ❔ Hardware support optional; format might be hardware accelerated. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
 | Video Decoder Support | ❌ Disallowed or not available. |
@@ -4545,9 +4545,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Depth/Stencil Target | ❌ Disallowed or not available. |
 | Raw UAV and SRV | ❌ Disallowed or not available. |
 | Structured UAV and SRV | ❌ Disallowed or not available. |
-| Typed UAV | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Store | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
-| UAV Typed Load | ❓[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| Typed UAV | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Store | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
+| UAV Typed Load | ❔[**12**] Hardware support optional for Direct3D 12; format might be hardware accelerated. |
 | UAV Atomic Add | ❌ Disallowed or not available. |
 | UAV Atomic Bitwise Ops | ❌ Disallowed or not available. |
 | UAV Atomic Cmp&Store/ Cmp&Exch | ❌ Disallowed or not available. |
@@ -4557,13 +4557,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -4608,13 +4608,13 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ✔️ Hardware support required. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Output | ✔️ Hardware support required. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ✔️ Hardware support required. |
@@ -4710,14 +4710,14 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ✔️ Hardware support required. |
 | Video Decoder Support | ❌ Disallowed or not available. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ✔️ Hardware support required. |
@@ -4761,7 +4761,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | CPU Lockable | ✔️ Hardware support required. |
 | 4x Multisample RenderTarget | ✔️ Hardware support required. |
 | 8x Multisample RenderTarget | ✔️ Hardware support required. |
-| Other Multisample Count RT | ❓ Hardware support optional; format might be hardware accelerated. |
+| Other Multisample Count RT | ❔ Hardware support optional; format might be hardware accelerated. |
 | Multisample Resolve | ✔️ Hardware support required. |
 | Multisample Load | ✔️ Hardware support required. |
 | Display Scan-Out | ❌ Disallowed or not available. |
@@ -5083,7 +5083,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5123,9 +5123,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5134,7 +5134,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5174,9 +5174,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5185,7 +5185,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 64 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5225,9 +5225,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5287,7 +5287,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5327,9 +5327,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5338,7 +5338,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5378,9 +5378,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5480,9 +5480,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Video Processor Input | ✔️ Hardware support required. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5491,7 +5491,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5531,9 +5531,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5542,7 +5542,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 32 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5582,9 +5582,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5593,7 +5593,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5633,9 +5633,9 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Multisample Load | ❌ Disallowed or not available. |
 | Display Scan-Out | ❌ Disallowed or not available. |
 | Cast Within Bit Layout | ❌ Disallowed or not available. |
-| Video Decoder Support | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Input | ❓ Hardware support optional; format might be hardware accelerated. |
-| Video Processor Output | ❓ Hardware support optional; format might be hardware accelerated. |
+| Video Decoder Support | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Input | ❔ Hardware support optional; format might be hardware accelerated. |
+| Video Processor Output | ❔ Hardware support optional; format might be hardware accelerated. |
 | Shared Resource | ✔️ Hardware support required. |
 | BackBuffer Castable Even Fully Typed | ❌ Disallowed or not available. |
 | Tiled Resource | ❌ Disallowed or not available. |
@@ -5644,7 +5644,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5695,7 +5695,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5746,7 +5746,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 8 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |
@@ -5797,7 +5797,7 @@ To programmatically verify format support in D3D11 and D3D12, refer to [Checking
 | Target | Support |
 | - | - |
 | Bits Per Element (BPE) | 16 |
-| Format Support | ❓ Hardware support optional; format might be hardware accelerated. |
+| Format Support | ❔ Hardware support optional; format might be hardware accelerated. |
 | Buffer | ❌ Disallowed or not available. |
 | Input Assembler Vertex Buffer | ❌ Disallowed or not available. |
 | Input Assembler Index Buffer | ❌ Disallowed or not available. |


### PR DESCRIPTION
Regarding f0d952cd63ba7b7f00c828bdb975e26c6038ea96 authored by @Karl-Bridge-Microsoft.

These pages are invaluable when performing DirectX format/functionality cross-comparisons, to evaluate _best-fit_ formats, etc.

Requesting that we use '❔' (`U+2754`) rather than '❓' (`U+2753`), so that _optional support_ is more clearly discernible from '❌'.