### PR TITLE
Update writing-manifest-based-events.md to fix string const cast errors

### DIFF
--- a/desktop-src/ETW/writing-manifest-based-events.md
+++ b/desktop-src/ETW/writing-manifest-based-events.md
@@ -49,8 +49,8 @@ enum TRANSFER_TYPE {
 #define MAX_PAYLOAD_DESCRIPTORS  9 + (2 * MAX_NAMEDVALUES)
 
 typedef struct _namedvalue {
-  LPWSTR name;
-  USHORT value;
+  LPCWSTR name;
+  USHORT  value;
 } NAMEDVALUE, *PNAMEDVALUE;
 
 void wmain(void)
@@ -66,7 +66,7 @@ void wmain(void)
     ULONG pImage = (ULONG)&Scores;
     DWORD TransferType = Upload;
     DWORD Day = MONDAY | TUESDAY;
-    LPWSTR Path = L"c:\\path\\folder\\file.ext";
+    LPCWSTR Path = L"c:\\path\\folder\\file.ext";
     BYTE Cert[11] = {0x2, 0x4, 0x8, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x0, 0x1};
     PBYTE Guid = (PBYTE) &ProviderGuid;
     USHORT ArraySize = MAX_NAMEDVALUES;


### PR DESCRIPTION
Change string type from LPWSTR to LPCWSTR to fix compiler errors like this: `error C2440: 'initializing': cannot convert from 'const wchar_t []' to 'LPWSTR' errors`


## Full error listing
Observed errors when compiling the sample with Visual Studio 2022:
```
1>Main.cpp(41,17): error C2440: 'initializing': cannot convert from 'const wchar_t [24]' to 'LPWSTR'
1>    Main.cpp(41,17):
1>    Conversion from string literal loses const qualifier (see /Zc:strictStrings)
1>Main.cpp(47,10): error C2440: 'initializing': cannot convert from 'const wchar_t [5]' to 'LPWSTR'
1>    Main.cpp(47,10):
1>    Conversion from string literal loses const qualifier (see /Zc:strictStrings)
1>Main.cpp(48,10): error C2440: 'initializing': cannot convert from 'const wchar_t [4]' to 'LPWSTR'
1>    Main.cpp(48,10):
1>    Conversion from string literal loses const qualifier (see /Zc:strictStrings)
1>Main.cpp(49,10): error C2440: 'initializing': cannot convert from 'const wchar_t [8]' to 'LPWSTR'
1>    Main.cpp(49,10):
1>    Conversion from string literal loses const qualifier (see /Zc:strictStrings)
1>Main.cpp(50,10): error C2440: 'initializing': cannot convert from 'const wchar_t [7]' to 'LPWSTR'
1>    Main.cpp(50,10):
1>    Conversion from string literal loses const qualifier (see /Zc:strictStrings)
1>Main.cpp(51,10): error C2440: 'initializing': cannot convert from 'const wchar_t [1]' to 'LPWSTR'
```

I'm also observing `wmain` return-type and pointer truncation warnings. However, those can probably be fixed separately.