### PR TITLE
Make RPC tutorial compatible with VS2022

### DIFF
--- a/desktop-src/Rpc/the-client-application.md
+++ b/desktop-src/Rpc/the-client-application.md
@@ -31,12 +31,12 @@ int main()
 {
     RPC_STATUS status;
     unsigned char * pszUuid             = NULL;
-    unsigned char * pszProtocolSequence = "ncacn_np";
+    unsigned char * pszProtocolSequence = (unsigned char*)"ncacn_np";
     unsigned char * pszNetworkAddress   = NULL;
-    unsigned char * pszEndpoint         = "\\pipe\\hello";
+    unsigned char * pszEndpoint         = (unsigned char*)"\\pipe\\hello";
     unsigned char * pszOptions          = NULL;
     unsigned char * pszStringBinding    = NULL;
-    unsigned char * pszString           = "hello, world";
+    unsigned char * pszString           = (unsigned char*)"hello, world";
     unsigned long ulCode;
  
     status = RpcStringBindingCompose(pszUuid,

--- a/desktop-src/Rpc/the-client-application.md
+++ b/desktop-src/Rpc/the-client-application.md
@@ -27,7 +27,7 @@ After the remote procedure calls are completed, the client first calls [**RpcStr
 #include "hello.h" 
 #include <windows.h>
 
-void main()
+int main()
 {
     RPC_STATUS status;
     unsigned char * pszUuid             = NULL;

--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -27,7 +27,7 @@ The server application must also include the two memory management functions tha
 #include "hello.h"
 #include <windows.h>
 
-void main()
+int main()
 {
     RPC_STATUS status;
     unsigned char * pszProtocolSequence = "ncacn_np";

--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -30,9 +30,9 @@ The server application must also include the two memory management functions tha
 int main()
 {
     RPC_STATUS status;
-    unsigned char * pszProtocolSequence = "ncacn_np";
+    unsigned char * pszProtocolSequence = (unsigned char*)"ncacn_np";
     unsigned char * pszSecurity         = NULL; 
-    unsigned char * pszEndpoint         = "\\pipe\\hello";
+    unsigned char * pszEndpoint         = (unsigned char*)"\\pipe\\hello";
     unsigned int    cMinCalls = 1;
     unsigned int    fDontWait = FALSE;
  


### PR DESCRIPTION
Fix the following problems faced when attempting to build the sample code with Visual Studio 2022:
* warning C4326: return type of 'main' should be 'int' instead of 'void'
* error C2440: 'initializing': cannot convert from 'const char [9]' to 'unsigned char *'

Please note that this is not a complete fix for the sample code. I'm also experiencing undeclared identifier errors with fixes proposed in #2097.