### PR TITLE
Update examples in waveballot.md and waveactivecountbits.md

### DIFF
--- a/desktop-src/direct3dhlsl/waveactivecountbits.md
+++ b/desktop-src/direct3dhlsl/waveactivecountbits.md
@@ -58,7 +58,7 @@ This function is supported from shader model 6.0 in all shader stages.
 This can be implemented more efficiently than a full WaveActiveSum, as described in the following example:
 
 ``` syntax
-result = WaveActiveCountBits( WaveActiveBallot( bBit ) );
+result = countbits( WaveActiveBallot( bBit ) );
 ```
 
 ## See also

--- a/desktop-src/direct3dhlsl/waveactivecountbits.md
+++ b/desktop-src/direct3dhlsl/waveactivecountbits.md
@@ -65,7 +65,7 @@ uint result = WaveActiveSum(1);
 uint4 bits = countbits( WaveActiveBallot( bBit ) );
 uint result = bits.x + bits.y + bits.z + bits.w;
 
-// Use WaveActiveCountBits to count number of active langes
+// Use WaveActiveCountBits to count number of active lanes
 uint result = WaveActiveCountBits(true);
 ```
 

--- a/desktop-src/direct3dhlsl/waveactivecountbits.md
+++ b/desktop-src/direct3dhlsl/waveactivecountbits.md
@@ -55,11 +55,20 @@ This function is supported from shader model 6.0 in all shader stages.
 
 ## Examples
 
-This can be implemented more efficiently than a full WaveActiveSum, as described in the following example:
+Although these are all equivalent, WaveActiveCountBits is the most efficient way to achieve this: 
 
 ``` syntax
-result = countbits( WaveActiveBallot( bBit ) );
+// Use WaveActiveSum to count number of active lanes
+uint result = WaveActiveSum(1);
+
+// Use countbits and WaveActiveBallot to count number of active lanes
+uint4 bits = countbits( WaveActiveBallot( bBit ) );
+uint result = bits.x + bits.y + bits.z + bits.w;
+
+// Use WaveActiveCountBits to count number of active langes
+uint result = WaveActiveCountBits(true);
 ```
+
 
 ## See also
 

--- a/desktop-src/direct3dhlsl/waveballot.md
+++ b/desktop-src/direct3dhlsl/waveballot.md
@@ -53,7 +53,8 @@ uint result = WaveActiveCountBits( bBit );
 Instead of:
 
 ``` syntax
-uint result = countbits( WaveActiveBallot( bBit ) );
+uint4 bits = countbits( WaveActiveBallot( bBit ) );
+uint result = bits.x + bits.y + bits.z + bits.w;
 ```
 
 This function is supported from shader model 6.0 in all shader stages. 


### PR DESCRIPTION
One example was incorrectly copied from the [spec](https://github.com/microsoft/DirectXShaderCompiler/wiki/Wave-Intrinsics#uint-waveactivecountbits-bool-bbit-), replacing `countbits` with `WaveActiveCountBits`. In both cases they were relying on an implicit vector truncation which would result in incorrect results on devices with wave size > 32.