### PR TITLE
Create stub for Event log EVTX format

### DIFF
--- a/desktop-src/EventLog/event-log-evtx-format.md
+++ b/desktop-src/EventLog/event-log-evtx-format.md
@@ -1,0 +1,9 @@
+---
+description:
+ms.assetid: 0e591b8f-15fd-4513-b8e2-a30dcce7b903
+title: Event Log EVTX Format
+ms.topic: concept-article
+ms.date: 07/29/2025
+---
+
+# Event Log EVTX Format

--- a/desktop-src/EventLog/toc.yml
+++ b/desktop-src/EventLog/toc.yml
@@ -37,6 +37,8 @@
       items: 
       - name: "Event Log File Format"
         href: event-log-file-format.md
+      - name: "Event Log EVTX Format"
+        href: event-log-evtx-format.md
       - name: "Reading from the Event Log"
         href: reading-from-the-event-log.md
       - name: "Viewing the Event Log"


### PR DESCRIPTION
Hi! Is it possible to extend existing Event Log documentation with EVTX format specification/binary layout, including header and event record structures? There is documentation for the legacy format, but seems like it's not supported in the latest Windows versions.