### PR TITLE
Fix quotes in pre-formatted examples

### DIFF
--- a/desktop-src/DxTechArts/games-for-windows-test-requirements-1-0-0006.md
+++ b/desktop-src/DxTechArts/games-for-windows-test-requirements-1-0-0006.md
@@ -324,8 +324,8 @@ This requirement has been retired.
 <pre class="syntax" data-space="preserve">
 
 ```xml
-<requestedExecutionLevel level=&quot;asInvoker|highestAvailable|requireAdministrator&quot; 
-              uiAccess=&quot;true|false&quot;/></code></pre>
+<requestedExecutionLevel level="asInvoker|highestAvailable|requireAdministrator" 
+              uiAccess="true|false"/>
 ```
 <br/>
 

--- a/desktop-src/WinRM/session-error.md
+++ b/desktop-src/WinRM/session-error.md
@@ -118,7 +118,7 @@ The resource URI is not valid: it does not contain keys, but the
 class selected is not a singleton. To access an instance which is 
 not a singleton, keys must be provided. Use the following command 
 to get more information in how to construct a resource URI: 
-&quot;winrm help uris&quot;. 
+"winrm help uris". 
 </f:Message></f:WSManFault>
 </f:ProviderFault>
 </f:Message

--- a/desktop-src/windowsribbon/windowsribbon-controls-dropdowncolorpicker.md
+++ b/desktop-src/windowsribbon/windowsribbon-controls-dropdowncolorpicker.md
@@ -92,18 +92,18 @@ The basic markup required for each Drop-Down Color Picker type is demonstrated i
 
 ```XML
 
-<Group CommandName=&quot;cmdDropDownColorPickerGroup&quot;
-       SizeDefinition=&quot;ThreeButtons&quot;>
+<Group CommandName="cmdDropDownColorPickerGroup"
+       SizeDefinition="ThreeButtons">
   <DropDownColorPicker
-    CommandName=&quot;cmdDropDownColorPickerThemeColors&quot;
-    ColorTemplate=&quot;ThemeColors&quot;/>
+    CommandName="cmdDropDownColorPickerThemeColors"
+    ColorTemplate="ThemeColors"/>
   <DropDownColorPicker
-    CommandName=&quot;cmdDropDownColorPickerStandardColors&quot;
-    ColorTemplate=&quot;StandardColors&quot;/>
+    CommandName="cmdDropDownColorPickerStandardColors"
+    ColorTemplate="StandardColors"/>
   <DropDownColorPicker
-    CommandName=&quot;cmdDropDownColorPickerHighlightColors&quot;
-    ColorTemplate=&quot;HighlightColors&quot;
-    StandardColorGridRows=&quot;1&quot;/>
+    CommandName="cmdDropDownColorPickerHighlightColors"
+    ColorTemplate="HighlightColors"
+    StandardColorGridRows="1"/>
 </Group>
 ```
 

--- a/desktop-src/wsw/metadata-mapping.md
+++ b/desktop-src/wsw/metadata-mapping.md
@@ -72,11 +72,11 @@ The address of an endpoint (see [**WS\_ENDPOINT\_ADDRESS**](/windows/desktop/api
 The channel binding (see [**WS\_CHANNEL\_BINDING**](/windows/desktop/api/WebServices/ne-webservices-ws_channel_binding)) is determined by the transport the soap binding used, as follows:
 
 ``` syntax
-<soap:binding transport=&quot;http://schemas.microsoft.com/soap/tcp&quot;/> => WS_TCP_CHANNEL_BINDING
+<soap:binding transport="http://schemas.microsoft.com/soap/tcp"/> => WS_TCP_CHANNEL_BINDING
 ```
 
 ``` syntax
-<soap:binding transport=&quot;http://schemas.xmlsoap.org/soap/http&quot;/> => WS_HTTP_CHANNEL_BINDING
+<soap:binding transport="http://schemas.xmlsoap.org/soap/http"/> => WS_HTTP_CHANNEL_BINDING
 ```
 
 ## WS\_CHANNEL\_PROPERTY\_ENVELOPE\_VERSION
@@ -272,9 +272,9 @@ This section applies when the [**WS\_ISSUED\_TOKEN\_MESSAGE\_SECURITY\_BINDING\_
 ``` syntax
 <sp:EndorsingSupportingTokens...>
     <wsp:Policy>
-        <sp:IssuedToken sp:IncludeToken=&quot;xs:anyURI&quot;? ...=&quot;&quot; >
+        <sp:IssuedToken sp:IncludeToken="xs:anyURI"? ...="" >
             <wsp:Issuer>...</wsp:Issuer>?
-            <wsp:RequestSecurityTokenTemplate TrustVersion='xs:anyURI&quot;?>
+            <wsp:RequestSecurityTokenTemplate TrustVersion='xs:anyURI"?>
                 ...
                 <wst10:Claims>
                     <wsi:ClaimType Optional='xs:boolean'?>xs:anyURI<wt:ClaimType>*
@@ -306,7 +306,7 @@ This section applies when the [**WS\_SECURITY\_CONTEXT\_MESSAGE\_SECURITY\_BINDI
 ``` syntax
 <sp:EndorsingSupportingTokens...>
     <wsp:Policy>
-        <sp:SecureConversationToken sp:IncludeToken=&quot;xs:anyURI&quot;? ...=&quot;&quot; >
+        <sp:SecureConversationToken sp:IncludeToken="xs:anyURI"? ...="" >
             <wsp:Issuer>...</wsp:Issuer>?
             <wsp:Policy>
                 <sp:RequireDerivedKeys.../>?


### PR DESCRIPTION
Wrote a script to find `&quot;` inside preformatted markdown blocks - this should correct all of them.

`&quot;` usage in WMDM\compiling-the-sample-service-provider-using-visual-studio.md is intentional and needs no correction.