### PR TITLE
Fix XML namespace declaration in schema

### DIFF
--- a/desktop-src/TaskSchd/task-scheduler-schema.md
+++ b/desktop-src/TaskSchd/task-scheduler-schema.md
@@ -31,7 +31,7 @@ The entire Task Scheduler schema is defined by the following XSD file.
 <?xml version="1.0" encoding="utf-8" ?>
 <xs:schema
     targetNamespace="http://schemas.microsoft.com/windows/2004/02/mit/task"
-    xmlns:xs="https://www.w3.org/2001/XMLSchema"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task"
     xmlns:td="http://schemas.microsoft.com/windows/2004/02/mit/task"
     elementFormDefault="qualified">


### PR DESCRIPTION
The [task xml example](https://learn.microsoft.com/en-us/previous-versions//aa446889(v=vs.85)#to-define-a-task-that-sends-an-email-when-an-event-occurs) provided in the docs, cannot be validated against its [corresponding schema](https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-schema) due to a malformed namespace.
This can be easily check using [Test-XML cmdlet](https://jdocs.mdbgo.io/PowerShell/Pscx/Test-Xml/).