### PR TITLE
Update writing-manifest-based-events.md with int wmain return-type

### DIFF
--- a/desktop-src/ETW/writing-manifest-based-events.md
+++ b/desktop-src/ETW/writing-manifest-based-events.md
@@ -53,7 +53,7 @@ typedef struct _namedvalue {
   USHORT  value;
 } NAMEDVALUE, *PNAMEDVALUE;
 
-void wmain(void)
+int wmain(void)
 {
     DWORD status = ERROR_SUCCESS;
     REGHANDLE RegistrationHandle = NULL; 
@@ -146,8 +146,8 @@ void wmain(void)
     }
 
 cleanup:
-
     EventUnregister(RegistrationHandle);
+    return 0;
 }
 ```
 


### PR DESCRIPTION
Fixes the following warning when building with the Visual Studio 2022 C++ compiler:
```
>Main.cpp(28,6): warning C4326: return type of 'wmain' should be 'int' instead of 'void'
```