### PR TITLE
Update publishing-your-event-schema-for-a-manifest-base-provider.md to make events appear in Event Viewer

### DIFF
--- a/desktop-src/ETW/publishing-your-event-schema-for-a-manifest-base-provider.md
+++ b/desktop-src/ETW/publishing-your-event-schema-for-a-manifest-base-provider.md
@@ -97,12 +97,15 @@ The following manifest defines the events that are used in examples in the [Prov
                     <event value="1" 
                         level="win:Informational" 
                         template="TransferTemplate" 
+                        channel="Application"
                         symbol="TransferEvent"
                         message ="$(string.Event.WhenToTransfer)"
                         keywords="Read Local" />
                 </events>
 
-
+                <channels>
+                    <importChannel name="Application" chid="Application"/>
+                </channels>
             </provider>
 
         </events>


### PR DESCRIPTION
The sample provider is currently hard to test, since events doesn't show up in Event Viewer. Therefore, proposing to map the events to the in-built "Application" channel, so that they show up in the Event Viewer "Application" folder.

Screenshot of how events from the [Writing Manifest-based Events](https://learn.microsoft.com/en-us/windows/win32/etw/writing-manifest-based-events) sample starts to show up in Event Viewer with this change:  
![image](https://github.com/user-attachments/assets/6e1a1631-92dc-42d5-b8b6-b4c1b3db6f02)
