### PR TITLE
correct SystemResponsiveness rounding and clamp rules

### DIFF
--- a/desktop-src/ProcThread/multimedia-class-scheduler-service.md
+++ b/desktop-src/ProcThread/multimedia-class-scheduler-service.md
@@ -22,7 +22,7 @@ The MMCSS settings are stored in the following registry key:
 
 **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Multimedia\\SystemProfile**
 
-This key contains a **REG\_DWORD** value named **SystemResponsiveness** that determines the percentage of CPU resources that should be guaranteed to low-priority tasks. For example, if this value is 20, then 20 % of CPU resources are reserved for low-priority tasks. Note that values between 10 and 100 that are not evenly divisible by 10 are rounded **down** to the nearest lower multiple of 10. Values **below 10** and **above 100** are clamped to 20. A value of **100 disables MMCSS** (driver returns `STATUS_SERVER_DISABLED`).
+This key contains a **REG\_DWORD** value named **SystemResponsiveness** that determines the percentage of CPU resources that should be guaranteed to low-priority tasks. For example, if this value is 20, then 20% of CPU resources are reserved for low-priority tasks. Note that values that are not evenly divisible by 10 are rounded down to the nearest multiple of 10. Values below 10 and above 100 are clamped to 20. A value of 100 disables MMCSS (driver returns `STATUS_SERVER_DISABLED`).
 
 The key also contains a subkey named **Tasks** that contains the list of tasks. By default, Windows supports the following tasks:
 

--- a/desktop-src/ProcThread/multimedia-class-scheduler-service.md
+++ b/desktop-src/ProcThread/multimedia-class-scheduler-service.md
@@ -22,7 +22,7 @@ The MMCSS settings are stored in the following registry key:
 
 **HKEY\_LOCAL\_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Multimedia\\SystemProfile**
 
-This key contains a **REG\_DWORD** value named **SystemResponsiveness** that determines the percentage of CPU resources that should be guaranteed to low-priority tasks. For example, if this value is 20, then 20% of CPU resources are reserved for low-priority tasks. Note that values that are not evenly divisible by 10 are rounded up to the nearest multiple of 10. A value of 0 is also treated as 10.
+This key contains a **REG\_DWORD** value named **SystemResponsiveness** that determines the percentage of CPU resources that should be guaranteed to low-priority tasks. For example, if this value is 20, then 20 % of CPU resources are reserved for low-priority tasks. Note that values between 10 and 100 that are not evenly divisible by 10 are rounded **down** to the nearest lower multiple of 10. Values **below 10** and **above 100** are clamped to 20. A value of **100 disables MMCSS** (driver returns `STATUS_SERVER_DISABLED`).
 
 The key also contains a subkey named **Tasks** that contains the list of tasks. By default, Windows supports the following tasks:
 


### PR DESCRIPTION
Replaces the outdated sentence that said  
“Note that values that are not evenly divisible by 10 are rounded up to the nearest multiple of 10. A value of 0 is also treated as 10”.

Clarifies the real driver behavior present in every build from
Vista RTM to Windows 11:

10–100 -> rounded down to the nearest lower multiple of 10  
0–9 and >100 -> clamped to 20 %  
100 (or a missing value, default 100) disables MMCSS  
(driver returns STATUS_SERVER_DISABLED, 0xC0000080)

Source: disassembly of mmcss.sys/mmcss.dll versions 6.0.6000.16386 through
10.0.26100.1 shows:

```c
if (value - 10 > 90)      // 0–9 and >100
    effective = 20;       // clamp
else
    effective = 10 * (value / 10);  // integer division floors to lower 10
```
This logic discards the remainder (integer division) and therefore always floors to a lower multiple of 10.