### PR TITLE
Clarify Raw Input reading behavior and usage patterns

### DIFF
--- a/desktop-src/inputdev/about-raw-input.md
+++ b/desktop-src/inputdev/about-raw-input.md
@@ -59,14 +59,22 @@ To get an application's registration status, call [**GetRegisteredRawInputDevice
 
 ## Reading Raw Input
 
-An application receives raw input from any HID whose [top level collection](/windows-hardware/drivers/hid/top-level-collections) (TLC) matches a TLC from the registration. When an application receives raw input, its message queue gets a [**WM\_INPUT**](wm-input.md) message and the queue status flag **QS\_RAWINPUT** is set (**QS\_INPUT** also includes this flag). An application can receive data when it is in the foreground and when it is in the background.
+An application receives raw input from any HID whose [top level collection](/windows-hardware/drivers/hid/top-level-collections) (TLC) matches a TLC from the registration. When an application receives raw input, its message queue gets a [WM_INPUT](wm-input.md) message and the queue status flag **QS_RAWINPUT** is set (**QS_INPUT** also includes this flag). An application can receive data when it is in the foreground and when it is in the background (if registered with **RIDEV_INPUTSINK**).
 
-There are two ways to read the raw data: the unbuffered (or standard) method and the buffered method. The unbuffered method gets the raw data one [**RAWINPUT**](/windows/win32/api/winuser/ns-winuser-rawinput) structure at a time and is adequate for many HIDs. Here, the application calls [**GetMessage**](/windows/desktop/api/winuser/nf-winuser-getmessage) to get the [**WM\_INPUT**](wm-input.md) message. Then the application calls [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) using the **RAWINPUT** handle contained in **WM\_INPUT**. For an example, see [Doing a Standard Read of Raw Input](using-raw-input.md).
+There are two ways to read the raw data: the standard method and the buffered method.
 
-In contrast, the buffered method gets an array of [**RAWINPUT**](/windows/win32/api/winuser/ns-winuser-rawinput) structures at a time. This is provided for devices that can produce large amounts of raw input. In this method, the application calls [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) to get an array of **RAWINPUT** structures. Note that the [**NEXTRAWINPUTBLOCK**](/windows/win32/api/winuser/nf-winuser-nextrawinputblock) macro is used to traverse an array of **RAWINPUT** structures. For an example, see [Doing a Buffered Read of Raw Input](using-raw-input.md).
+**Standard method** reads one [RAWINPUT](/windows/win32/api/winuser/ns-winuser-rawinput) structure at a time and is adequate for most devices. The application calls [GetMessage](/windows/win32/api/winuser/nf-winuser-getmessage) to retrieve the [WM_INPUT](wm-input.md) message, then calls [GetRawInputData](/windows/win32/api/winuser/nf-winuser-getrawinputdata) with the **HRAWINPUT** handle passed in *lParam*. For an example, see [Performing a Standard Read of Raw Input](using-raw-input.md).
 
-To interpret the raw input, detailed information about the HIDs is required. An application gets the device information by calling [**GetRawInputDeviceInfo**](/windows/win32/api/winuser/nf-winuser-getrawinputdeviceinfoa) with the device handle. This handle can come either from [**WM\_INPUT**](wm-input.md) or from the **hDevice** member of [**RAWINPUTHEADER**](/windows/win32/api/winuser/ns-winuser-rawinputheader).
+**Buffered method** reads an array of [RAWINPUT](/windows/win32/api/winuser/ns-winuser-rawinput) structures at a time and is useful for high-frequency devices such as mice at 1000Hz, where multiple events may accumulate between message loop iterations. The application calls [GetRawInputBuffer](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) to drain all accumulated events in a single batch. Use the [NEXTRAWINPUTBLOCK](/windows/win32/api/winuser/nf-winuser-nextrawinputblock) macro to traverse the resulting array.
 
+> [!IMPORTANT]
+> [GetMessage](/windows/win32/api/winuser/nf-winuser-getmessage) removes the current [WM_INPUT](wm-input.md) from the raw input queue before returning. As a result, [GetRawInputBuffer](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) will not see the current event — only events that arrived after it. When combining both methods, the correct pattern is:
+> 1. Call [GetRawInputData](/windows/win32/api/winuser/nf-winuser-getrawinputdata) with the *lParam* handle to read the current event.
+> 2. Call [GetRawInputBuffer](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) in a loop to drain any additional events that accumulated in the queue.
+>
+> For an example, see [Performing a Batched Read of Raw Input](using-raw-input.md).
+
+To interpret the raw input, detailed information about the HIDs may be required. An application gets the device information by calling [GetRawInputDeviceInfo](/windows/win32/api/winuser/nf-winuser-getrawinputdeviceinfoa) with the device handle. This handle can come either from the *lParam* of [WM_INPUT](wm-input.md) via [GetRawInputData](/windows/win32/api/winuser/nf-winuser-getrawinputdata) with **RID_HEADER**, or from the **hDevice** member of [RAWINPUTHEADER](/windows/win32/api/winuser/ns-winuser-rawinputheader).
 
 ## See also
 - [Keyboard Input](keyboard-input.md)

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -137,6 +137,36 @@ void ProcessInput(const RAWINPUT* input)
     }
 }
 
+void DrainRawInputQueue(void)
+{
+    for (;;)
+    {
+        UINT bufferSize = g_bufferSize;
+        UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
+
+        if (count == 0)
+            break;
+
+        if (count == (UINT)-1)
+        {
+            /* Buffer too small — grow and retry. */
+            g_bufferSize = max(bufferSize, g_bufferSize * 2);
+            g_pBuffer = realloc(g_pBuffer, g_bufferSize);
+            if (g_pBuffer == NULL)
+                break;
+            continue;
+        }
+
+        {
+            RAWINPUT* ri = (RAWINPUT*)g_pBuffer;
+            UINT i;
+            for (i = 0; i < count; ++i, ri = NEXTRAWINPUTBLOCK(ri))
+                ProcessInput(ri);
+        }
+        /* Do not break — there may be more events in the queue. */
+    }
+}
+
 /* ... */
 
 case WM_INPUT:
@@ -158,32 +188,7 @@ case WM_INPUT:
     /* Phase 2 (optional): drain any additional events that accumulated in the
      * queue since this message was posted. Recommended for high-frequency
      * devices such as mice at 1000Hz. */
-    for (;;)
-    {
-        UINT cbBuffer = g_bufferSize;
-        UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &cbBuffer, sizeof(RAWINPUTHEADER));
-
-        if (count == 0)
-            break;
-
-        if (count == (UINT)-1)
-        {
-            /* Buffer too small — grow and retry. */
-            g_bufferSize = max(cbBuffer, g_bufferSize * 2);
-            g_pBuffer = realloc(g_pBuffer, g_bufferSize);
-            if (g_pBuffer == NULL)
-                break;
-            continue;
-        }
-
-        {
-            RAWINPUT* ri = (RAWINPUT*)g_pBuffer;
-            UINT i;
-            for (i = 0; i < count; ++i, ri = NEXTRAWINPUTBLOCK(ri))
-                ProcessInput(ri);
-        }
-        /* Do not break — there may be more events in the queue. */
-    }
+    DrainRawInputQueue();
 
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
@@ -194,9 +199,6 @@ case WM_INPUT:
 This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 
 ```cpp
-static UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
-static void* g_pBuffer    = NULL;
-
 MSG msg;
 BOOL running = TRUE;
 
@@ -208,8 +210,6 @@ RAWINPUTDEVICE rid[2] = {
     { 0x01, 0x06, RIDEV_INPUTSINK, hWnd }, /* keyboard */
 };
 RegisterRawInputDevices(rid, 2, sizeof(RAWINPUTDEVICE));
-
-g_pBuffer = malloc(g_bufferSize);
 
 /* Drain raw input queue every 16ms (~60Hz) */
 SetTimer(hWnd, 1, 16, NULL);
@@ -229,32 +229,7 @@ while (running)
 
         if (msg.message == WM_TIMER)
         {
-            for (;;)
-            {
-                UINT bufferSize = g_bufferSize;
-                UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
-        
-                if (count == 0)
-                    break;
-        
-                if (count == (UINT)-1)
-                {
-                    /* Buffer too small — grow and retry. */
-                    g_bufferSize = max(cbBuffer, g_bufferSize * 2);
-                    g_pBuffer = realloc(g_pBuffer, g_bufferSize);
-                    if (g_pBuffer == NULL)
-                        break;
-                    continue;
-                }
-        
-                {
-                    RAWINPUT* input = (RAWINPUT*)g_pBuffer;
-                    UINT i;
-                    for (i = 0; i < count; ++i, input = NEXTRAWINPUTBLOCK(input))
-                        ProcessInput(input);
-                }
-                /* Do not break — there may be more events in the queue. */
-            }
+            DrainRawInputQueue();
         }
         DispatchMessageW(&msg);
     }

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -23,8 +23,8 @@ This section includes sample code for the following purposes:
 -   [Registering for Raw Input](#registering-for-raw-input)
     -   [Example 1](#example-1)
     -   [Example 2](#example-2)
--   [Reading Raw Input from a WM_INPUT Handler](#reading-raw-input-from-a-wm_input-handler)
--   [Performing a Batched Read of Raw Input Using a Timer](#performing-a-batched-read-of-raw-input-using-a-timer)
+-   [Performing a Standard Read of Raw Input](#performing-a-standard-read-of-raw-input)
+-   [Performing a Buffered Read of Raw Input](#performing-a-buffered-read-of-raw-input)
 
 ## Registering for Raw Input
 
@@ -142,7 +142,7 @@ case WM_INPUT:
 } 
 ```
 
-## Reading Raw Input from a WM_INPUT Handler
+## Performing a Standard Read of Raw Input
 
 This sample shows the minimal pattern for reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
 
@@ -179,7 +179,7 @@ case WM_INPUT:
 }
 ```
 
-## Performing a Batched Read of Raw Input Using a Timer
+## Performing a Buffered Read of Raw Input
 
 This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -86,94 +86,74 @@ if (RegisterRawInputDevices(Rid, 2, sizeof(Rid[0])) == FALSE)
 
 ## Performing a Standard Read of Raw Input
 
-This sample shows how an application does an unbuffered (or standard) read of raw input from either a keyboard or mouse Human Interface Device (HID) and then prints out various information from the device.
+This sample shows the minimal pattern for unbuffered (or standard) reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
 
 ```cpp
-case WM_INPUT: 
-{
-    UINT dwSize;
-
-    GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &dwSize, sizeof(RAWINPUTHEADER));
-    LPBYTE lpb = new BYTE[dwSize];
-
-    if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER)) != dwSize)
-         OutputDebugString (TEXT("GetRawInputData does not return correct size !\n")); 
-
-    RAWINPUT* raw = (RAWINPUT*)lpb;
-
-    if (raw->header.dwType == RIM_TYPEKEYBOARD) 
-    {
-        hResult = StringCchPrintf(szTempOutput, STRSAFE_MAX_CCH,
-            TEXT(" Kbd: make=%04x Flags:%04x Reserved:%04x ExtraInformation:%08x, msg=%04x VK=%04x \n"), 
-            raw->data.keyboard.MakeCode, 
-            raw->data.keyboard.Flags, 
-            raw->data.keyboard.Reserved, 
-            raw->data.keyboard.ExtraInformation, 
-            raw->data.keyboard.Message, 
-            raw->data.keyboard.VKey);
-        if (FAILED(hResult))
-        {
-        // TODO: write error handler
-        }
-        OutputDebugString(szTempOutput);
-    }
-    else if (raw->header.dwType == RIM_TYPEMOUSE) 
-    {
-        hResult = StringCchPrintf(szTempOutput, STRSAFE_MAX_CCH,
-            TEXT("Mouse: usFlags=%04x ulButtons=%04x usButtonFlags=%04x usButtonData=%04x ulRawButtons=%04x lLastX=%04x lLastY=%04x ulExtraInformation=%04x\r\n"), 
-            raw->data.mouse.usFlags, 
-            raw->data.mouse.ulButtons, 
-            raw->data.mouse.usButtonFlags, 
-            raw->data.mouse.usButtonData, 
-            raw->data.mouse.ulRawButtons, 
-            raw->data.mouse.lLastX, 
-            raw->data.mouse.lLastY, 
-            raw->data.mouse.ulExtraInformation);
-
-        if (FAILED(hResult))
-        {
-        // TODO: write error handler
-        }
-        OutputDebugString(szTempOutput);
-    } 
-
-    delete[] lpb; 
-    return 0;
-} 
-```
-
-## Performing a Standard Read of Raw Input
-
-This sample shows the minimal pattern for reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
-
-```cpp
-/* Initialized once at startup */
-UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
-void* g_pBuffer    = NULL;
-
 void ProcessInput(const RAWINPUT* input)
 {
     if (input->header.dwType == RIM_TYPEKEYBOARD)
-        printf("key vk=0x%02x flags=0x%x\n", input->data.keyboard.VKey, input->data.keyboard.Flags);
+    {
+        const RAWKEYBOARD* kb = &input->data.keyboard;
+        const char* transition = (kb->Flags & RI_KEY_BREAK) ? "up" : "down";
+        const char* extended   = (kb->Flags & RI_KEY_E0)    ? " e0" :
+                                 (kb->Flags & RI_KEY_E1)    ? " e1" : "";
+
+        printf("keyboard: vk=0x%02x scan=0x%02x %s%s msg=0x%04x extra=0x%08x\n",
+            kb->VKey,
+            kb->MakeCode,
+            transition,
+            extended,
+            kb->Message,
+            kb->ExtraInformation);
+    }
     else if (input->header.dwType == RIM_TYPEMOUSE)
-        printf("mouse dx=%d dy=%d\n", input->data.mouse.lLastX, input->data.mouse.lLastY);
+    {
+        const RAWMOUSE* mouse = &input->data.mouse;
+
+        /* Movement */
+        const char* moveMode = (mouse->usFlags & MOUSE_MOVE_ABSOLUTE) ? "abs" : "rel";
+        printf("mouse: move %s dx=%d dy=%d\n", moveMode, mouse->lLastX, mouse->lLastY);
+
+        /* Buttons */
+        if (mouse->usButtonFlags & RI_MOUSE_LEFT_BUTTON_DOWN)   printf("  left down\n");
+        if (mouse->usButtonFlags & RI_MOUSE_LEFT_BUTTON_UP)     printf("  left up\n");
+        if (mouse->usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN)  printf("  right down\n");
+        if (mouse->usButtonFlags & RI_MOUSE_RIGHT_BUTTON_UP)    printf("  right up\n");
+        if (mouse->usButtonFlags & RI_MOUSE_MIDDLE_BUTTON_DOWN) printf("  middle down\n");
+        if (mouse->usButtonFlags & RI_MOUSE_MIDDLE_BUTTON_UP)   printf("  middle up\n");
+        if (mouse->usButtonFlags & RI_MOUSE_BUTTON_4_DOWN)      printf("  x1 down\n");
+        if (mouse->usButtonFlags & RI_MOUSE_BUTTON_4_UP)        printf("  x1 up\n");
+        if (mouse->usButtonFlags & RI_MOUSE_BUTTON_5_DOWN)      printf("  x2 down\n");
+        if (mouse->usButtonFlags & RI_MOUSE_BUTTON_5_UP)        printf("  x2 up\n");
+
+        /* Wheel */
+        if (mouse->usButtonFlags & RI_MOUSE_WHEEL)
+            printf("  wheel delta=%d\n", (int)(short)mouse->usButtonData);
+        if (mouse->usButtonFlags & RI_MOUSE_HWHEEL)
+            printf("  hwheel delta=%d\n", (int)(short)mouse->usButtonData);
+    }
+    else if (input->header.dwType == RIM_TYPEHID)
+    {
+        const RAWHID* hid = &input->data.hid;
+        printf("hid: count=%u size=%u\n", hid->dwCount, hid->dwSizeHid);
+    }
 }
-
-/* ... */
-
-g_pBuffer = malloc(g_bufferSize);
-
-/* ... */
 
 case WM_INPUT:
 {
-    UINT bufferSize = g_bufferSize;
-    UINT result = GetRawInputData((HRAWINPUT)lParam, RID_INPUT, g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
+    UINT bufferSize = 0;
 
-    if (result != (UINT)-1)
-        ProcessInput((RAWINPUT*)g_pBuffer);
-    else
-        Log(_T("GetRawInputData failed: %d"), GetLastError());
+    /* Query required buffer size */
+    GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &bufferSize, sizeof(RAWINPUTHEADER));
+
+    RAWINPUT* input = (RAWINPUT*)malloc(bufferSize);
+    if (input == NULL)
+        return DefWindowProc(hWnd, uMsg, wParam, lParam);
+
+    if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, input, &bufferSize, sizeof(RAWINPUTHEADER)) != (UINT)-1)
+        ProcessInput(input);
+
+    free(input);
 
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
@@ -184,6 +164,14 @@ case WM_INPUT:
 This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 
 ```cpp
+/* Initialized once at startup */
+UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
+void* g_pBuffer    = NULL;
+
+g_pBuffer = malloc(g_bufferSize);
+
+/* ... */
+
 HWND hWnd = CreateWindowExW(0, L"RawInputSink", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
 RAWINPUTDEVICE rid = { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }; /* mouse */
 RegisterRawInputDevices(&rid, 1, sizeof(rid));

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -88,7 +88,13 @@ if (RegisterRawInputDevices(Rid, 2, sizeof(Rid[0])) == FALSE)
 
 This sample shows the minimal pattern for standard reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
 
-```cpp
+For high-frequency devices such as mice at 1000Hz, multiple events may accumulate between message loop iterations. In that case, follow up with [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) to drain the remaining queue — see the optional Phase 2 below.
+
+```c
+/* Initialized once at startup */
+UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
+void* g_pBuffer    = NULL; /* g_pBuffer = malloc(g_bufferSize); */
+
 void ProcessInput(const RAWINPUT* input)
 {
     if (input->header.dwType == RIM_TYPEKEYBOARD)
@@ -97,24 +103,17 @@ void ProcessInput(const RAWINPUT* input)
         const char* transition = (kb->Flags & RI_KEY_BREAK) ? "up" : "down";
         const char* extended   = (kb->Flags & RI_KEY_E0)    ? " e0" :
                                  (kb->Flags & RI_KEY_E1)    ? " e1" : "";
-
         printf("keyboard: vk=0x%02x scan=0x%02x %s%s msg=0x%04x extra=0x%08x\n",
-            kb->VKey,
-            kb->MakeCode,
-            transition,
-            extended,
-            kb->Message,
-            kb->ExtraInformation);
+            kb->VKey, kb->MakeCode, transition, extended,
+            kb->Message, kb->ExtraInformation);
     }
     else if (input->header.dwType == RIM_TYPEMOUSE)
     {
         const RAWMOUSE* mouse = &input->data.mouse;
+        const char* moveMode  = (mouse->usFlags & MOUSE_MOVE_ABSOLUTE) ? "abs" : "rel";
 
-        /* Movement */
-        const char* moveMode = (mouse->usFlags & MOUSE_MOVE_ABSOLUTE) ? "abs" : "rel";
         printf("mouse: move %s dx=%d dy=%d\n", moveMode, mouse->lLastX, mouse->lLastY);
 
-        /* Buttons */
         if (mouse->usButtonFlags & RI_MOUSE_LEFT_BUTTON_DOWN)   printf("  left down\n");
         if (mouse->usButtonFlags & RI_MOUSE_LEFT_BUTTON_UP)     printf("  left up\n");
         if (mouse->usButtonFlags & RI_MOUSE_RIGHT_BUTTON_DOWN)  printf("  right down\n");
@@ -126,9 +125,8 @@ void ProcessInput(const RAWINPUT* input)
         if (mouse->usButtonFlags & RI_MOUSE_BUTTON_5_DOWN)      printf("  x2 down\n");
         if (mouse->usButtonFlags & RI_MOUSE_BUTTON_5_UP)        printf("  x2 up\n");
 
-        /* Wheel */
         if (mouse->usButtonFlags & RI_MOUSE_WHEEL)
-            printf("  wheel delta=%d\n", (int)(short)mouse->usButtonData);
+            printf("  wheel delta=%d\n",  (int)(short)mouse->usButtonData);
         if (mouse->usButtonFlags & RI_MOUSE_HWHEEL)
             printf("  hwheel delta=%d\n", (int)(short)mouse->usButtonData);
     }
@@ -139,21 +137,53 @@ void ProcessInput(const RAWINPUT* input)
     }
 }
 
+/* ... */
+
 case WM_INPUT:
 {
+    /* Phase 1: read the event carried by this WM_INPUT message. */
     UINT bufferSize = 0;
-
-    /* Query required buffer size */
     GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &bufferSize, sizeof(RAWINPUTHEADER));
 
     RAWINPUT* input = (RAWINPUT*)malloc(bufferSize);
-    if (input == NULL)
-        return DefWindowProc(hWnd, uMsg, wParam, lParam);
+    if (input != NULL)
+    {
+        if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, input, &bufferSize, sizeof(RAWINPUTHEADER)) != (UINT)-1)
+        {
+            ProcessInput(input);
+        }
+        free(input);
+    }
 
-    if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, input, &bufferSize, sizeof(RAWINPUTHEADER)) != (UINT)-1)
-        ProcessInput(input);
+    /* Phase 2 (optional): drain any additional events that accumulated in the
+     * queue since this message was posted. Recommended for high-frequency
+     * devices such as mice at 1000Hz. */
+    for (;;)
+    {
+        UINT cbBuffer = g_bufferSize;
+        UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &cbBuffer, sizeof(RAWINPUTHEADER));
 
-    free(input);
+        if (count == 0)
+            break;
+
+        if (count == (UINT)-1)
+        {
+            /* Buffer too small — grow and retry. */
+            g_bufferSize = max(cbBuffer, g_bufferSize * 2);
+            g_pBuffer = realloc(g_pBuffer, g_bufferSize);
+            if (g_pBuffer == NULL)
+                break;
+            continue;
+        }
+
+        {
+            RAWINPUT* ri = (RAWINPUT*)g_pBuffer;
+            UINT i;
+            for (i = 0; i < count; ++i, ri = NEXTRAWINPUTBLOCK(ri))
+                ProcessInput(ri);
+            /* Do not break — there may be more events in the queue. */
+        }
+    }
 
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
@@ -164,14 +194,6 @@ case WM_INPUT:
 This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 
 ```cpp
-/* Initialized once at startup */
-UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
-void* g_pBuffer    = NULL;
-
-g_pBuffer = malloc(g_bufferSize);
-
-/* ... */
-
 HWND hWnd = CreateWindowExW(0, L"RawInputSink", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
 RAWINPUTDEVICE rid = { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }; /* mouse */
 RegisterRawInputDevices(&rid, 1, sizeof(rid));

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -93,7 +93,10 @@ For high-frequency devices such as mice at 1000Hz, multiple events may accumulat
 ```c
 /* Initialized once at startup */
 UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
-void* g_pBuffer    = NULL; /* g_pBuffer = malloc(g_bufferSize); */
+void* g_pBuffer    = NULL;
+
+/* Call once before entering the message loop: */
+/* g_pBuffer = malloc(g_bufferSize); */
 
 void ProcessInput(const RAWINPUT* input)
 {
@@ -172,22 +175,14 @@ void DrainRawInputQueue(void)
 case WM_INPUT:
 {
     /* Phase 1: read the event carried by this WM_INPUT message. */
-    UINT bufferSize = 0;
-    GetRawInputData((HRAWINPUT)lParam, RID_INPUT, NULL, &bufferSize, sizeof(RAWINPUTHEADER));
-
-    RAWINPUT* input = (RAWINPUT*)malloc(bufferSize);
-    if (input != NULL)
+    UINT bufferSize = g_bufferSize;
+    if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER)) != (UINT)-1)
     {
-        if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, input, &bufferSize, sizeof(RAWINPUTHEADER)) != (UINT)-1)
-        {
-            ProcessInput(input);
-        }
-        free(input);
+        ProcessInput((RAWINPUT*)g_pBuffer);
     }
 
-    /* Phase 2 (optional): drain any additional events that accumulated in the
-     * queue since this message was posted. Recommended for high-frequency
-     * devices such as mice at 1000Hz. */
+    /* Phase 2 (optional): drain any additional events that accumulated in the queue since this message was posted.
+     * Recommended for high-frequency devices such as mice at 1000Hz. */
     DrainRawInputQueue();
 
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
@@ -196,14 +191,13 @@ case WM_INPUT:
 
 ## Performing a Buffered Read of Raw Input
 
-This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
+This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. All other messages are dispatched normally via [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage). This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 
 ```cpp
 MSG msg;
 BOOL running = TRUE;
 
-HWND hWnd = CreateWindowExW(0, L"Message", NULL, 0,
-    0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
+HWND hWnd = CreateWindowExW(0, L"Message", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
 
 RAWINPUTDEVICE rid[2] = {
     { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }, /* mouse */
@@ -231,12 +225,11 @@ while (running)
         {
             DrainRawInputQueue();
         }
+
         DispatchMessageW(&msg);
     }
 
     if (running)
         WaitMessage();
 }
-
-free(g_pBuffer);
 ```

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -181,8 +181,8 @@ case WM_INPUT:
             UINT i;
             for (i = 0; i < count; ++i, ri = NEXTRAWINPUTBLOCK(ri))
                 ProcessInput(ri);
-            /* Do not break — there may be more events in the queue. */
         }
+        /* Do not break — there may be more events in the queue. */
     }
 
     return DefWindowProc(hWnd, uMsg, wParam, lParam);
@@ -194,59 +194,74 @@ case WM_INPUT:
 This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
 
 ```cpp
-HWND hWnd = CreateWindowExW(0, L"RawInputSink", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
-RAWINPUTDEVICE rid = { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }; /* mouse */
-RegisterRawInputDevices(&rid, 1, sizeof(rid));
+static UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
+static void* g_pBuffer    = NULL;
+
+MSG msg;
+BOOL running = TRUE;
+
+HWND hWnd = CreateWindowExW(0, L"Message", NULL, 0,
+    0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
+
+RAWINPUTDEVICE rid[2] = {
+    { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }, /* mouse */
+    { 0x01, 0x06, RIDEV_INPUTSINK, hWnd }, /* keyboard */
+};
+RegisterRawInputDevices(rid, 2, sizeof(RAWINPUTDEVICE));
+
+g_pBuffer = malloc(g_bufferSize);
 
 /* Drain raw input queue every 16ms (~60Hz) */
 SetTimer(hWnd, 1, 16, NULL);
 
-MSG msg;
-for (;;)
+/* Message loop — WM_INPUT is skipped via range filters so it
+ * accumulates in the raw input queue for DrainRawInputQueue to drain. */
+while (running)
 {
-    /* Dispatch all messages except WM_INPUT */
     while (PeekMessageW(&msg, NULL, 0, WM_INPUT - 1, PM_REMOVE) ||
            PeekMessageW(&msg, NULL, WM_INPUT + 1, 0xFFFF, PM_REMOVE))
     {
         if (msg.message == WM_QUIT)
-            goto Exit;
+        {
+            running = FALSE;
+            break;
+        }
 
         if (msg.message == WM_TIMER)
         {
-            /* Timer tick — drain all WM_INPUT accumulated in the queue */
             for (;;)
             {
                 UINT bufferSize = g_bufferSize;
                 UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
-
+        
                 if (count == 0)
                     break;
-
+        
                 if (count == (UINT)-1)
                 {
-                    /* Buffer too small — grow and retry */
-                    g_bufferSize = max(bufferSize, g_bufferSize * 2);
+                    /* Buffer too small — grow and retry. */
+                    g_bufferSize = max(cbBuffer, g_bufferSize * 2);
                     g_pBuffer = realloc(g_pBuffer, g_bufferSize);
                     if (g_pBuffer == NULL)
-                        goto Exit;
+                        break;
                     continue;
                 }
-
+        
                 {
                     RAWINPUT* input = (RAWINPUT*)g_pBuffer;
                     UINT i;
                     for (i = 0; i < count; ++i, input = NEXTRAWINPUTBLOCK(input))
                         ProcessInput(input);
-                    /* Do not break — there may be more events in the queue. */
                 }
+                /* Do not break — there may be more events in the queue. */
             }
         }
-
         DispatchMessageW(&msg);
     }
 
-    WaitMessage();
+    if (running)
+        WaitMessage();
 }
 
-Exit:;
+free(g_pBuffer);
 ```

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -23,8 +23,8 @@ This section includes sample code for the following purposes:
 -   [Registering for Raw Input](#registering-for-raw-input)
     -   [Example 1](#example-1)
     -   [Example 2](#example-2)
--   [Performing a Standard Read of Raw Input](#performing-a-standard-read-of-raw-input)
--   [Performing a Buffered Read of Raw Input](#performing-a-buffered-read-of-raw-input)
+-   [Reading Raw Input from a WM_INPUT Handler](#reading-raw-input-from-a-wm_input-handler)
+-   [Performing a Batched Read of Raw Input Using a Timer](#performing-a-batched-read-of-raw-input-using-a-timer)
 
 ## Registering for Raw Input
 
@@ -142,54 +142,101 @@ case WM_INPUT:
 } 
 ```
 
-## Performing a Buffered Read of Raw Input
+## Reading Raw Input from a WM_INPUT Handler
 
-This sample shows how an application does a buffered read of raw input from a generic HID.
+This sample shows the minimal pattern for reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
 
 ```cpp
-case MSG_GETRIBUFFER: // Private message
-    {
-    UINT cbSize;
-    Sleep(1000);
+/* Initialized once at startup */
+UINT  g_bufferSize = 64 * sizeof(RAWINPUT);
+void* g_pBuffer    = NULL;
 
-    VERIFY(GetRawInputBuffer(NULL, &cbSize, sizeof(RAWINPUTHEADER)) == 0);
-    cbSize *= 16; // up to 16 messages
-    Log(_T("Allocating %d bytes"), cbSize);
-    PRAWINPUT pRawInput = (PRAWINPUT)malloc(cbSize);
-    if (pRawInput == NULL)
-    {
-        Log(_T("Not enough memory"));
-        return;
-    }
-
-    for (;;)
-    {
-        UINT cbSizeT = cbSize;
-        UINT nInput = GetRawInputBuffer(pRawInput, &cbSizeT, sizeof(RAWINPUTHEADER));
-        Log(_T("nInput = %d"), nInput);
-        if (nInput == 0)
-        {
-            break;
-        }
-
-        ASSERT(nInput > 0);
-        PRAWINPUT* paRawInput = (PRAWINPUT*)malloc(sizeof(PRAWINPUT) * nInput);
-        if (paRawInput == NULL)
-        {
-            Log(_T("paRawInput NULL"));
-            break;
-        }
-
-        PRAWINPUT pri = pRawInput;
-        for (UINT i = 0; i < nInput; ++i)
-        {
-            Log(_T(" input[%d] = @%p"), i, pri);
-            paRawInput[i] = pri;
-            pri = NEXTRAWINPUTBLOCK(pri);
-        }
-
-        free(paRawInput);
-    }
-    free(pRawInput);
+void ProcessInput(const RAWINPUT* input)
+{
+    if (input->header.dwType == RIM_TYPEKEYBOARD)
+        printf("key vk=0x%02x flags=0x%x\n", input->data.keyboard.VKey, input->data.keyboard.Flags);
+    else if (input->header.dwType == RIM_TYPEMOUSE)
+        printf("mouse dx=%d dy=%d\n", input->data.mouse.lLastX, input->data.mouse.lLastY);
 }
+
+/* ... */
+
+g_pBuffer = malloc(g_bufferSize);
+
+/* ... */
+
+case WM_INPUT:
+{
+    UINT bufferSize = g_bufferSize;
+    UINT result = GetRawInputData((HRAWINPUT)lParam, RID_INPUT, g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
+
+    if (result != (UINT)-1)
+        ProcessInput((RAWINPUT*)g_pBuffer);
+    else
+        Log(_T("GetRawInputData failed: %d"), GetLastError());
+
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+```
+
+## Performing a Batched Read of Raw Input Using a Timer
+
+This sample shows how to read raw input in fixed-rate batches using a periodic timer. [**WM_INPUT**](wm-input.md) messages are intentionally never dispatched through [**DispatchMessage**](/windows/win32/api/winuser/nf-winuser-dispatchmessage) — because [**GetMessage**](/windows/win32/api/winuser/nf-winuser-getmessage) removes messages from the raw input queue before returning, only [**PeekMessage**](/windows/win32/api/winuser/nf-winuser-peekmessagew) with explicit message range filters is used, skipping [**WM_INPUT**](wm-input.md) entirely. This keeps all raw input events in the queue where [**GetRawInputBuffer**](/windows/win32/api/winuser/nf-winuser-getrawinputbuffer) can drain them all at once on each timer tick. This approach is well-suited for game loops and other applications that process input at a fixed rate rather than reacting to each event individually.
+
+```cpp
+HWND hWnd = CreateWindowExW(0, L"RawInputSink", NULL, 0, 0, 0, 0, 0, HWND_MESSAGE, NULL, NULL, NULL);
+RAWINPUTDEVICE rid = { 0x01, 0x02, RIDEV_INPUTSINK, hWnd }; /* mouse */
+RegisterRawInputDevices(&rid, 1, sizeof(rid));
+
+/* Drain raw input queue every 16ms (~60Hz) */
+SetTimer(hWnd, 1, 16, NULL);
+
+MSG msg;
+for (;;)
+{
+    /* Dispatch all messages except WM_INPUT */
+    while (PeekMessageW(&msg, NULL, 0, WM_INPUT - 1, PM_REMOVE) ||
+           PeekMessageW(&msg, NULL, WM_INPUT + 1, 0xFFFF, PM_REMOVE))
+    {
+        if (msg.message == WM_QUIT)
+            goto Exit;
+
+        if (msg.message == WM_TIMER)
+        {
+            /* Timer tick — drain all WM_INPUT accumulated in the queue */
+            for (;;)
+            {
+                UINT bufferSize = g_bufferSize;
+                UINT count = GetRawInputBuffer((RAWINPUT*)g_pBuffer, &bufferSize, sizeof(RAWINPUTHEADER));
+
+                if (count == 0)
+                    break;
+
+                if (count == (UINT)-1)
+                {
+                    /* Buffer too small — grow and retry */
+                    g_bufferSize = max(bufferSize, g_bufferSize * 2);
+                    g_pBuffer = realloc(g_pBuffer, g_bufferSize);
+                    if (g_pBuffer == NULL)
+                        goto Exit;
+                    continue;
+                }
+
+                {
+                    RAWINPUT* input = (RAWINPUT*)g_pBuffer;
+                    UINT i;
+                    for (i = 0; i < count; ++i, input = NEXTRAWINPUTBLOCK(input))
+                        ProcessInput(input);
+                    /* Do not break — there may be more events in the queue. */
+                }
+            }
+        }
+
+        DispatchMessageW(&msg);
+    }
+
+    WaitMessage();
+}
+
+Exit:;
 ```

--- a/desktop-src/inputdev/using-raw-input.md
+++ b/desktop-src/inputdev/using-raw-input.md
@@ -86,7 +86,7 @@ if (RegisterRawInputDevices(Rid, 2, sizeof(Rid[0])) == FALSE)
 
 ## Performing a Standard Read of Raw Input
 
-This sample shows the minimal pattern for unbuffered (or standard) reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
+This sample shows the minimal pattern for standard reading raw input from a [**WM_INPUT**](wm-input.md) message handler. Each [**WM_INPUT**](wm-input.md) message carries an **HRAWINPUT** handle in **lParam** referencing the current input event — it must be read via [**GetRawInputData**](/windows/win32/api/winuser/nf-winuser-getrawinputdata) before calling [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowprocw).
 
 ```cpp
 void ProcessInput(const RAWINPUT* input)


### PR DESCRIPTION
This PR corrects and clarifies the Raw Input documentation.

**Changes**
- Add note that `GetMessage` removes `WM_INPUT` from the raw input queue before returning, making it invisible to `GetRawInputBuffer`
- Document the correct pattern: call `GetRawInputData(lParam)` first, then drain with `GetRawInputBuffer` in a loop
- Note that background input requires `RIDEV_INPUTSINK`
- Replace outdated samples: remove `Sleep(1000)` workaround, fix `cbSize * 16` buffer guess, remove `DefRawInputProc` no-op
- Add timer-based batched read sample using `PeekMessage` range filters

See also https://github.com/MicrosoftDocs/sdk-api/pull/2190