### PR TITLE
Fix typo in XInput's deadzone section

### DIFF
--- a/desktop-src/xinput/getting-started-with-xinput.md
+++ b/desktop-src/xinput/getting-started-with-xinput.md
@@ -143,7 +143,7 @@ Note that you may define your own dead zones for the sticks and triggers (anywhe
 
 Once the deadzone is enforced, you may find it useful to scale the resulting range \[0.0..1.0\] floating point (as in the example above), and optionally apply a non-linear transform.
 
-For example, with driving games, it may be helpful to cube the result to provide a better feel to driving the cars using a gamepad, as cubing the result gives you more precision in the lower ranges, which is desirable, since gamers typically either apply soft force to get subtle movement or apply hard force all the way in one direction to get rd response.
+For example, with driving games, it may be helpful to cube the result to provide a better feel to driving the cars using a gamepad, as cubing the result gives you more precision in the lower ranges, which is desirable, since gamers typically either apply soft force to get subtle movement or apply hard force all the way in one direction to get rapid response.
 
 ### Setting Vibration Effects
 


### PR DESCRIPTION
Small typo in the deadzone section of the `Getting Started With XInput in Windows applications` doc, `rd` was most likely meant to be `rapid`.