### PR TITLE
add Windows 10 to the supported versions of the WFP condition `FWPM_CONDITION_RPC_OPNUM`

### DIFF
--- a/desktop-src/FWP/filtering-conditions-available-at-each-filtering-layer.md
+++ b/desktop-src/FWP/filtering-conditions-available-at-each-filtering-layer.md
@@ -482,6 +482,7 @@ The list of filtering conditions that are available at each layer are as follows
 - FWPM_CONDITION_RPC_PROTOCOL
 - FWPM_CONDITION_SEC_ENCRYPT_ALGORITHM
 - FWPM_CONDITION_SEC_KEY_SIZE
+- FWPM_CONDITION_RPC_OPNUM (with the October 2025 Cumulative Update or later)
 ### Windows 11 and later
 - FWPM_CONDITION_RPC_OPNUM
 ## FWPM_LAYER_RPC_EPMAP


### PR DESCRIPTION
The FWPM_CONDITION_RPC_OPNUM WFP filter condition is now supported hosts running Windows Server 2019, Windows Server 2022 and Windows 10 hosts running the October 2025 Cumulative Update or later.

This can be confirmed in the netsh tool, by analysing the `rpcrt4.dll` (where it appears to have been enabled earlier than October 2025), and in the conditions use by Microsoft Defender for Identity and that products [system requirements](https://learn.microsoft.com/en-us/defender-for-identity/deploy/prerequisites-sensor-version-3) of 
- Windows Server 2019 or later
- [October 2025 Cumulative Update](https://support.microsoft.com/en-us/topic/october-14-2025-kb5066782-os-build-20348-4294-f4af3c9e-7a60-4d17-a964-cfe1f1dd15f6) or later. 

The current Windows Filtering Platform documentation omits that FWPM_CONDITION_RPC_OPNUM is suported on Windows 10/Server 2019 and later, instead stating it can only be used on Windows 11 hosts.

I'm not sure on the exact syntax/formatting that should be used to best include this information. I've added it as a note under the condition in the Windows 10 section of the supported filtering conditions.