### PR TITLE
Fixed wrong `InitialResourceState` value

### DIFF
--- a/desktop-src/direct3d12/predication-queries.md
+++ b/desktop-src/direct3d12/predication-queries.md
@@ -159,7 +159,7 @@ In the **LoadAssets** method a buffer needs to be created to store the results o
                      &heapProps,
                      D3D12_HEAP_FLAG_NONE,
                      &queryBufferDesc,
-                     D3D12_RESOURCE_STATE_GENERIC_READ,
+                     D3D12_RESOURCE_STATE_PREDICATION,
                      nullptr,
                      IID_PPV_ARGS(&m_queryResult)
                      ));


### PR DESCRIPTION
Resource of predication buffer needs `D3D12_RESOURCE_STATE_PREDICATION` flag on creating.

https://github.com/microsoft/DirectX-Graphics-Samples/blob/3f3903ff48afa693b4a7f3ef1f4d1b94dfeb32ec/Samples/Desktop/D3D12PredicationQueries/src/D3D12PredicationQueries.cpp#L411C1-L411C46