### PR TITLE
Update Video Processor MFT documentation

### DIFF
--- a/desktop-src/medfound/video-processor-mft.md
+++ b/desktop-src/medfound/video-processor-mft.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Video Processor MFT
 
-The video processor MFT is a Microsoft Media Foundation transform (MFT) that performs colorspace conversion, video resizing, deinterlacing, frame rate conversion, rotation, cropping, spatial left and right view unpacking, and mirroring.
+The video processor MFT is a Microsoft Media Foundation transform (MFT) that performs colorspace conversion, tone mapping, video resizing, deinterlacing, frame rate conversion, rotation, cropping, spatial left and right view unpacking, mirroring, and sphere mapping.
 
 ## CLSID
 
@@ -19,6 +19,8 @@ CLSID\_VideoProcessorMFT
 -   [**IMFRealTimeClientEx**](/windows/desktop/api/mfidl/nn-mfidl-imfrealtimeclientex)
 -   [**IMFTransform**](/windows/desktop/api/mftransform/nn-mftransform-imftransform)
 -   [**IMFVideoProcessorControl**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol)
+-   [**IMFVideoProcessorControl2**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol2)
+-   [**IMFVideoProcessorControl3**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol3)
 
 ## Input Formats
 
@@ -45,6 +47,16 @@ CLSID\_VideoProcessorMFT
 -   **MFVideoFormat\_YUY2**
 -   **MFVideoFormat\_YV12**
 -   **MFVideoFormat\_YVYU**
+-   **MFVideoFormat\_P010**
+-   **MFVideoFormat\_P016**
+-   **MFVideoFormat\_A16B16G16R16F**
+-   **MFVideoFormat\_A2R10G10B10**
+-   **MFVideoFormat\_Y210**
+-   **MFVideoFormat\_Y410**
+-   **MFVideoFormat\_Y416**
+-   **MFVideoFormat\_L8**
+-   **MFVideoFormat\_L16**
+-   **MFVideoFormat\_D16**
 
 ## Output Formats
 
@@ -63,10 +75,59 @@ CLSID\_VideoProcessorMFT
 -   **MFVideoFormat\_Y216**
 -   **MFVideoFormat\_YUY2**
 -   **MFVideoFormat\_YV12**
+-   **MFVideoFormat\_P010**
+-   **MFVideoFormat\_P016**
+-   **MFVideoFormat\_A16B16G16R16F**
+-   **MFVideoFormat\_A2R10G10B10**
+-   **MFVideoFormat\_Y210**
+-   **MFVideoFormat\_Y410**
+-   **MFVideoFormat\_Y416**
 
 Not every combination of input and output formats is supported. To test whether a conversion is supported, set the input type and then call [**IMFTransform::GetOutputAvailableType**](/windows/desktop/api/mftransform/nf-mftransform-imftransform-getoutputavailabletype).
 
 For more information about these formats, see [Video Subtype GUIDs](video-subtype-guids.md).
+
+## Color Space Transforms
+
+The following attributes can be set on either the input or output types to change the color space of the content:
+-  **MF\_MT\_VIDEO\_PRIMARIES**
+-  **MF\_MT\_TRANSFER\_FUNCTION**
+-  **MF\_MT\_YUV\_MATRIX**
+-  **MF\_MT\_VIDEO\_CHROMA\_SITING**
+-  **MF\_MT\_VIDEO\_NOMINAL\_RANGE**
+-  **MF\_MT\_MAX\_MASTERING\_LUMINANCE**
+-  **MF\_MT\_MAX\_LUMINANCE\_LEVEL**
+-  **MF\_MT\_CUSTOM\_VIDEO\_PRIMARIES**
+-  **MF\_MT\_PALETTE**
+
+## Image Transforms
+
+The following attributes can be set on either the input or output types to perform spatial transforms on the video:
+-  **MF\_MT\_PIXEL\_ASPECT\_RATIO**
+-  **MF\_MT\_VIDEO\_ROTATION**
+-  **MF\_MT\_PAN\_SCAN\_APERTURE**
+-  **MF\_MT\_GEOMETRIC\_APERTURE**
+-  **MF\_MT\_MINIMUM\_DISPLAY\_APERTURE**
+-  **MF_MT_VIDEO_3D**
+-  **MF_MT_VIDEO_3D_FORMAT**
+
+## Temporal Transforms
+
+The following attributes can be set on either the input or output types to perform temporal transforms on the video:
+-  **MF\_MT\_INTERLACE\_MODE**
+-  **MF\_MT\_FRAME\_RATE**
+
+Note that if **MF\_XVP\_DISABLE\_FRC** is set to TRUE then frame rate conversion is disabled, but deinterlacing will still be performed.
+
+## Transform Attributes
+
+The following attributes can be set on the transform using **IMFTransform::GetAttributes**:
+-  **MF\_XVP\_DISABLE\_FRC**
+-  **MF\_XVP\_CALLER\_ALLOCATES\_OUTPUT**
+-  **MF\_LOW\_LATENCY**
+-  **MF\_XVP\_SAMPLE\_LOCK\_TIMEOUT**
+-  **MF\_ENABLE\_3DVIDEO\_OUTPUT**
+-  **MF\_VIDEO\_PROCESSOR\_ALGORITHM**
 
 ## Remarks
 

--- a/desktop-src/medfound/video-processor-mft.md
+++ b/desktop-src/medfound/video-processor-mft.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Video Processor MFT
 
-The video processor MFT is a Microsoft Media Foundation transform (MFT) that performs colorspace conversion, tone mapping, video resizing, deinterlacing, frame rate conversion, rotation, cropping, spatial left and right view unpacking, mirroring, and sphere mapping.
+The video processor MFT is a Microsoft Media Foundation transform (MFT) that performs colorspace conversion, tone mapping, video resizing, deinterlacing, frame rate conversion, rotation, cropping, spatial left and right view unpacking, mirroring, renderer effect processing, and sphere mapping.
 
 ## CLSID
 
@@ -21,9 +21,11 @@ CLSID\_VideoProcessorMFT
 -   [**IMFVideoProcessorControl**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol)
 -   [**IMFVideoProcessorControl2**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol2)
 -   [**IMFVideoProcessorControl3**](/windows/desktop/api/mfidl/nn-mfidl-imfvideoprocessorcontrol3)
+-   [**IMFVideoRendererEffectControl**](/windows/desktop/api/mfidl/nn-mfidl-imfvideorenderereffectcontrol)
 
 ## Input Formats
 
+The following formats are supported values for the **MF\_MT\_SUBTYPE** value of the media type set via [**IMFTransform::SetInputType**](/windows/desktop/api/mftransform/nf-mftransform-imftransform-setinputtype)
 -   **MFVideoFormat\_ABGR32**
 -   **MFVideoFormat\_ARGB32**
 -   **MFVideoFormat\_AYUV**
@@ -60,6 +62,7 @@ CLSID\_VideoProcessorMFT
 
 ## Output Formats
 
+The following formats are supported values for the **MF\_MT\_SUBTYPE** value of the media type set via [**IMFTransform::SetOutputType**](/windows/desktop/api/mftransform/nf-mftransform-imftransform-setoutputtype)
 -   **MFVideoFormat\_ARGB32**
 -   **MFVideoFormat\_AYUV**
 -   **MFVideoFormat\_I420**
@@ -108,10 +111,10 @@ The following attributes can be set on either the input or output types to perfo
 -  **MF\_MT\_PAN\_SCAN\_APERTURE**
 -  **MF\_MT\_GEOMETRIC\_APERTURE**
 -  **MF\_MT\_MINIMUM\_DISPLAY\_APERTURE**
--  **MF_MT_VIDEO_3D**
--  **MF_MT_VIDEO_3D_FORMAT**
+-  **MF\_MT\_VIDEO\_3D**
+-  **MF\_MT\_VIDEO\_3D\_FORMAT**
 
-## Temporal Transforms
+## Framerate Transforms
 
 The following attributes can be set on either the input or output types to perform temporal transforms on the video:
 -  **MF\_MT\_INTERLACE\_MODE**
@@ -142,7 +145,19 @@ The following remarks pertain to working with source rectangles and destination 
 -   Both the destination and source rectangle will always be clamped to fit inside their respective frames—the source rectangle to the source frame and the destination rectangle to the destination frame. This means that negative values are not meaningful—they will be always clamped to 0.
 -   The source rectangle is in the destination frame's coordinate system, minus any destination rectangle. This means that transformations like rotation are "undone" on the source rectangle. Therefore, you do not need to know if the video was rotated or 3D unpacked. For example, you could draw a rectangle on top of the video tag, take the relative coordinates (relative to the video tag), normalize them (range 0 to 1) and pass them down as the source rectangle and they should work as expected, even if the video is being rotated.
 
-The video processor supports GPU-accelerated video processing, using Microsoft Direct3D 11. For more information, see [MF\_SA\_D3D11\_AWARE](mf-sa-d3d11-aware.md).
+The video processor supports GPU-accelerated video processing, using Microsoft Direct3D 11, or Direct3D 12. For more information, see [MF\_SA\_D3D11\_AWARE](mf-sa-d3d11-aware.md) and [MF\_SA\_D3D12\_AWARE](mf-sa-d3d12-aware.md).
+
+The video processor is used as the front-end converter for video rendering when using SVR which is exposed by the [MediaPlayer](/uwp/api/windows.media.playback.mediaplayer) and [IMFMediaEngine](/windows/win32/api/mfmediaengine/nn-mfmediaengine-imfmediaengine) components.  Decoders, plugins or sources used by either of these components 
+
+### Renderer Effects
+
+The Video Processor MFT is the host component for Renderer effects.  Renderer effects allow applications to plugin to the normal video transform and rendering process.  For typical applications a video plugin (see: [IMFMediaEngineEx::InsertVideoEffect](/windows/desktop/api/mfmediaengine/nf-mfmediaengine-imfmediaengineex-insertvideoeffect)) is sufficient.  But some scenarios require more information about the exact conditions that a video is being rendered in.
+Consider a renderer effect for the following situations:
+-  The plugin needs to know the resolution that the video is rendered at (e.g. to perform a special scaling operation like super resolution)
+-  The plugin needs to know properties of the display that the video is being rendered on (e.g. to perform accurate tone mapping)
+-  The plugin needs to know exactly the final output format of the presented video
+
+To load a renderer effect configure the **MF\_MT\_VIDEO\_RENDERER\_EXTENSION\_PROFILE** attribute on the input type of the Video Processor MFT.
 
 ### Stereoscopic Video
 


### PR DESCRIPTION
- Add newly supported video formats.
- Include sections on Color space Transforms, Imaging Transforms, Framerate Transforms to give more detail on what parts of the input and output media types the Video Processor will use.
- Add section for Transform Attributes supported
- D3D12 is now supported
- Renderer effects are now supported
- Add details on Video Processor's use by SVR

Most of these properties have been long supported by the Video Processor.  But a user of the component would not know whether a given attribute would be processed or not.  This PR attempts to make it more clear which attributes on the media types will actually be observed by the Video Processor and thus a conversion will be performed.