### PR TITLE
Update for WINHTTP_OPTION_HTTP_VERSION description

### DIFF
--- a/desktop-src/WinHttp/option-flags.md
+++ b/desktop-src/WinHttp/option-flags.md
@@ -240,9 +240,10 @@ Gets a DWORD indicating which advanced HTTP version was used on a given request.
 
 ## WINHTTP_OPTION_HTTP_VERSION
 
-Sets or retrieves an [**HTTP\_VERSION\_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure that contains the legacy HTTP version being supported. This structure is valid for HTTP/1.0 and HTTP/1.1, to configure and observe modern HTTP versions, see **WINHTTP\_OPTION\_ENABLE\_HTTP\_PROTOCOL** and **WINHTTP\_OPTION\_HTTP\_PROTOCOL\_USED**.
+Sets or retrieves an [**HTTP\_VERSION\_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure declaring the supported legacy HTTP version. This is a process-wide option; use **NULL** for the handle.
 
-This is a process-wide option; use **NULL** for the handle.
+> [!NOTE]
+> This structure is valid for HTTP/1.0 and HTTP/1.1. For modern HTTP versions, see **WINHTTP\_OPTION\_ENABLE\_HTTP\_PROTOCOL** and **WINHTTP\_OPTION\_HTTP\_PROTOCOL\_USED**.
 
 ## WINHTTP_OPTION_HTTP2_KEEPALIVE
 

--- a/desktop-src/WinHttp/option-flags.md
+++ b/desktop-src/WinHttp/option-flags.md
@@ -240,10 +240,10 @@ Gets a DWORD indicating which advanced HTTP version was used on a given request.
 
 ## WINHTTP_OPTION_HTTP_VERSION
 
-Sets or retrieves an [**HTTP\_VERSION\_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure declaring the supported legacy HTTP version. This is a process-wide option; use **NULL** for the handle.
+Sets or retrieves an [**HTTP_VERSION_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure declaring the supported legacy HTTP version. This is a process-wide option; use **NULL** for the handle.
 
 > [!NOTE]
-> This structure is valid for HTTP/1.0 and HTTP/1.1. For modern HTTP versions, see **WINHTTP\_OPTION\_ENABLE\_HTTP\_PROTOCOL** and **WINHTTP\_OPTION\_HTTP\_PROTOCOL\_USED**.
+> This structure is valid for HTTP/1.0 and HTTP/1.1. For modern HTTP versions, see **WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL** and **WINHTTP_OPTION_HTTP_PROTOCOL_USED**.
 
 ## WINHTTP_OPTION_HTTP2_KEEPALIVE
 

--- a/desktop-src/WinHttp/option-flags.md
+++ b/desktop-src/WinHttp/option-flags.md
@@ -240,7 +240,9 @@ Gets a DWORD indicating which advanced HTTP version was used on a given request.
 
 ## WINHTTP_OPTION_HTTP_VERSION
 
-Sets or retrieves an [**HTTP\_VERSION\_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure that contains the HTTP version being supported. This is a process-wide option; use **NULL** for the handle.
+Sets or retrieves an [**HTTP\_VERSION\_INFO**](/windows/win32/api/winhttp/ns-winhttp-http_version_info) structure that contains the legacy HTTP version being supported. This structure is valid for HTTP/1.0 and HTTP/1.1, to configure and observe modern HTTP versions, see **WINHTTP\_OPTION\_ENABLE\_HTTP\_PROTOCOL** and **WINHTTP\_OPTION\_HTTP\_PROTOCOL\_USED**.
+
+This is a process-wide option; use **NULL** for the handle.
 
 ## WINHTTP_OPTION_HTTP2_KEEPALIVE
 


### PR DESCRIPTION
I've received comments that it's difficult to understand how to determine what HTTP version(s) is/are in use or supported, especially because the documentation around `WINHTTP_OPTION_HTTP_VERSION` is out of date and seems to describe a behavior it will never actually perform. This change modifies the text on that option to clearly identify that it's for legacy protocols (HTTP/1.0 & HTTP/1.1) and directs the reader to the options used for modern HTTP.