### PR TITLE
RPC tutorial: Fix undeclared handle errors

### DIFF
--- a/desktop-src/Rpc/the-client-application.md
+++ b/desktop-src/Rpc/the-client-application.md
@@ -47,7 +47,7 @@ void main()
                                      &pszStringBinding);
     if (status) exit(status);
 
-    status = RpcBindingFromStringBinding(pszStringBinding, &hello_ClientIfHandle);
+    status = RpcBindingFromStringBinding(pszStringBinding, &hello_IfHandle);
  
     if (status) exit(status);
  

--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -43,7 +43,7 @@ void main()
  
     if (status) exit(status);
  
-    status = RpcServerRegisterIf(hello_ServerIfHandle,  
+    status = RpcServerRegisterIf(hello_v1_0_s_ifspec,  
                                  NULL,   
                                  NULL); 
  


### PR DESCRIPTION
Motivation: Make the sample code build out-of-the-box.

Fixes the following errors when building the RPC tutorial code with VS2022:
```
error C2065: 'hello_ClientIfHandle': undeclared identifier
error C2065: hello_ServerIfHandle: undeclared identifier
```

Please note that this is not a complete fix for the sample code. I'm also experiencing main-function and string type problems with fixes proposed in #2096.