### PR TITLE
Update publishing-your-event-schema-for-a-manifest-base-provider.md to fix schema validation error

### DIFF
--- a/desktop-src/ETW/publishing-your-event-schema-for-a-manifest-base-provider.md
+++ b/desktop-src/ETW/publishing-your-event-schema-for-a-manifest-base-provider.md
@@ -16,7 +16,7 @@ The following manifest defines the events that are used in examples in the [Prov
 <!-- <?xml version="1.0" encoding="UTF-16"?> -->
 <instrumentationManifest
     xmlns="http://schemas.microsoft.com/win/2004/08/events" 
-    xmlns:win="https://manifests.microsoft.com/win/2004/08/windows/events"
+    xmlns:win="http://manifests.microsoft.com/win/2004/08/windows/events"
     xmlns:xs="https://www.w3.org/2001/XMLSchema"    
     >
 


### PR DESCRIPTION
Attempting to compile the manifest with `mc.exe manifest.man` leads to the following error: 
```
error : For <data> element 'Image', the prefix of 'win:Pointer' is not in the winmeta namespace.
```

Changing the https://manifests.microsoft.com/win/2004/08/windows/events URL to http://manifests.microsoft.com/win/2004/08/windows/events (https to http) seem to fix this problem.