### PR TITLE
Fix incorrect explanation in WM_RBUTTONUP message doc

### DIFF
--- a/desktop-src/inputdev/wm-rbuttonup.md
+++ b/desktop-src/inputdev/wm-rbuttonup.md
@@ -45,7 +45,7 @@ Indicates whether various virtual keys are down. This parameter can be one or mo
 | <span id="MK_CONTROL"></span><span id="mk_control"></span><dl> <dt>**MK\_CONTROL**</dt> <dt>0x0008</dt> </dl>    | The CTRL key is down.<br/>            |
 | <span id="MK_LBUTTON"></span><span id="mk_lbutton"></span><dl> <dt>**MK\_LBUTTON**</dt> <dt>0x0001</dt> </dl>    | The left mouse button is down.<br/>   |
 | <span id="MK_MBUTTON"></span><span id="mk_mbutton"></span><dl> <dt>**MK\_MBUTTON**</dt> <dt>0x0010</dt> </dl>    | The middle mouse button is down.<br/> |
-| <span id="MK_RBUTTON"></span><span id="mk_rbutton"></span><dl> <dt>**MK\_RBUTTON**</dt> <dt>0x0002</dt> </dl>    | The SHIFT key is down.<br/>           |
+| <span id="MK_RBUTTON"></span><span id="mk_rbutton"></span><dl> <dt>**MK\_RBUTTON**</dt> <dt>0x0002</dt> </dl>    | The right mouse button is down.<br/>  |
 | <span id="MK_XBUTTON1"></span><span id="mk_xbutton1"></span><dl> <dt>**MK\_XBUTTON1**</dt> <dt>0x0020</dt> </dl> | The XBUTTON1 is down.<br/>      |
 | <span id="MK_XBUTTON2"></span><span id="mk_xbutton2"></span><dl> <dt>**MK\_XBUTTON2**</dt> <dt>0x0040</dt> </dl> | The XBUTTON2 is down.<br/>     |
 


### PR DESCRIPTION
Fix incorrect explanation for `MK_RBUTTON (0x0002)`. Example of correct explanation: [WM_RBUTTONDOWN](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-rbuttondown)