### PR TITLE
Update quality-of-service.md to document inactivity based QoS management and add instructions to disable

### DIFF
--- a/desktop-src/ProcThread/quality-of-service.md
+++ b/desktop-src/ProcThread/quality-of-service.md
@@ -18,7 +18,7 @@ The system maintains multiple QoS levels, each with differentiated performance a
 | QoS level | Description|Performance and power | Release |
 | --- | --- | --- | --- |
 | High | Windowed applications that are in the foreground and in focus, or audible, and explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation) | Standard high performance. |1709 |
-| Medium | Windowed applications that may be visible to the end user but are not in focus. Also includes lowering of the foreground application after a period of user inactivity. | Varies by platform, between High and Low. | 1709, Inactivity feature: Ge 2025.05 |
+| Medium | Windowed applications that may be visible to the end user but are not in focus. Also includes lowering the QoS of the foreground application after a period of user inactivity. | Varies by platform, between High and Low. | 1709, Inactivity feature: Ge 2025.05 |
 | Low | Windowed applications that are not visible or audible to the end user. | On battery, selects most efficient CPU frequency and schedules to efficient core. | 1709 |
 | Utility | Background services | On battery, selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 22H2 |
 | Eco | Applications that explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation). | Always selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 |
@@ -26,7 +26,7 @@ The system maintains multiple QoS levels, each with differentiated performance a
 | Deadline | Threads explicitly tagged by [Multimedia Class Scheduler Service](/windows/desktop/procthread/multimedia-class-scheduler-service) to denote that audio threads require performance to meet deadlines. | High performance to meet media deadlines. | 2004 |
 
 ### How to Disable User Inactivity Feature
-By default, Windows may lower the Quality of Service (QoS) policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
+By default, Windows may lower the QoS policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
 
   * **Path**: `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling`
   * **Value Name**: `DisableUserPresenceQos`
@@ -35,7 +35,8 @@ By default, Windows may lower the Quality of Service (QoS) policy of a foregroun
       * `1` (feature is disabled)
       * `0` (feature is enabled)
 
-> **Warning:** Incorrectly editing the registry may cause system instability. Always back up the registry before making changes.
+> [!Warning]
+> Incorrectly editing the registry may cause system instability. Always back up the registry before making changes.
 
 ## Quality of Service classification
 

--- a/desktop-src/ProcThread/quality-of-service.md
+++ b/desktop-src/ProcThread/quality-of-service.md
@@ -18,12 +18,24 @@ The system maintains multiple QoS levels, each with differentiated performance a
 | QoS level | Description|Performance and power | Release |
 | --- | --- | --- | --- |
 | High | Windowed applications that are in the foreground and in focus, or audible, and explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation) | Standard high performance. |1709 |
-| Medium | Windowed applications that may be visible to the end user but are not in focus. | Varies by platform, between High and Low. | 1709 |
+| Medium | Windowed applications that may be visible to the end user but are not in focus. Also includes lowering of the foreground application after a period of user inactivity. | Varies by platform, between High and Low. | 1709, Inactivity feature: Ge 2025.05 |
 | Low | Windowed applications that are not visible or audible to the end user. | On battery, selects most efficient CPU frequency and schedules to efficient core. | 1709 |
 | Utility | Background services | On battery, selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 22H2 |
 | Eco | Applications that explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation). | Always selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 |
 | Media | Threads explicitly tagged by the [Multimedia Class Scheduler Service](/windows/desktop/procthread/multimedia-class-scheduler-service) to denote multimedia batch buffering. | CPU frequency reduced for efficient batch processing. | 2004 |
 | Deadline | Threads explicitly tagged by [Multimedia Class Scheduler Service](/windows/desktop/procthread/multimedia-class-scheduler-service) to denote that audio threads require performance to meet deadlines. | High performance to meet media deadlines. | 2004 |
+
+### How to Disable User Inactivity Feature
+By default, Windows may lower the Quality of Service (QoS) policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
+
+  * **Path**: `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling`
+  * **Value Name**: `DisableUserPresenceQos`
+  * **Value Type**: `REG_DWORD`
+  * **Value Data**:
+      * `1` (feature is disabled)
+      * `0` (feature is enabled)
+
+> **Warning:** Incorrectly editing the registry may cause system instability. Always back up the registry before making changes.
 
 ## Quality of Service classification
 


### PR DESCRIPTION
## Pull Request Summary
- **QoS table update**: Added a note that Medium QoS now applies to foreground apps after a period of user inactivity and marked its release in **Ge 2025.05**.
- **New disablement section**: Included details for opting-out of the feature via reg key.