### PR TITLE
Update writing-manifest-based-events.md to fix pointer truncation warning

### DIFF
--- a/desktop-src/ETW/writing-manifest-based-events.md
+++ b/desktop-src/ETW/writing-manifest-based-events.md
@@ -63,7 +63,7 @@ void wmain(void)
     // Data to load into event descriptors
 
     USHORT Scores[3] = {45, 63, 21};
-    ULONG pImage = (ULONG)&Scores;
+    void* pImage = &Scores;
     DWORD TransferType = Upload;
     DWORD Day = MONDAY | TUESDAY;
     LPWSTR Path = L"c:\\path\\folder\\file.ext";
@@ -96,7 +96,7 @@ void wmain(void)
     // Add the data to the array in the order of the <data> elements
     // defined in the event's template. 
    
-    EventDataDescCreate(&Descriptors[i++], &pImage, sizeof(ULONG));
+    EventDataDescCreate(&Descriptors[i++], &pImage, sizeof(pImage));
     EventDataDescCreate(&Descriptors[i++], Scores, sizeof(Scores));
     EventDataDescCreate(&Descriptors[i++], Guid, sizeof(GUID));
     EventDataDescCreate(&Descriptors[i++], Cert, sizeof(Cert));


### PR DESCRIPTION
I'm experiencing the following warnings when building the sample with Visual Studio 2022 against the x64 platform:
```
1>Main.cpp(72,20): warning C4311: 'type cast': pointer truncation from 'USHORT (*)[3]' to 'ULONG'
1>Main.cpp(72,20): warning C4302: 'type cast': truncation from 'USHORT (*)[3]' to 'ULONG'
```

The problem seem to be caused by the code assuming `sizeof(ULONG)`  to match `sizeof(USHORT*)`, which is no longer true in 64bit. Proposing to fix this by changing `pImage` to a pointer type and updating the variable size accordingly in the `EventDataDescCreate` call below.