### PR TITLE
RPC tutorial: Add HelloProc implementation in server

### DIFF
--- a/desktop-src/Rpc/the-server-application.md
+++ b/desktop-src/Rpc/the-server-application.md
@@ -55,7 +55,12 @@ int main()
                              fDontWait);
  
     if (status) exit(status);
- }
+}
+
+void HelloProc(unsigned char * pszString)
+{
+    printf("%s\n", pszString);
+}
 
 /******************************************************/
 /*         MIDL allocate and free                     */


### PR DESCRIPTION
The tutorial currently only provides an implementation of the `Shutdown` (in the "Stopping the Server Application" page), whereas an implementation of `HelloProc` is currently missing. Therefore, propose to add an `HelloProc` implementation, based on the "The Standalone Application" page, so that the sample builds more out-of-the-box.