### PR TITLE
RISC-V Relocation Types Missing from PE Format Definition

### DIFF
--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -780,6 +780,11 @@ The following relocation type indicators are defined for the Mitsubishi M32R pro
 | IMAGE\_REL\_M32R\_TOKEN <br/>    | 0x000E <br/> | The CLR token. <br/>                                                                                                                                                                                                                                                                                                                                                                                    |
 
 
+ 
+
+##### RISC-V Processors
+
+The following relocation type indicators are defined for RISC-V processors.
 
  
 


### PR DESCRIPTION
Hi,

I'm currently implement RISC-V PE/COFF format support in LLVM https://github.com/llvm/llvm-project/pull/148045 for compiling UEFI Applications. I wonder if there are COFF Relocation type definition for RISC-V processors? If not could those definitions be added. Thanks.

@Karl-Bridge-Microsoft @makubacki @RussKeldorph @htpiv 