### PR TITLE
Update changing-privileges-in-a-token.md to reflect that AdjustTokenPrivileges() can remove privileges

### DIFF
--- a/desktop-src/SecBP/changing-privileges-in-a-token.md
+++ b/desktop-src/SecBP/changing-privileges-in-a-token.md
@@ -13,7 +13,7 @@ You can change the privileges in either a primary or an impersonation token in t
 -   Enable, disable, or remove privileges by using the [**AdjustTokenPrivileges**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) function.
 -   Restrict or remove privileges by using the [**CreateRestrictedToken**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-createrestrictedtoken) function.
 
-[**AdjustTokenPrivileges**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add privileges to the token. It can only enable existing privileges that are currently disabled, disable existing privileges that are currently enabled, or remove existing privileges. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--). Any privileges that are removed with **AdjustTokenPrivileges** cannot subsequently be reenabled.
+[**AdjustTokenPrivileges**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add privileges to the token. It can only enable existing privileges that are currently disabled, disable existing privileges that are currently enabled, or remove existing privileges. Any privileges that are removed with **AdjustTokenPrivileges** cannot subsequently be reenabled. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--).
 
 To assign privileges to a user account, see [Assigning Privileges to an Account](assigning-privileges-to-an-account.md).
 

--- a/desktop-src/SecBP/changing-privileges-in-a-token.md
+++ b/desktop-src/SecBP/changing-privileges-in-a-token.md
@@ -10,10 +10,10 @@ ms.date: 05/31/2018
 
 You can change the privileges in either a primary or an impersonation token in two ways:
 
--   Enable, disable, or remove privileges by using the [**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) function.
--   Restrict or remove privileges by using the [**CreateRestrictedToken**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-createrestrictedtoken) function.
+-   Enable, disable, or remove privileges by using the [**AdjustTokenPrivileges**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) function.
+-   Restrict or remove privileges by using the [**CreateRestrictedToken**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-createrestrictedtoken) function.
 
-[**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add privileges to the token. It can only enable existing privileges that are currently disabled, disable existing privileges that are currently enabled, or remove existing privileges. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--).
+[**AdjustTokenPrivileges**](/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add privileges to the token. It can only enable existing privileges that are currently disabled, disable existing privileges that are currently enabled, or remove existing privileges. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--). Any privileges that are removed with **AdjustTokenPrivileges** cannot subsequently be reenabled.
 
 To assign privileges to a user account, see [Assigning Privileges to an Account](assigning-privileges-to-an-account.md).
 

--- a/desktop-src/SecBP/changing-privileges-in-a-token.md
+++ b/desktop-src/SecBP/changing-privileges-in-a-token.md
@@ -10,10 +10,10 @@ ms.date: 05/31/2018
 
 You can change the privileges in either a primary or an impersonation token in two ways:
 
--   Enable or disable privileges by using the [**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) function.
+-   Enable, disable, or remove privileges by using the [**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) function.
 -   Restrict or remove privileges by using the [**CreateRestrictedToken**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-createrestrictedtoken) function.
 
-[**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add or remove privileges from the token. It can only enable existing privileges that are currently disabled or disable existing privileges that are currently enabled. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--).
+[**AdjustTokenPrivileges**](/windows/desktop/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) cannot add privileges to the token. It can only enable existing privileges that are currently disabled, disable existing privileges that are currently enabled, or remove existing privileges. For examples, see [Enabling and Disabling Privileges in C++](/windows/desktop/SecAuthZ/enabling-and-disabling-privileges-in-c--).
 
 To assign privileges to a user account, see [Assigning Privileges to an Account](assigning-privileges-to-an-account.md).
 


### PR DESCRIPTION
The existing document indicates that AdjustTokenPrivileges() cannot remove privileges, which contradicts the documentation for that function. Every supported version of Windows supports removing privileges through AdjustTokenPrivileges().