### PR TITLE
Update quality-of-service.md

### DIFF
--- a/desktop-src/ProcThread/quality-of-service.md
+++ b/desktop-src/ProcThread/quality-of-service.md
@@ -18,7 +18,7 @@ The system maintains multiple QoS levels, each with differentiated performance a
 | QoS level | Description|Performance and power | Release |
 | --- | --- | --- | --- |
 | High | Windowed applications that are in the foreground and in focus, or audible, and explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation) | Standard high performance. |1709 |
-| Medium | Windowed applications that may be visible to the end user but are not in focus. Also includes lowering the QoS of the foreground application after a period of user inactivity. | Varies by platform, between High and Low. | 1709, Inactivity feature: Ge 2025.05 |
+| Medium | Windowed applications that may be visible to the end user but are not in focus. Also includes lowering the QoS of the foreground application after a period of user inactivity (on battery only). | Varies by platform, between High and Low. | 1709, Inactivity feature: Ge 2025.05 |
 | Low | Windowed applications that are not visible or audible to the end user. | On battery, selects most efficient CPU frequency and schedules to efficient core. | 1709 |
 | Utility | Background services | On battery, selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 22H2 |
 | Eco | Applications that explicitly tag processes with [SetProcessInformation](/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setprocessinformation) or threads with [SetThreadInformation](/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreadinformation). | Always selects most efficient CPU frequency and schedules to efficient cores. | Windows 11 |
@@ -26,6 +26,10 @@ The system maintains multiple QoS levels, each with differentiated performance a
 | Deadline | Threads explicitly tagged by [Multimedia Class Scheduler Service](/windows/desktop/procthread/multimedia-class-scheduler-service) to denote that audio threads require performance to meet deadlines. | High performance to meet media deadlines. | 2004 |
 
 ### How to Disable User Inactivity Feature
+
+> [!Note]
+> Reviewers and testers should disable this feature during testing (example: running performance benchmarks) on battery. Automated tests lacking user input may trigger this feature, lowering QoS and skewing results.
+
 By default, Windows may lower the QoS policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
 
   * **Path**: `Computer\HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling`

--- a/desktop-src/ProcThread/quality-of-service.md
+++ b/desktop-src/ProcThread/quality-of-service.md
@@ -28,7 +28,7 @@ The system maintains multiple QoS levels, each with differentiated performance a
 ### How to Disable User Inactivity Feature
 
 > [!Note]
-> Reviewers and testers should disable this feature during testing (example: running performance benchmarks) on battery. Automated tests lacking user input may trigger this feature, lowering QoS and skewing results.
+> Reviewers and testers should disable this feature during testing on battery (for example, when running performance benchmarks). Automated tests lacking user input may trigger this feature, lowering QoS and skewing results.
 
 By default, Windows may lower the QoS policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
 

--- a/desktop-src/ProcThread/quality-of-service.md
+++ b/desktop-src/ProcThread/quality-of-service.md
@@ -28,7 +28,7 @@ The system maintains multiple QoS levels, each with differentiated performance a
 ### How to Disable User Inactivity Feature
 
 > [!Note]
-> Reviewers and testers should disable this feature during testing on battery (for example, when running performance benchmarks). Automated tests lacking user input may trigger this feature, lowering QoS and skewing results.
+> This feature should be disabled when testing on battery (for example, running performance benchmarks). Automated tests lacking user input may trigger this feature, lowering QoS and skewing results.
 
 By default, Windows may lower the QoS policy of a foreground application to Medium QoS after a period of user inactivity where no input is detected. You can disable this feature by setting the following registry value:
 


### PR DESCRIPTION
Updates the Quality of Service documentation to reflect changes shipping in the Ge 11D Win11 release.

Changes include:
- Clarified that the "User Inactivity" QoS demotion feature is restricted to DC (battery) power only.
- Added guidance for reviewers and testers to disable the feature when testing on battery.