### PR TITLE
VK_PACKET is also invalid for WM_SETHOTKEY

### DIFF
--- a/desktop-src/inputdev/wm-sethotkey.md
+++ b/desktop-src/inputdev/wm-sethotkey.md
@@ -81,7 +81,7 @@ The return value is one of the following.
 
 A hot key cannot be associated with a child window.
 
-**VK\_ESCAPE**, **VK\_SPACE**, and **VK\_TAB** are invalid hot keys.
+**VK\_ESCAPE**, **VK\_SPACE**, **VK\_TAB**, and **VK\_PACKET** are invalid hot keys.
 
 When the user presses the hot key, the system generates a [**WM\_SYSCOMMAND**](/windows/desktop/menurc/wm-syscommand) message with *wParam* equal to **SC\_HOTKEY** and *lParam* equal to the window's handle. If this message is passed on to [**DefWindowProc**](/windows/desktop/api/winuser/nf-winuser-defwindowproca), the system will bring the window's last active popup (if it exists) or the window itself (if there is no popup window) to the foreground.
 


### PR DESCRIPTION
Testing WM_SETHOTKEY seems to show that VK_PACKET is also an invalid "hotkey", besides VK_ESCAPE, VK_SPACE, and VK_TAB. VK_PACKET is a pseudo-hotkey indicator value that is normally used in combination with other hotkeys.