### PR TITLE
Fixed bug in example in 3d-perspective-transform.md

### DIFF
--- a/desktop-src/Direct2D/3d-perspective-transform.md
+++ b/desktop-src/Direct2D/3d-perspective-transform.md
@@ -45,7 +45,7 @@ m_d2dContext->CreateEffect(CLSID_D2D13DPerspectiveTransform, &perspectiveTransfo
 
 perspectiveTransformEffect->SetInput(0, bitmap);
 
-perspectiveTransformEffect->SetValue(D2D1_3DPERSPECTIVETRANSFORM_PROP_PERSPECTIVE_ORIGIN, D2D1::Vector3F(0.0f, 192.0f, 0.0f));
+perspectiveTransformEffect->SetValue(D2D1_3DPERSPECTIVETRANSFORM_PROP_PERSPECTIVE_ORIGIN, D2D1::Vector2F(0.0f, 192.0f));
 perspectiveTransformEffect->SetValue(D2D1_3DPERSPECTIVETRANSFORM_PROP_ROTATION, D2D1::Vector3F(0.0f, 30.0f, 0.0f));
 
 m_d2dContext->BeginDraw();


### PR DESCRIPTION
The existing example doesn't work. To make it work you need to change the parameter from Vector3F to Vector2F.