### PR TITLE
RPC tutorial: Switch to unicode Win32 API

### DIFF
--- a/desktop-src/Rpc/the-client-application.md
+++ b/desktop-src/Rpc/the-client-application.md
@@ -30,16 +30,16 @@ After the remote procedure calls are completed, the client first calls [**RpcStr
 int main()
 {
     RPC_STATUS status;
-    unsigned char * pszUuid             = NULL;
-    unsigned char * pszProtocolSequence = (unsigned char*)"ncacn_np";
-    unsigned char * pszNetworkAddress   = NULL;
-    unsigned char * pszEndpoint         = (unsigned char*)"\\pipe\\hello";
-    unsigned char * pszOptions          = NULL;
-    unsigned char * pszStringBinding    = NULL;
+    unsigned short* pszUuid             = NULL;
+    unsigned short* pszProtocolSequence = (unsigned short*)L"ncacn_np";
+    unsigned short* pszNetworkAddress   = NULL;
+    unsigned short* pszEndpoint         = (unsigned short*)L"\\pipe\\hello";
+    unsigned short* pszOptions          = NULL;
+    unsigned short* pszStringBinding    = NULL;
     unsigned char * pszString           = (unsigned char*)"hello, world";
     unsigned long ulCode;
  
-    status = RpcStringBindingCompose(pszUuid,
+    status = RpcStringBindingComposeW(pszUuid,
                                      pszProtocolSequence,
                                      pszNetworkAddress,
                                      pszEndpoint,
@@ -47,7 +47,7 @@ int main()
                                      &pszStringBinding);
     if (status) exit(status);
 
-    status = RpcBindingFromStringBinding(pszStringBinding, &hello_IfHandle);
+    status = RpcBindingFromStringBindingW(pszStringBinding, &hello_IfHandle);
  
     if (status) exit(status);
  
@@ -63,7 +63,7 @@ int main()
     }
     RpcEndExcept
  
-    status = RpcStringFree(&pszStringBinding); 
+    status = RpcStringFreeW(&pszStringBinding); 
  
     if (status) exit(status);
  

--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -30,13 +30,13 @@ The server application must also include the two memory management functions tha
 int main()
 {
     RPC_STATUS status;
-    unsigned char * pszProtocolSequence = (unsigned char*)"ncacn_np";
-    unsigned char * pszSecurity         = NULL; 
-    unsigned char * pszEndpoint         = (unsigned char*)"\\pipe\\hello";
+    unsigned short* pszProtocolSequence = (unsigned short*)L"ncacn_np";
+    unsigned short* pszSecurity         = NULL;
+    unsigned short* pszEndpoint         = (unsigned short*)L"\\pipe\\hello";
     unsigned int    cMinCalls = 1;
     unsigned int    fDontWait = FALSE;
  
-    status = RpcServerUseProtseqEp(pszProtocolSequence,
+    status = RpcServerUseProtseqEpW(pszProtocolSequence,
                                    RPC_C_LISTEN_MAX_CALLS_DEFAULT,
                                    pszEndpoint,
                                    pszSecurity); 


### PR DESCRIPTION
Visual Studio 2022 defaults to build against the unicode Win32 API (with "W" suffices). The current sample code assumes the ASCII Win32 (with "A" suffices), which means that it fails to compile in a Visual C++ project with default project settings.

Propose to fix the problem by updating the code to instead use the unicode Win32 API with "W" suffices. It could also be possible to instead fix the problem by adding "A" suffices to the same functions if that is preferred(?)