### PR TITLE
Fix ContextMenuHandlers key typo

### DIFF
--- a/desktop-src/shell/handlers.md
+++ b/desktop-src/shell/handlers.md
@@ -388,7 +388,7 @@ HKEY_CLASSES_ROOT
    MyProgram.1
       (Default) = MyProgram Application
       Shellex
-         ContextMenuHandler
+         ContextMenuHandlers
             MyCommand
                (Default) = {00000000-1111-2222-3333-444444444444}
          PropertySheetHandlers


### PR DESCRIPTION
The example at the bottom of the page includes a typo that will cause ContextMenuHandlers to fail registering:

Context menu handlers are registered under a "ContextMenuHandlers" key (plural form), not "ContextMenuHandler".