### PR TITLE
Update lb-setanchorindex.md

### DIFF
--- a/desktop-src/Controls/lb-setanchorindex.md
+++ b/desktop-src/Controls/lb-setanchorindex.md
@@ -27,7 +27,7 @@ Sets the anchor item that is, the item from which a multiple selection starts. A
 *wParam* 
 </dt> <dd>
 
-Specifies the index of the new anchor item.
+Specifies the zero-based index of the new anchor item.
 
 Windows 95/Windows 98/Windows Millennium Edition (Windows Me) : The *wParam* parameter is limited to 16-bit values. This means list boxes cannot contain more than 32,767 items. Although the number of items is restricted, the total size in bytes of the items in a list box is limited only by available memory.
 


### PR DESCRIPTION
Clarified the return value to match the language used for the [LB_SETCARETINDEX](https://learn.microsoft.com/en-us/windows/win32/controls/lb-setcaretindex) message.