### PR TITLE
Remove client support attributes from Dwm* APIs

### DIFF
--- a/desktop-src/dwm/dwmdxgetwindowsharedsurface.md
+++ b/desktop-src/dwm/dwmdxgetwindowsharedsurface.md
@@ -89,6 +89,5 @@ This API is intended for implementing a graphics driver or runtime. An applicati
 |-|-|
 | Minimum supported client | Windows 7 \[desktop apps only\] |
 | Minimum supported server | None supported |
-| End of client support | Windows 7 |
 | Header | N/A |
 | DLL | Dwmapi.dll |

--- a/desktop-src/dwm/dwmdxupdatewindowsharedsurface.md
+++ b/desktop-src/dwm/dwmdxupdatewindowsharedsurface.md
@@ -69,6 +69,5 @@ This method should only ever be called after [**DwmDxGetWindowSharedSurface**](d
 |-|-|
 | Minimum supported client | Windows 7 \[desktop apps only\] |
 | Minimum supported server | None supported |
-| End of client support | Windows 7 |
 | Header | N/A |
 | DLL | Dwmapi.dll |

--- a/desktop-src/dwm/getwindowcompositionattribute.md
+++ b/desktop-src/dwm/getwindowcompositionattribute.md
@@ -56,6 +56,5 @@ This function has no associated import library or header file; you must call it 
 |-|-|
 | Minimum supported client | Windows 7 \[desktop apps only\] |
 | Minimum supported server | None supported |
-| End of client support | Windows 7 |
 | Header | N/A |
 | DLL | user32.dll |

--- a/desktop-src/dwm/setwindowcompositionattribute.md
+++ b/desktop-src/dwm/setwindowcompositionattribute.md
@@ -53,6 +53,5 @@ This function has no associated import library or header file; you must call it 
 |-|-|
 | Minimum supported client | Windows 7 \[desktop apps only\] |
 | Minimum supported server | None supported |
-| End of client support | Windows 7 |
 | Header | N/A |
 | DLL | user32.dll |


### PR DESCRIPTION
These APIs are actively used by Microsoft and others; these support attributes don't make any sense.