### PR TITLE
Changing minimum Shader Model from SM50 to SM20 for function `mad`.

### DIFF
--- a/desktop-src/direct3dhlsl/mad.md
+++ b/desktop-src/direct3dhlsl/mad.md
@@ -76,7 +76,7 @@ This function is supported in the following shader models.
 
 | Shader Model                                                                | Supported |
 |-----------------------------------------------------------------------------|-----------|
-| [Shader Model 5](d3d11-graphics-reference-sm5.md) and higher shader models | yes       |
+| [Shader Model 2 (DirectX HLSL)](dx-graphics-hlsl-sm2.md) and higher shader models | yes       |
 
 
 


### PR DESCRIPTION
Function [mad](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/mad) works for:
ps_2_0
<img width="953" height="825" alt="image" src="https://github.com/user-attachments/assets/3352c82d-5854-40c8-a32f-d9729b2e4ef1" />
ps_3_0
<img width="953" height="827" alt="image" src="https://github.com/user-attachments/assets/3bd34bff-62e4-474c-92a2-b200895c0bb9" />
ps_4_0
<img width="1287" height="825" alt="image" src="https://github.com/user-attachments/assets/3222da62-1bc5-4c6d-a803-e7fadb1ae7ef" />
And higher.