### PR TITLE
Fix further mojibake issues

### DIFF
--- a/desktop-src/Direct2D/id2d1brush-settransform.md
+++ b/desktop-src/Direct2D/id2d1brush-settransform.md
@@ -124,7 +124,3 @@ D2D1_RECT_F rcTransformedBrushRect = D2D1::RectF(100, 100, 200, 200);
 
 [**ID2D1Brush**](/windows/win32/api/d2d1/nn-d2d1-id2d1brush)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1device-createprintcontrol.md
+++ b/desktop-src/Direct2D/id2d1device-createprintcontrol.md
@@ -45,7 +45,3 @@ Creates an [**ID2D1PrintControl**](/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1prin
 
 [**ID2D1Device**](/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1device)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1devicecontext-createbitmapfromdxgisurface-overload.md
+++ b/desktop-src/Direct2D/id2d1devicecontext-createbitmapfromdxgisurface-overload.md
@@ -45,7 +45,3 @@ Creates a bitmap from a DXGI surface that can be set as a target surface or have
 
 [**ID2D1DeviceContext**](/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1devicecontext)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1devicecontext2-createink-overload.md
+++ b/desktop-src/Direct2D/id2d1devicecontext2-createink-overload.md
@@ -45,7 +45,3 @@ Creates a new [**ID2D1Ink**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1ink) objec
 
 [**ID2D1DeviceContext2**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1devicecontext2)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1devicecontext2-createinkstyle-overload.md
+++ b/desktop-src/Direct2D/id2d1devicecontext2-createinkstyle-overload.md
@@ -45,7 +45,3 @@ Creates a new [**ID2D1InkStyle**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1inkst
 
 [**ID2D1DeviceContext2**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1devicecontext2)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1devicecontext3-drawspritebatch-overloaded.md
+++ b/desktop-src/Direct2D/id2d1devicecontext3-drawspritebatch-overloaded.md
@@ -45,7 +45,3 @@ Renders part or all of the given sprite batch to the device context using the sp
 
 [**ID2D1DeviceContext3**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1devicecontext3)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1factory-createrectanglegeometry.md
+++ b/desktop-src/Direct2D/id2d1factory-createrectanglegeometry.md
@@ -47,7 +47,3 @@ Creates an [**ID2D1RectangleGeometry**](/windows/win32/api/d2d1/nf-d2d1-id2d1fac
 
 [**ID2D1Factory**](/windows/win32/api/d2d1/nn-d2d1-id2d1factory)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1factory-createroundedrectanglegeometry.md
+++ b/desktop-src/Direct2D/id2d1factory-createroundedrectanglegeometry.md
@@ -47,7 +47,3 @@ Creates an [**ID2D1RoundedRectangleGeometry**](/previous-versions/windows/deskto
 
 [**ID2D1Factory**](/windows/win32/api/d2d1/nn-d2d1-id2d1factory)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1geometrysink-addarc.md
+++ b/desktop-src/Direct2D/id2d1geometrysink-addarc.md
@@ -47,7 +47,3 @@ Creates a single arc and adds it to the path geometry.
 
 [**ID2D1GeometrySink**](/windows/win32/api/d2d1/nn-d2d1-id2d1geometrysink)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1geometrysink-addbezier.md
+++ b/desktop-src/Direct2D/id2d1geometrysink-addbezier.md
@@ -105,7 +105,3 @@ if (SUCCEEDED(hr))
 
 [**ID2D1GeometrySink**](/windows/win32/api/d2d1/nn-d2d1-id2d1geometrysink)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1geometrysink-addquadraticbezier.md
+++ b/desktop-src/Direct2D/id2d1geometrysink-addquadraticbezier.md
@@ -47,7 +47,3 @@ Creates a quadratic Bezier curve between the current point and the specified end
 
 [**ID2D1GeometrySink**](/windows/win32/api/d2d1/nn-d2d1-id2d1geometrysink)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1hwndrendertarget-resize.md
+++ b/desktop-src/Direct2D/id2d1hwndrendertarget-resize.md
@@ -51,7 +51,3 @@ After this method is called, the contents of the render target's back-buffer are
 
 [**ID2D1HwndRenderTarget**](/previous-versions/windows/desktop/legacy/dd371275(v=vs.85))
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1imagesourcefromwic-ensurecached-overload.md
+++ b/desktop-src/Direct2D/id2d1imagesourcefromwic-ensurecached-overload.md
@@ -45,7 +45,3 @@ Loads image data into caches of image sources if that data is not already cached
 
 [**ID2D1ImageSourceFromWic**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1imagesourcefromwic)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1imagesourcefromwic-trimcache-overload.md
+++ b/desktop-src/Direct2D/id2d1imagesourcefromwic-trimcache-overload.md
@@ -45,7 +45,3 @@ Trims the populated regions of the image source cache to just the specified rect
 
 [**ID2D1ImageSourceFromWic**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1imagesourcefromwic)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1ink-setsegmentatend-overload.md
+++ b/desktop-src/Direct2D/id2d1ink-setsegmentatend-overload.md
@@ -45,7 +45,3 @@ Updates the last segment in this ink object with new control points.
 
 [**ID2D1Ink**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1ink)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1inkstyle-setnibtransform-overload.md
+++ b/desktop-src/Direct2D/id2d1inkstyle-setnibtransform-overload.md
@@ -45,7 +45,3 @@ Sets the transform to apply to this style's nib shape.
 
 [**ID2D1InkStyle**](/windows/win32/api/d2d1_3/nn-d2d1_3-id2d1inkstyle)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1properties-setvaluebyname-overload.md
+++ b/desktop-src/Direct2D/id2d1properties-setvaluebyname-overload.md
@@ -46,7 +46,3 @@ Sets the named property to the given value.
 
 [**ID2D1Properties**](/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1properties)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-createcompatiblerendertarget.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-createcompatiblerendertarget.md
@@ -125,7 +125,3 @@ Code has been omitted from this example.
 
 [**ID2D1RenderTarget**](/windows/win32/api/d2d1/nn-d2d1-id2d1rendertarget)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-createlayer.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-createlayer.md
@@ -100,7 +100,3 @@ HRESULT DemoApp::RenderWithLayer(ID2D1RenderTarget *pRT)
 
 [**ID2D1RenderTarget**](/windows/win32/api/d2d1/nn-d2d1-id2d1rendertarget)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-createlineargradientbrush.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-createlineargradientbrush.md
@@ -70,7 +70,3 @@ For an example showing how to create a gradient stop collection and use it to de
 
 [Brushes Overview](direct2d-brushes-overview.md)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-createradialgradientbrush.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-createradialgradientbrush.md
@@ -58,7 +58,3 @@ For an example, see [How to Create a Radial Gradient Brush](how-to-create-a-radi
 
 [Brushes Overview](direct2d-brushes-overview.md)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-createsolidcolorbrush.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-createsolidcolorbrush.md
@@ -58,7 +58,3 @@ For an example, see [How to Create a Solid Color Brush](how-to-create-a-solid-co
 
 [Direct2D QuickStart](getting-started-with-direct2d.md)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-drawellipse.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-drawellipse.md
@@ -58,7 +58,3 @@ For an example, see [How to Draw and Fill a Basic Shape](how-to-draw-an-ellipse.
 
 [**FillEllipse**](/windows/win32/api/d2d1/nf-d2d1-id2d1rendertarget-fillellipse(constd2d1_ellipse_id2d1brush))
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-drawroundedrectangle.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-drawroundedrectangle.md
@@ -135,7 +135,3 @@ HRESULT DrawAndFillRoundedRectangleExample::OnRender()
 
 [**D2D1::RoundedRect**](/windows/win32/api/d2d1/nf-d2d1-id2d1roundedrectanglegeometry-getroundedrect)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-fillellipse.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-fillellipse.md
@@ -58,7 +58,3 @@ For an example, see [How to Draw and Fill a Basic Shape](how-to-draw-an-ellipse.
 
 [How to Draw and Fill a Basic Shape](how-to-draw-an-ellipse.md)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-fillroundedrectangle.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-fillroundedrectangle.md
@@ -135,7 +135,3 @@ HRESULT DrawAndFillRoundedRectangleExample::OnRender()
 
 [**D2D1::RoundedRect**](/windows/win32/api/d2d1/nf-d2d1-id2d1roundedrectanglegeometry-getroundedrect)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1rendertarget-pushaxisalignedclip.md
+++ b/desktop-src/Direct2D/id2d1rendertarget-pushaxisalignedclip.md
@@ -57,7 +57,3 @@ For an example, see the [How to Clip with an Axis-Aligned Clip Rectangle](how-to
 
 [**ID2D1RenderTarget**](/windows/win32/api/d2d1/nn-d2d1-id2d1rendertarget)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1svgdocument-createpaint-overload.md
+++ b/desktop-src/Direct2D/id2d1svgdocument-createpaint-overload.md
@@ -45,7 +45,3 @@ Creates a paint object which can be used to set the 'fill' or 'stroke' propertie
 
 [**ID2D1SvgDocument**](/windows/win32/api/d2d1svg/nn-d2d1svg-id2d1svgdocument)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1svgelement-setattributevalue-overload.md
+++ b/desktop-src/Direct2D/id2d1svgelement-setattributevalue-overload.md
@@ -59,7 +59,3 @@ Sets an attribute of this element.
 
 [**ID2D1SvgElement**](/windows/win32/api/d2d1svg/nn-d2d1svg-id2d1svgelement)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1svgstrokedasharray-getdashes-overload.md
+++ b/desktop-src/Direct2D/id2d1svgstrokedasharray-getdashes-overload.md
@@ -45,7 +45,3 @@ Gets dashes from the array.
 
 [**ID2D1SvgStrokeDashArray**](/windows/win32/api/d2d1svg/nn-d2d1svg-id2d1svgstrokedasharray)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/Direct2D/id2d1svgstrokedasharray-updatedashes-overload.md
+++ b/desktop-src/Direct2D/id2d1svgstrokedasharray-updatedashes-overload.md
@@ -45,7 +45,3 @@ Updates the array.
 
 [**ID2D1SvgStrokeDashArray**](/windows/win32/api/d2d1svg/nn-d2d1svg-id2d1svgstrokedasharray)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/SecAuthN/acceptsecuritycontext--credssp.md
+++ b/desktop-src/SecAuthN/acceptsecuritycontext--credssp.md
@@ -129,8 +129,8 @@ After the security context has been established, the server application can use 
 
 | Requirement | Value |
 |--------------------------|-------------------------------------------|
-| Minimum supported client | Windows�Vista \[desktop apps only\]       |
-| Minimum supported server | Windows Server�2008 \[desktop apps only\] |
+| Minimum supported client | Windows Vista \[desktop apps only\]       |
+| Minimum supported server | Windows Server 2008 \[desktop apps only\] |
 | Header                   | Sspi.h (include Security.h)               |
 | Library                  | Secur32.lib                               |
 | DLL                      | Secur32.dll                               |

--- a/desktop-src/SecCrypto/cryptuidlgselectcertificate.md
+++ b/desktop-src/SecCrypto/cryptuidlgselectcertificate.md
@@ -49,12 +49,12 @@ If the **dwFlags** member of the [**CRYPTUI\_SELECTCERTIFICATE\_STRUCT**](cryptu
 
 
 | Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�XP \[desktop apps only\]<br/>                                                       |
-| Minimum supported server<br/> | Windows Server�2003 \[desktop apps only\]<br/>                                              |
-| End of support<br/> | Windows�7 \[desktop apps only\]<br/>                                                       |
-| Library<br/>                  | <dl> <dt>Cryptui.lib</dt> </dl>            |
-| DLL<br/>                      | <dl> <dt>Cryptui.dll</dt> </dl>            |
+|-------------------------------|---------------------------------------------------------------------------------------------|
+| Minimum supported client<br/> | Windows XP \[desktop apps only\]<br/>                                                       |
+| Minimum supported server<br/> | Windows Server 2003 \[desktop apps only\]<br/>                                              |
+| End of support<br/>           | Windows 7 \[desktop apps only\]<br/>                                                        |
+| Library<br/>                  | <dl> <dt>Cryptui.lib</dt> </dl>                                                             |
+| DLL<br/>                      | <dl> <dt>Cryptui.dll</dt> </dl>                                                             |
 | Unicode and ANSI names<br/>   | **CryptUIDlgSelectCertificateW** (Unicode) and **CryptUIDlgSelectCertificateA** (ANSI)<br/> |
 
 

--- a/desktop-src/WmiSdk/cframeworkquery-getvaluesforprop.md
+++ b/desktop-src/WmiSdk/cframeworkquery-getvaluesforprop.md
@@ -33,16 +33,12 @@ If the constraints on "Name" are not sufficiently limiting, an empty *sa* array 
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>FrQuery.h (include FwCommon.h)</dt> </dl>                                                     |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>FrQuery.h (include FwCommon.h)</dt> </dl>         |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/chstring-chstring.md
+++ b/desktop-src/WmiSdk/chstring-chstring.md
@@ -34,16 +34,10 @@ Each of the following constructors initializes a new [**CHString**](chstring.md)
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
-
-
-
-�
-
-�

--- a/desktop-src/WmiSdk/chstring-find.md
+++ b/desktop-src/WmiSdk/chstring-find.md
@@ -29,16 +29,10 @@ The **Find** method searches a string for the first match of a substring.
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
-
-
-
-�
-
-�

--- a/desktop-src/WmiSdk/chstring-format.md
+++ b/desktop-src/WmiSdk/chstring-format.md
@@ -29,16 +29,10 @@ The **Format** method formats and stores a series of characters and values in a 
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
-
-
-
-�
-
-�

--- a/desktop-src/WmiSdk/chstring-formatmessagew.md
+++ b/desktop-src/WmiSdk/chstring-formatmessagew.md
@@ -29,16 +29,12 @@ The overloaded **FormatMessageW** method formats a message string.
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/chstring-mid.md
+++ b/desktop-src/WmiSdk/chstring-mid.md
@@ -29,16 +29,12 @@ The **Mid** method extracts a substring of length *nCount* characters from a [**
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChString.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/cinstance--setwbemint64.md
+++ b/desktop-src/WmiSdk/cinstance--setwbemint64.md
@@ -30,12 +30,12 @@ The [**CInstance::GetWBEMINT64**](cinstance-getwbemint64.md) method sets a 64-bi
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>Instance.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>Instance.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
@@ -46,7 +46,3 @@ The [**CInstance::GetWBEMINT64**](cinstance-getwbemint64.md) method sets a 64-bi
 
 [**CInstance**](/windows/win32/api/instance/nl-instance-cinstance)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/WmiSdk/cobjectpathparser--free.md
+++ b/desktop-src/WmiSdk/cobjectpathparser--free.md
@@ -29,12 +29,12 @@ An overloaded method that releases the memory that contains the path.
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ObjPath.h (include ObjPath.h)</dt> </dl>                                                      |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ObjPath.h (include ObjPath.h)</dt> </dl>          |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
@@ -45,7 +45,3 @@ An overloaded method that releases the memory that contains the path.
 
 [**CObjectPathParser**](/windows/win32/api/objpath/nl-objpath-cobjectpathparser)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/WmiSdk/cwbemproviderglue-getemptyinstance.md
+++ b/desktop-src/WmiSdk/cwbemproviderglue-getemptyinstance.md
@@ -29,16 +29,12 @@ The **GetEmptyInstance** method retrieves a single unpopulated instance of the s
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemGlue.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemGlue.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/insertat-method-in-class-chstringarray.md
+++ b/desktop-src/WmiSdk/insertat-method-in-class-chstringarray.md
@@ -29,12 +29,12 @@ The **InsertAt** method inserts an element (or multiple copies of an element) or
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>ChStrArr.h (include FwCommon.h)</dt> </dl>                                                    |
-| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                                                                       |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>ChStrArr.h (include FwCommon.h)</dt> </dl>        |
+| Library<br/>                  | <dl> <dt>FrameDyn.lib</dt> </dl>                           |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
@@ -45,7 +45,3 @@ The **InsertAt** method inserts an element (or multiple copies of an element) or
 
 [**CHStringArray**](/windows/win32/api/chstrarr/nl-chstrarr-chstringarray)
 </dt> </dl>
-
-�
-
-�

--- a/desktop-src/WmiSdk/wbemtime--getlocaloffsetfordate.md
+++ b/desktop-src/WmiSdk/wbemtime--getlocaloffsetfordate.md
@@ -12,7 +12,7 @@ ms.topic: reference
 
 \[The [**WBEMTime**](wbemtime.md) class is part of the WMI Provider Framework which is now considered in final state, and no further development, enhancements, or updates will be available for non-security related issues affecting these libraries. The [MI APIs](/previous-versions/windows/desktop/wmi_v2/windows-management-infrastructure) should be used for all new development.\]
 
-The **GetLocalOffsetForDate** method returns the offset in minutes (+ or �) between GMT and local time for the time supplied in the argument.
+The **GetLocalOffsetForDate** method returns the offset in minutes (+ or -) between GMT and local time for the time supplied in the argument.
 
 ### Overload list
 
@@ -31,15 +31,11 @@ The **GetLocalOffsetForDate** method returns the offset in minutes (+ or �) be
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                                                                         |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                             |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/wbemtime--operator-equal.md
+++ b/desktop-src/WmiSdk/wbemtime--operator-equal.md
@@ -32,15 +32,11 @@ The [**WBEMTime**](wbemtime.md) class assignment operators are overloaded to fac
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                                                                         |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                             |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/wbemtime--operator-minus.md
+++ b/desktop-src/WmiSdk/wbemtime--operator-minus.md
@@ -12,7 +12,7 @@ ms.topic: reference
 
 \[The [**WBEMTime**](wbemtime.md) class is part of the WMI Provider Framework which is now considered in final state, and no further development, enhancements, or updates will be available for non-security related issues affecting these libraries. The [MI APIs](/previous-versions/windows/desktop/wmi_v2/windows-management-infrastructure) should be used for all new development.\]
 
-The [**WBEMTime**](wbemtime.md) class subtraction operator (�) has been overloaded to:
+The [**WBEMTime**](wbemtime.md) class subtraction operator (-) has been overloaded to:
 
 -   Subtract a time span from an object's time to produce a new time object that contains the resulting time.
 -   Subtract a time from the object's time to produce a new time span object that contains the difference between the two times.
@@ -32,15 +32,11 @@ The [**WBEMTime**](wbemtime.md) class subtraction operator (�) has been overlo
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                                                                         |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                             |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/wbemtime-wbemtime.md
+++ b/desktop-src/WmiSdk/wbemtime-wbemtime.md
@@ -33,15 +33,11 @@ The **WBEMTime** class constructor facilitates conversions between various Windo
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                                                                         |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                             |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/wbemtimespan-wbemtimespan.md
+++ b/desktop-src/WmiSdk/wbemtimespan-wbemtimespan.md
@@ -30,15 +30,11 @@ The **WBEMTimeSpan** class constructor creates a time span object. The construct
 
 
 
-| Requirement | Value |
-|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Minimum supported client<br/> | Windows�Vista<br/>                                                                                                                                      |
-| Minimum supported server<br/> | Windows Server�2008<br/>                                                                                                                                |
-| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                                                                         |
+| Requirement                   | Value                                                      |
+|-------------------------------|------------------------------------------------------------|
+| Minimum supported client<br/> | Windows Vista<br/>                                         |
+| Minimum supported server<br/> | Windows Server 2008<br/>                                   |
+| Header<br/>                   | <dl> <dt>WbemTime.h</dt> </dl>                             |
 | DLL<br/>                      | <dl> <dt>FrameDynOS.dll; </dt> <dt>FrameDyn.dll</dt> </dl> |
 
 
-
-�
-
-�

--- a/desktop-src/WmiSdk/what-s-new-in-windows-vista.md
+++ b/desktop-src/WmiSdk/what-s-new-in-windows-vista.md
@@ -7,7 +7,7 @@ ms.topic: whats-new
 ms.date: 05/31/2018
 ---
 
-# Whats New in Windows�Vista
+# Whats New in Windows Vista
 
 Starting with Windows Vista, WMI contains many new features based upon requests by WMI users.
 

--- a/desktop-src/extensible-storage-engine/transactions.md
+++ b/desktop-src/extensible-storage-engine/transactions.md
@@ -12,7 +12,7 @@ ms.topic: reference
 # Transactions (Windows Events)
 
 
-_**Applies to:** Windows�| Windows Server_
+_**Applies to:** Windows | Windows Server_
 
 ## Transactions
 


### PR DESCRIPTION
These didn't quite fit into my previous PR (#2175) since they required some manual fixup.

It seems like there was an actual drop of encoding at some point in the past, and there were several 'invalid unicode character' insertions (`\uFFDF` aka ￟). Mostly these were just at the end of various files (so I cleaned them up). In a couple of cases they were mid-table, so I also adjusted the table lines.
In two cases, they were representing a "minus sign", likely as a unicode character instead of ASCII `-`.