### PR TITLE
Note `Reserved1` field in `DSTORAGE_REQUEST_OPTIONS`

### DIFF
--- a/desktop-src/dstorage/dstorage/ns-dstorage-dstorage_request_options.md
+++ b/desktop-src/dstorage/dstorage/ns-dstorage-dstorage_request_options.md
@@ -48,9 +48,10 @@ Options for a DirectStorage request.
 ```cpp
 struct DSTORAGE_REQUEST_OPTIONS {
   DSTORAGE_COMPRESSION_FORMAT       CompressionFormat : 8;
+  UINT8                             Reserved1[7];
   DSTORAGE_REQUEST_SOURCE_TYPE      SourceType : 1;
   DSTORAGE_REQUEST_DESTINATION_TYPE DestinationType : 7;
-  UINT64                            Reserved : 48;
+  UINT64                            Reserved : 56;
 };
 ```
 

--- a/desktop-src/dstorage/dstorage/ns-dstorage-dstorage_request_options.md
+++ b/desktop-src/dstorage/dstorage/ns-dstorage-dstorage_request_options.md
@@ -51,7 +51,7 @@ struct DSTORAGE_REQUEST_OPTIONS {
   UINT8                             Reserved1[7];
   DSTORAGE_REQUEST_SOURCE_TYPE      SourceType : 1;
   DSTORAGE_REQUEST_DESTINATION_TYPE DestinationType : 7;
-  UINT64                            Reserved : 56;
+  UINT64                            Reserved : 48;
 };
 ```
 


### PR DESCRIPTION
While the notes down below mention this `UINT8[7] Reserved1` field, it's not in the top-level struct "declaration sample" making it very confusing to relate how the fields are laid out (with the recent addition of GACL shuffle transform); especially because `Reserved : 48` was mentioned. 

Also note that that `48` was likely a typo; the field size is `56` such that together with `SourceType : 1` and `DestinationType : 7` it forms a full 64-bit integer.