### PR TITLE
Fixes example

### DIFF
--- a/desktop-src/Midl/helpstring.md
+++ b/desktop-src/Midl/helpstring.md
@@ -99,9 +99,9 @@ library Lines
      ]
      interface ILine : IDispatch                         
      {
-         [propget, helpstring("Returns and sets RGB color.")]
+         [propget, helpstring("Returns the current RGB color.")]
          HRESULT Color([out, retval] long* ReturnVal); 
-         [propput, helpstring("Returns and sets RGB color.")]
+         [propput, helpstring("Sets a new RGB color.")]
          HRESULT Color([in] long rgb);
      }
 };


### PR DESCRIPTION
Adjusts the `helpstring` texts to match the interface effects.

Previously, both `helpstring` texts read "Returns and sets RGB color.", which is inaccurate for either the `propget` or the `propput` method.