### PR TITLE
Update taskschedulerschema-versiontype-simpletype.md

### DIFF
--- a/desktop-src/TaskSchd/taskschedulerschema-versiontype-simpletype.md
+++ b/desktop-src/TaskSchd/taskschedulerschema-versiontype-simpletype.md
@@ -37,7 +37,7 @@ The **versionType** simple type is a **string** that is restricted by the follow
 
 -   `\d+(\.\d+){1,3}`
 
-    A double followed by one, two, or three doubles. For example, 1.2, or 1.2.3.
+    A number followed by one, two, or three numbers; the numbers are separated by dots. For example, 1.2, 1.2.3, or 9.87.65.432.
 
 ## Requirements
 


### PR DESCRIPTION
Fix the description of the regular expression: `d+` does not 
stand for *double*, but for a non-empty sequence of decimal digits,
which I simplify here as *number*. Also add an example
that demonstrates the use of multi-digit numbers.