### PR TITLE
RPC tutorial: Link to PRC library directly from sources

### DIFF
--- a/desktop-src/Rpc/the-client-application.md
+++ b/desktop-src/Rpc/the-client-application.md
@@ -26,6 +26,7 @@ After the remote procedure calls are completed, the client first calls [**RpcStr
 #include <ctype.h>
 #include "hello.h" 
 #include <windows.h>
+#pragma comment(lib, "Rpcrt4.lib")
 
 int main()
 {

--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -26,6 +26,7 @@ The server application must also include the two memory management functions tha
 #include <ctype.h>
 #include "hello.h"
 #include <windows.h>
+#pragma comment(lib, "Rpcrt4.lib")
 
 int main()
 {


### PR DESCRIPTION
Done to make the sample projects to build out-of-the-box without having to tweak linker settings for the project.

It might be that you'll want to clean up or potentially remove https://learn.microsoft.com/en-us/windows/win32/rpc/compiling-and-linking if merging this PR, since the PR more or less makes this page redundant.