### PR TITLE
Update unpremultiply.md

### DIFF
--- a/desktop-src/Direct2D/unpremultiply.md
+++ b/desktop-src/Direct2D/unpremultiply.md
@@ -14,7 +14,7 @@ Use this effect to convert an image from premultiplied alpha to unpremultiplied 
 
 This effect has no properties.
 
-The CLSID for this effect is CLSID\_D2D1UnPremultiply.
+The CLSID for this effect is **CLSID_D2D1UnPremultiply**.
 
 ## Output bitmap
 

--- a/desktop-src/Direct2D/unpremultiply.md
+++ b/desktop-src/Direct2D/unpremultiply.md
@@ -14,7 +14,7 @@ Use this effect to convert an image from premultiplied alpha to unpremultiplied 
 
 This effect has no properties.
 
-The CLSID for this effect is CLSID\_D2D1Unpremultiply.
+The CLSID for this effect is CLSID\_D2D1UnPremultiply.
 
 ## Output bitmap
 


### PR DESCRIPTION
There was a typo in the CLSID, meaning it would cause compile errors if just copied/pasted.