### PR TITLE
Fix "&quot;" inside of code blocks

### DIFF
--- a/desktop-src/ADSI/reading-the-schema.md
+++ b/desktop-src/ADSI/reading-the-schema.md
@@ -22,7 +22,7 @@ Set SchemaContainer = GetObject("LDAP://Fabrikam/Schema")
 
 ```C++
 
-hr = ADsGetObject(L&quot;LDAP://Fabrikam/Schema&quot;, IID_IADsContainer, (void**) &pSchema );
+hr = ADsGetObject(L"LDAP://Fabrikam/Schema", IID_IADsContainer, (void**) &pSchema );
 ```
 
 
@@ -58,7 +58,7 @@ IADsContainer *pSchema=NULL;
 
  CoInitialize(NULL);
 
- hr = ADsGetObject(L&quot;LDAP://Fabrikam/Schema&quot;, 
+ hr = ADsGetObject(L"LDAP://Fabrikam/Schema", 
                    IID_IADsContainer, (void**) &pSchema );
 
  if ( !SUCCEEDED(hr) )
@@ -89,7 +89,7 @@ IADsContainer *pSchema=NULL;
        pChild->get_Name(&bstrName);
        pChild->get_Class(&bstrClass);
                 
-       printf(&quot;%S\t\t(%S)\n&quot;, bstrName, bstrClass );
+       printf("%S\t\t(%S)\n", bstrName, bstrClass );
                 
        // Clean-up
        SysFreeString(bstrName);

--- a/desktop-src/CIMWin32Prov/scheduleautochk-method-in-class-win32-logicaldisk.md
+++ b/desktop-src/CIMWin32Prov/scheduleautochk-method-in-class-win32-logicaldisk.md
@@ -92,7 +92,7 @@ errReturn = objDisk.ScheduleAutoChk(Array("C:"))
 
 ```PowerShell
 
-Invoke-WmiMethod -path win32_logicaldisk -Name ScheduleAutoChk -ArgumentList @(&quot;C:&quot;)
+Invoke-WmiMethod -path win32_logicaldisk -Name ScheduleAutoChk -ArgumentList @("C:")
 ```
 
 

--- a/desktop-src/DirectShow/using-the-sample-grabber.md
+++ b/desktop-src/DirectShow/using-the-sample-grabber.md
@@ -63,7 +63,7 @@ To start, create the [Filter Graph Manager](filter-graph-manager.md) and query f
 
 ## Add the Sample Grabber to the Filter Graph
 
-Create an instance of the Sample Grabber filter and addit to the filter graph. Query the Sample Grabber filter for the [**ISampleGrabber**](isamplegrabber.md) interface.
+Create an instance of the Sample Grabber filter and add it to the filter graph. Query the Sample Grabber filter for the [**ISampleGrabber**](isamplegrabber.md) interface.
 
 
 ```C++
@@ -79,7 +79,7 @@ Create an instance of the Sample Grabber filter and addit to the filter graph. Q
         goto done;
     }
 
-    hr = pGraph->AddFilter(pGrabberF, L&quot;Sample Grabber&quot;);
+    hr = pGraph->AddFilter(pGrabberF, L"Sample Grabber");
     if (FAILED(hr))
     {
         goto done;
@@ -131,7 +131,7 @@ For example, if you specified uncompressed video, you can connect a source filte
     IPin *pPin = NULL;
 
 
-    hr = pGraph->AddSourceFilter(pszVideoFile, L&quot;Source&quot;, &pSourceF);
+    hr = pGraph->AddSourceFilter(pszVideoFile, L"Source", &pSourceF);
     if (FAILED(hr))
     {
         goto done;
@@ -179,7 +179,7 @@ The following example connects the Sample Grabber to the Null Renderer filter:
         goto done;
     }
 
-    hr = pGraph->AddFilter(pNullF, L&quot;Null Filter&quot;);
+    hr = pGraph->AddFilter(pNullF, L"Null Filter");
     if (FAILED(hr))
     {
         goto done;
@@ -368,7 +368,7 @@ HRESULT GrabVideoBitmap(PCWSTR pszVideoFile, PCWSTR pszBitmapFile)
         goto done;
     }
 
-    hr = pGraph->AddFilter(pGrabberF, L&quot;Sample Grabber&quot;);
+    hr = pGraph->AddFilter(pGrabberF, L"Sample Grabber");
     if (FAILED(hr))
     {
         goto done;
@@ -391,7 +391,7 @@ HRESULT GrabVideoBitmap(PCWSTR pszVideoFile, PCWSTR pszBitmapFile)
         goto done;
     }
 
-    hr = pGraph->AddSourceFilter(pszVideoFile, L&quot;Source&quot;, &pSourceF);
+    hr = pGraph->AddSourceFilter(pszVideoFile, L"Source", &pSourceF);
     if (FAILED(hr))
     {
         goto done;
@@ -425,7 +425,7 @@ HRESULT GrabVideoBitmap(PCWSTR pszVideoFile, PCWSTR pszBitmapFile)
         goto done;
     }
 
-    hr = pGraph->AddFilter(pNullF, L&quot;Null Filter&quot;);
+    hr = pGraph->AddFilter(pNullF, L"Null Filter");
     if (FAILED(hr))
     {
         goto done;

--- a/desktop-src/LearnWin32/managing-the-lifetime-of-an-object.md
+++ b/desktop-src/LearnWin32/managing-the-lifetime-of-an-object.md
@@ -75,7 +75,7 @@ if (SUCCEEDED(hr))
                 hr = pItem->GetDisplayName(SIGDN_FILESYSPATH, &pszFilePath);
                 if (SUCCEEDED(hr))
                 {
-                    MessageBox(NULL, pszFilePath, L&quot;File Path&quot;, MB_OK);
+                    MessageBox(NULL, pszFilePath, L"File Path", MB_OK);
                     CoTaskMemFree(pszFilePath);
                 }
                 pItem->Release();

--- a/desktop-src/RRAS/obtaining-the-mib-ii-interfaces-table.md
+++ b/desktop-src/RRAS/obtaining-the-mib-ii-interfaces-table.md
@@ -53,7 +53,7 @@ void main()
 
 #include <windows.h>
 #include <stdio.h>
-#include &quot;Iphlpapi.h&quot;
+#include "Iphlpapi.h"
 
 int __cdecl main(){
 
@@ -70,14 +70,14 @@ int __cdecl main(){
     // Connect to the MIB server to obtain the hMibSrv handle
     dwRes = MprAdminMIBServerConnect(NULL, &hMibSrv);    
     if (dwRes != NO_ERROR){
-        wprintf(L&quot;ERROR: Unable to connect to the MIB server specified.\n&quot;);
+        wprintf(L"ERROR: Unable to connect to the MIB server specified.\n");
         return ERROR_SUCCESS;
     }
 
     // Retrieve the MIB interfaces table. The local RRAS service MUST be running or this call will fail.
     dwRes = MprAdminMIBEntryGet(hMibSrv, PID_IP, IPRTRMGR_PID, (PVOID)&MibOpaqueQuery, dwInSize, (PVOID*)&pMibOpaqueInfo, &dwOutSize);
     if (dwRes != NO_ERROR){
-        wprintf(L&quot;ERROR: Unable to retrieve the MIB interface table.\n&quot;);
+        wprintf(L"ERROR: Unable to retrieve the MIB interface table.\n");
         return ERROR_SUCCESS;
     }
 
@@ -93,10 +93,10 @@ int __cdecl main(){
     pIntfTable = (PMIB_IFTABLE)pMibOpaqueInfo->rgbyData;
 
     // Print out the name and description of each MIB interface in the table
-    wprintf(L&quot;There were %d MIB table records found:\n&quot;, pIntfTable->dwNumEntries);
+    wprintf(L"There were %d MIB table records found:\n", pIntfTable->dwNumEntries);
     for(UINT i=0; i < pIntfTable->dwNumEntries; i++){
-        wprintf(L&quot;%d\t%s\t&quot;, i, pIntfTable->table[i].wszName, pIntfTable->table[i].bDescr);
-        printf(&quot;%s\n&quot;, pIntfTable->table[i].bDescr);
+        wprintf(L"%d\t%s\t", i, pIntfTable->table[i].wszName, pIntfTable->table[i].bDescr);
+        printf("%s\n", pIntfTable->table[i].bDescr);
     }
 
     return ERROR_SUCCESS;

--- a/desktop-src/directcomp/how-to--animate-a-visual.md
+++ b/desktop-src/directcomp/how-to--animate-a-visual.md
@@ -268,21 +268,21 @@ private:
 //
 // ApplyAnimations.cpp
 //
-// THIS CODE AND INFORMATION IS PROVIDED &quot;AS IS&quot; WITHOUT WARRANTY OF
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 // ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
 // PARTICULAR PURPOSE.
 //
 // Copyright (c) Microsoft Corporation. All rights reserved
 
-// Instructions: Click the client area to view a &quot;slide&quot;. This creates
+// Instructions: Click the client area to view a "slide". This creates
 //     a visual and changes the visual&#39;s bitmap content with each click.
-//   Animation is applied to the opacity to &quot;fade in&quot; each new bitmap.
+//   Animation is applied to the opacity to "fade in" each new bitmap.
 
 //
 // NOTE: This app is HARDCODED to look for images in C:\IMAGES.
 //
-#include &quot;ApplyAnimations.h&quot;
+#include "ApplyAnimations.h"
 
 #define OFFSET_X 20
 #define OFFSET_Y 20
@@ -413,8 +413,8 @@ HRESULT DemoApp::Initialize()
         }
 
         m_hwnd = CreateWindow(
-            L&quot;DirectCompDemoApp&quot;,
-            L&quot;DirectComposition Demo Application&quot;,
+            L"DirectCompDemoApp",
+            L"DirectComposition Demo Application",
             WS_OVERLAPPEDWINDOW,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
@@ -618,7 +618,7 @@ HRESULT DemoApp::CreateDeviceResources()
     // TODO: Remove hard coding. Enable the user to 
     //       select a directory.
     //***********************************************
-    GetImageFilenames(L&quot;c:\\images\\*.jpg&quot;);
+    GetImageFilenames(L"c:\\images\\*.jpg");
 
     return hr;
 }
@@ -698,7 +698,7 @@ HRESULT DemoApp::OnClick()
 
         pbuf = new TCHAR[MAX_PATH];
 
-        StringCbCopy((wchar_t *)pbuf, MAX_PATH,  L&quot;c:\\images\\&quot;);
+        StringCbCopy((wchar_t *)pbuf, MAX_PATH,  L"c:\\images\\");
         StringCchCat((wchar_t *)pbuf, MAX_PATH, m_pImageFileNames[i]);
 
         hr = m_pD2DFactory->CreateDxgiSurfaceRenderTarget(pDXGISurface, &props, &pRenderTarget);

--- a/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
+++ b/desktop-src/directcomp/how-to--apply-transforms-and-effects-to-a-visual.md
@@ -316,7 +316,7 @@ private:
 //
 // ApplyEffects.cpp
 //
-// THIS CODE AND INFORMATION IS PROVIDED &quot;AS IS&quot; WITHOUT WARRANTY OF
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 // ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
 // PARTICULAR PURPOSE.
@@ -326,7 +326,7 @@ private:
 // Instructions: Hover over the image to see the opacity change. Click
 //   the image to apply a 3D rotation.
 
-#include &quot;ApplyEffects.h&quot;
+#include "ApplyEffects.h"
 
 #define OFFSET_X 20
 #define OFFSET_Y 20
@@ -540,7 +540,7 @@ HRESULT DemoApp::CreateResources()
 {
     HRESULT hr = S_OK;
 
-    hr = LoadResourceGDIBitmap(L&quot;Penguins&quot;, m_hBitmap);
+    hr = LoadResourceGDIBitmap(L"Penguins", m_hBitmap);
    
     return hr;
 }

--- a/desktop-src/directcomp/initialize-directcomposition.md
+++ b/desktop-src/directcomp/initialize-directcomposition.md
@@ -453,7 +453,7 @@ private:
 //
 // SimpleComposition.cpp
 //
-// THIS CODE AND INFORMATION IS PROVIDED &quot;AS IS&quot; WITHOUT WARRANTY OF
+// THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF
 // ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO
 // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
 // PARTICULAR PURPOSE.
@@ -463,7 +463,7 @@ private:
 // Instructions: Right-click in the client area to cause DirectCompostion
 // to create a simple composition consisting of a single GDI bitmap.
 
-#include &quot;SimpleComposition.h&quot;
+#include "SimpleComposition.h"
 
 /******************************************************************
 *                                                                 *
@@ -547,7 +547,7 @@ HRESULT DemoApp::Initialize()
     wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName  = nullptr;
     wcex.hCursor       = LoadCursor(NULL, IDC_ARROW);
-    wcex.lpszClassName = L&quot;DirectCompDemoApp&quot;;
+    wcex.lpszClassName = L"DirectCompDemoApp";
 
     RegisterClassEx(&wcex);
 
@@ -566,8 +566,8 @@ HRESULT DemoApp::Initialize()
     }
 
     m_hwnd = CreateWindow(
-        L&quot;DirectCompDemoApp&quot;,
-        L&quot;DirectComposition Demo Application&quot;,
+        L"DirectCompDemoApp",
+        L"DirectComposition Demo Application",
         WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT,
         CW_USEDEFAULT,
@@ -665,7 +665,7 @@ HRESULT DemoApp::CreateResources()
 {
     HRESULT hr = S_OK;
 
-    hr = LoadResourceGDIBitmap(L&quot;Logo&quot;, m_hBitmap);
+    hr = LoadResourceGDIBitmap(L"Logo", m_hBitmap);
    
     return hr;
 }

--- a/desktop-src/shell/common-file-dialog.md
+++ b/desktop-src/shell/common-file-dialog.md
@@ -506,7 +506,7 @@ HRESULT AddCustomControls()
                 if (SUCCEEDED(hr))
                 {
                     // Create a Visual Group.
-                    hr = pfdc->StartVisualGroup(CONTROL_GROUP, L&quot;Sample Group&quot;);
+                    hr = pfdc->StartVisualGroup(CONTROL_GROUP, L"Sample Group");
                     if (SUCCEEDED(hr))
                     {
                         // Add a radio-button list.
@@ -521,12 +521,12 @@ HRESULT AddCustomControls()
                                 // Add individual buttons to the radio-button list.
                                 hr = pfdc->AddControlItem(CONTROL_RADIOBUTTONLIST,
                                                           CONTROL_RADIOBUTTON1,
-                                                          L&quot;Change Title to ABC&quot;);
+                                                          L"Change Title to ABC");
                                 if (SUCCEEDED(hr))
                                 {
                                     hr = pfdc->AddControlItem(CONTROL_RADIOBUTTONLIST,
                                                               CONTROL_RADIOBUTTON2,
-                                                              L&quot;Change Title to XYZ&quot;);
+                                                              L"Change Title to XYZ");
                                     if (SUCCEEDED(hr))
                                     {
                                         // Set the default selection to option 1.
@@ -615,13 +615,13 @@ HRESULT AddOpenChoices()
                     hr = pfdc->EnableOpenDropDown(OPENCHOICES);
                     if (SUCCEEDED(hr))
                     {
-                        hr = pfdc->AddControlItem(OPENCHOICES, OPEN, L&quot;&Open&quot;);
+                        hr = pfdc->AddControlItem(OPENCHOICES, OPEN, L"&Open");
                     }                    
                     if (SUCCEEDED(hr))
                     {
                         hr = pfdc->AddControlItem(OPENCHOICES, 
                                                 OPEN_AS_READONLY, 
-                                                L&quot;Open as &read-only&quot;);
+                                                L"Open as &read-only");
                     }
                     if (SUCCEEDED(hr))
                     {

--- a/desktop-src/wsw/service-metadata.md
+++ b/desktop-src/wsw/service-metadata.md
@@ -29,7 +29,7 @@ Optionally, an application can also specify the service name and namespace as pa
 
 ``` syntax
 WS_SERVICE_METADATA_DOCUMENT document = {0};
-WS_STRING documentName = WS_STRING_VALUE(L&quot;a.wsdl&quot;);
+WS_STRING documentName = WS_STRING_VALUE(L"a.wsdl");
 document.name = &documentName;
 document.content = &wsdlDocument
 WS_SERVICE_METADATA_DOCUMENT** metadataDocuments [] = {&document};
@@ -105,14 +105,14 @@ Specifying URL suffix for Ws-MetadataExchange requests
 An application can optionally enable only accepting requests for WS-MetadataExchange on a specific path. This is done by specifying a suffix for the given WS\_SERVICE\_ENDPOINT. This suffix is concatenated as-is to the actual URL for the WS\_SERVICE\_ENDPOINT. The concatenated string is used as the matching URL to the 'to' header received.
 
 ``` syntax
-const WS_STRING suffix = WS_STRING_VALUE(L&quot;mex&quot;);
+const WS_STRING suffix = WS_STRING_VALUE(L"mex");
 WS_SERVICE_ENDPOINT_PROPERTY serviceProperties[1] = {};
 serviceProperties[0].id = WS_SERVICE_ENDPOINT_PROPERTY_METADATA_EXCHANGE_URL_SUFFIX;
 serviceProperties[0].value =  &suffix;
 serviceProperties[0].valueSize = sizeof(suffix);
 ```
 
-The following API elements relate to service metada.
+The following API elements relate to service metadata.
 
 | Enumeration                                                       | Description                                                                     |
 |-------------------------------------------------------------------|---------------------------------------------------------------------------------|


### PR DESCRIPTION
I verified that these do currently appear malformed on the webpages; this PR changes `&quot;` appearing in generated C++ code to the expected `"`.