### PR TITLE
Fix AdjustTokenPrivileges call in privilege sample

### DIFF
--- a/desktop-src/SecAuthZ/enabling-and-disabling-privileges-in-c--.md
+++ b/desktop-src/SecAuthZ/enabling-and-disabling-privileges-in-c--.md
@@ -65,7 +65,7 @@ BOOL SetPrivilege(
            hToken, 
            FALSE, 
            &tp, 
-           sizeof(TOKEN_PRIVILEGES), 
+           0, 
            (PTOKEN_PRIVILEGES) NULL, 
            (PDWORD) NULL) )
     { 


### PR DESCRIPTION
According to the [AdjustTokenPrivileges](https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-adjusttokenprivileges) documentation, then the `BufferLength` parameter specifies the size of the `PreviousState` parameter. Since `PreviousState=NULL`, then it follows that `BufferLength` should be 0.

I've already tested the changes locally.