### PR TITLE
Add article for new TLS Hybrid Key Exchange groups 

### DIFF
--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -1,0 +1,70 @@
+---
+description: Supported groups enabled in Windows 11 version 24H2 and later.
+title: TLS Supported Groups in Windows 11 version 24H2, Windows Server 2025, and later
+ms.topic: reference
+ms.keywords: 'hybrid key exchange, tls supported groups, supported groups, ecc curves, elliptic curves, tls elliptic curves, ECC curves, schannel, ECC, EC, Elliptic Curve Cryptography'
+ms.date: 05/20/2026
+---
+
+# TLS Supported Groups in Windows 11 version 24H2 and later
+> [!NOTE]
+> With the addition of post-quantum key exchange algorithms, the TLS parameter previously referred to as "Elliptic Curves" has been renamed "Supported Groups" to be inclusive of non-EC algorithms. Reference: [IANA TLS parammeters](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8). 
+
+> [!NOTE]
+> NEW post-quantum ML-KEM groups are now available in the latest Windows Insider Preview builds for Windows 11 client and Windows Server 2025. These groups are disabled by default, and must be enabled using one of the configuration methods linked at the end of this article. The minimum supported builds are [26100.8514](https://learn.microsoft.com/en-us/windows-insider/release-notes/release-preview-24h2-25h2/build-26100-8514-26200-8514) for Windows 11 24H2 and 25H2, [28000.2173](https://learn.microsoft.com/en-us/windows-insider/release-notes/release-preview-26h1/build-28000-2173) for Windows 11 26H2, and [29550](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29550/4501665) for Windows Server 2025.
+
+For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
+
+| Elliptic curve string | Available in FIPS mode |
+|-------------|--------------|
+| curve25519 | No |
+| nistP256 | Yes |
+| nistP384 | Yes |
+
+
+The following groups are supported by the Microsoft Schannel Provider, but not enabled by default:
+
+| Elliptic curve string | Available in FIPS mode |
+|-------------|--------------|
+| x25519_mlkem768 | No |
+| secp256r1_mlekm768 | Yes |
+| secp384r1_mlkem1024 | Yes |
+| brainpoolP256r1 | No |
+| brainpoolP384r1 | No |
+| brainpoolP512r1 | No |
+| curve25519 | No |
+| nistP192 | No |
+| nistP224 | No |
+| nistP521 | Yes |
+| secP160k1 | No |
+| secP160r1 | No |
+| secP160r2 | No |
+| secP192k1 | No |
+| secP192r1 | No |
+| secP224k1 | No |
+| secP224r1 | No |
+| secP256k1 | No |
+| secP256r1 | No |
+| secP384r1 | No |
+| secP521r1 | No |
+
+
+
+## Enabling Elliptic Curves
+
+To add elliptic curves, either deploy a group policy or use the TLS cmdlets:
+- To use group policy, [configure ECC Curve Order](/windows-server/security/tls/manage-tls#configuring-tls-ecc-curve-order) under Computer Configuration > Administrative Templates > Network > SSL Configuration Settings with the priority list for all elliptic curves you want enabled.
+
+- To use PowerShell, see [TLS cmdlets](/powershell/module/tls) for a complete list of TLS cmdlet syntax and descriptions.
+
+
+
+## See Also
+
+[Configuring TLS ECC Curve Order](/windows-server/security/tls/manage-tls#configuring-tls-ecc-curve-order)
+
+[Managing TLS ECC order](/windows-server/security/tls/manage-tls#managing-tls-ecc-order)
+
+[Managing Windows ECC curves using Group Policy](/windows-server/security/tls/manage-tls#managing-windows-ecc-curves-using-group-policy)
+
+[TLS cmdlets](/powershell/module/tls)

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -16,7 +16,7 @@ ms.date: 05/20/2026
 For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
 | Elliptic curve string | Supported Protocol Versions | Available in FIPS mode | 
-|-------------|--------------|
+|-------------|--------------|--------------|
 | curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP256 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
 | nistP384 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
@@ -25,7 +25,7 @@ For Windows 11, versions 24H2 and later, the following groups are enabled and in
 The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
 | Elliptic curve string |  Supported Protocol Versions | Available in FIPS mode |
-|-------------|--------------|
+|-------------|--------------|--------------|
 | x25519_mlkem768 | TLS 1.3 | Yes |
 | secp256r1_mlkem768 | TLS 1.3 | Yes |
 | secp384r1_mlkem1024 | TLS 1.3 | Yes |

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -15,7 +15,7 @@ ms.date: 05/20/2026
 
 For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
-| Supported Group String | Supported Protocol Versions | Available in FIPS mode | 
+| Supported Group String | Supported Protocol Versions | Available in FIPS mode (legacy) | 
 |-------------|--------------|--------------|
 | curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP256 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
@@ -24,7 +24,7 @@ For Windows 11, versions 24H2 and later, the following groups are enabled and in
 
 The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
-| Supported Group String |  Supported Protocol Versions | Available in FIPS mode |
+| Supported Group String |  Supported Protocol Versions | Available in FIPS mode (legacy) |
 |-------------|--------------|--------------|
 | x25519_mlkem768 | TLS 1.3 | No |
 | secp256r1_mlkem768 | TLS 1.3 | No |
@@ -48,7 +48,8 @@ The following groups are supported by the Microsoft Schannel Provider, but are n
 | secP384r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | secP521r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 
-
+> [!NOTE]
+> The legacy FIPS mode setting is no longer recommended nor required to operate with FIPS approval. Using FIPS-approved algorithms is the only configuration needed.
 
 ## Enabling Supported Groups
 

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -15,44 +15,44 @@ ms.date: 05/20/2026
 
 For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
-| Elliptic curve string | Available in FIPS mode |
+| Elliptic curve string | Supported Protocol Versions | Available in FIPS mode | 
 |-------------|--------------|
-| curve25519 | No |
-| nistP256 | Yes |
-| nistP384 | Yes |
+| curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| nistP256 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
+| nistP384 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
 
 
 The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
-| Elliptic curve string | Available in FIPS mode |
+| Elliptic curve string |  Supported Protocol Versions | Available in FIPS mode |
 |-------------|--------------|
-| x25519_mlkem768 | No |
-| secp256r1_mlekm768 | Yes |
-| secp384r1_mlkem1024 | Yes |
-| brainpoolP256r1 | No |
-| brainpoolP384r1 | No |
-| brainpoolP512r1 | No |
-| curve25519 | No |
-| nistP192 | No |
-| nistP224 | No |
-| nistP521 | Yes |
-| secP160k1 | No |
-| secP160r1 | No |
-| secP160r2 | No |
-| secP192k1 | No |
-| secP192r1 | No |
-| secP224k1 | No |
-| secP224r1 | No |
-| secP256k1 | No |
-| secP256r1 | No |
-| secP384r1 | No |
-| secP521r1 | No |
+| x25519_mlkem768 | TLS 1.3 | Yes |
+| secp256r1_mlkem768 | TLS 1.3 | Yes |
+| secp384r1_mlkem1024 | TLS 1.3 | Yes |
+| brainpoolP256r1 | TLS 1.0, 1.1, 1.2 | No |
+| brainpoolP384r1 | TLS 1.0, 1.1, 1.2 | No |
+| brainpoolP512r1 | TLS 1.0, 1.1, 1.2 | No |
+| curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| nistP192 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| nistP224 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| nistP521 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
+| secP160k1 | TLS 1.0, 1.1, 1.2 | No |
+| secP160r1 | TLS 1.0, 1.1, 1.2 | No |
+| secP160r2 | TLS 1.0, 1.1, 1.2 | No |
+| secP192k1 | TLS 1.0, 1.1, 1.2 | No |
+| secP192r1 | TLS 1.0, 1.1, 1.2 | No |
+| secP224k1 | TLS 1.0, 1.1, 1.2 | No |
+| secP224r1 | TLS 1.0, 1.1, 1.2 | No |
+| secP256k1 | TLS 1.0, 1.1, 1.2 | No |
+| secP256r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP384r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP521r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 
 
 
-## Enabling Elliptic Curves
+## Enabling Supported Groups
 
-To add elliptic curves, either deploy a group policy or use the TLS cmdlets:
+To add supported groups or change the default priority order, either deploy a group policy or use the TLS cmdlets:
 - To use group policy, [configure ECC Curve Order](/windows-server/security/tls/manage-tls#configuring-tls-ecc-curve-order) under Computer Configuration > Administrative Templates > Network > SSL Configuration Settings with the priority list for all elliptic curves you want enabled.
 
 - To use PowerShell, see [TLS cmdlets](/powershell/module/tls) for a complete list of TLS cmdlet syntax and descriptions.

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -29,21 +29,21 @@ The following groups are supported by the Microsoft Schannel Provider, but are n
 | x25519_mlkem768 | TLS 1.3 | Yes |
 | secp256r1_mlkem768 | TLS 1.3 | Yes |
 | secp384r1_mlkem1024 | TLS 1.3 | Yes |
-| brainpoolP256r1 | TLS 1.0, 1.1, 1.2 | No |
-| brainpoolP384r1 | TLS 1.0, 1.1, 1.2 | No |
-| brainpoolP512r1 | TLS 1.0, 1.1, 1.2 | No |
+| brainpoolP256r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| brainpoolP384r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| brainpoolP512r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP192 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP224 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP521 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
-| secP160k1 | TLS 1.0, 1.1, 1.2 | No |
-| secP160r1 | TLS 1.0, 1.1, 1.2 | No |
-| secP160r2 | TLS 1.0, 1.1, 1.2 | No |
-| secP192k1 | TLS 1.0, 1.1, 1.2 | No |
-| secP192r1 | TLS 1.0, 1.1, 1.2 | No |
-| secP224k1 | TLS 1.0, 1.1, 1.2 | No |
-| secP224r1 | TLS 1.0, 1.1, 1.2 | No |
-| secP256k1 | TLS 1.0, 1.1, 1.2 | No |
+| secP160k1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP160r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP160r2 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP192k1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP192r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP224k1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP224r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
+| secP256k1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | secP256r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | secP384r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | secP521r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -15,7 +15,7 @@ ms.date: 05/20/2026
 
 For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
-| Elliptic curve string | Supported Protocol Versions | Available in FIPS mode | 
+| Supported group string | Supported Protocol Versions | Available in FIPS mode | 
 |-------------|--------------|--------------|
 | curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP256 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
@@ -24,7 +24,7 @@ For Windows 11, versions 24H2 and later, the following groups are enabled and in
 
 The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
-| Elliptic curve string |  Supported Protocol Versions | Available in FIPS mode |
+| Supported group string |  Supported Protocol Versions | Available in FIPS mode |
 |-------------|--------------|--------------|
 | x25519_mlkem768 | TLS 1.3 | Yes |
 | secp256r1_mlkem768 | TLS 1.3 | Yes |
@@ -53,7 +53,7 @@ The following groups are supported by the Microsoft Schannel Provider, but are n
 ## Enabling Supported Groups
 
 To add supported groups or change the default priority order, either deploy a group policy or use the TLS cmdlets:
-- To use group policy, [configure ECC Curve Order](/windows-server/security/tls/manage-tls#configuring-tls-ecc-curve-order) under Computer Configuration > Administrative Templates > Network > SSL Configuration Settings with the priority list for all elliptic curves you want enabled.
+- To use group policy, [configure ECC Curve Order](/windows-server/security/tls/manage-tls#configuring-tls-ecc-curve-order) under Computer Configuration > Administrative Templates > Network > SSL Configuration Settings with the priority list for all supported groups you want enabled.
 
 - To use PowerShell, see [TLS cmdlets](/powershell/module/tls) for a complete list of TLS cmdlet syntax and descriptions.
 

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -2,7 +2,7 @@
 description: Supported groups enabled in Windows 11 versions 24H2 and later.
 title: TLS Supported Groups in Windows 11 version 24H2, Windows Server 2025, and later
 ms.topic: reference
-ms.keywords: 'hybrid key exchange, tls supported groups, supported groups, ecc curves, elliptic curves, tls elliptic curves, ECC curves, schannel, ECC, EC, Elliptic Curve Cryptography'
+ms.keywords: 'hybrid key exchange, tls supported groups, supported groups, ecc curves, elliptic curves, tls elliptic curves, ECC curves, schannel, ECC, EC, Elliptic Curve Cryptography, post quantum, PQC, post-quantum TLS'
 ms.date: 05/20/2026
 ---
 
@@ -15,7 +15,7 @@ ms.date: 05/20/2026
 
 For Windows 11, versions 24H2 and later, the following groups are enabled and in this priority order by default using the Microsoft Schannel Provider:
 
-| Supported group string | Supported Protocol Versions | Available in FIPS mode | 
+| Supported Group String | Supported Protocol Versions | Available in FIPS mode | 
 |-------------|--------------|--------------|
 | curve25519 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | nistP256 | TLS 1.0, 1.1, 1.2, 1.3 | Yes |
@@ -24,7 +24,7 @@ For Windows 11, versions 24H2 and later, the following groups are enabled and in
 
 The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
-| Supported group string |  Supported Protocol Versions | Available in FIPS mode |
+| Supported Group String |  Supported Protocol Versions | Available in FIPS mode |
 |-------------|--------------|--------------|
 | x25519_mlkem768 | TLS 1.3 | Yes |
 | secp256r1_mlkem768 | TLS 1.3 | Yes |

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -26,9 +26,9 @@ The following groups are supported by the Microsoft Schannel Provider, but are n
 
 | Supported Group String |  Supported Protocol Versions | Available in FIPS mode |
 |-------------|--------------|--------------|
-| x25519_mlkem768 | TLS 1.3 | Yes |
-| secp256r1_mlkem768 | TLS 1.3 | Yes |
-| secp384r1_mlkem1024 | TLS 1.3 | Yes |
+| x25519_mlkem768 | TLS 1.3 | No |
+| secp256r1_mlkem768 | TLS 1.3 | No |
+| secp384r1_mlkem1024 | TLS 1.3 | No |
 | brainpoolP256r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | brainpoolP384r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |
 | brainpoolP512r1 | TLS 1.0, 1.1, 1.2, 1.3 | No |

--- a/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
+++ b/desktop-src/SecAuthN/tls-supported-groups-in-windows-11-24h2-and-later.md
@@ -1,14 +1,14 @@
 ---
-description: Supported groups enabled in Windows 11 version 24H2 and later.
+description: Supported groups enabled in Windows 11 versions 24H2 and later.
 title: TLS Supported Groups in Windows 11 version 24H2, Windows Server 2025, and later
 ms.topic: reference
 ms.keywords: 'hybrid key exchange, tls supported groups, supported groups, ecc curves, elliptic curves, tls elliptic curves, ECC curves, schannel, ECC, EC, Elliptic Curve Cryptography'
 ms.date: 05/20/2026
 ---
 
-# TLS Supported Groups in Windows 11 version 24H2 and later
+# TLS Supported Groups in Windows 11 versions 24H2 and later
 > [!NOTE]
-> With the addition of post-quantum key exchange algorithms, the TLS parameter previously referred to as "Elliptic Curves" has been renamed "Supported Groups" to be inclusive of non-EC algorithms. Reference: [IANA TLS parammeters](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8). 
+> With the addition of post-quantum key exchange algorithms, the TLS parameter previously referred to as "Elliptic Curves" has been renamed "Supported Groups" to be inclusive of non-EC algorithms. Reference: [IANA TLS parameters](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-8). 
 
 > [!NOTE]
 > NEW post-quantum ML-KEM groups are now available in the latest Windows Insider Preview builds for Windows 11 client and Windows Server 2025. These groups are disabled by default, and must be enabled using one of the configuration methods linked at the end of this article. The minimum supported builds are [26100.8514](https://learn.microsoft.com/en-us/windows-insider/release-notes/release-preview-24h2-25h2/build-26100-8514-26200-8514) for Windows 11 24H2 and 25H2, [28000.2173](https://learn.microsoft.com/en-us/windows-insider/release-notes/release-preview-26h1/build-28000-2173) for Windows 11 26H2, and [29550](https://techcommunity.microsoft.com/discussions/windowsserverinsiders/announcing-windows-server-vnext-preview-build-29550/4501665) for Windows Server 2025.
@@ -22,7 +22,7 @@ For Windows 11, versions 24H2 and later, the following groups are enabled and in
 | nistP384 | Yes |
 
 
-The following groups are supported by the Microsoft Schannel Provider, but not enabled by default:
+The following groups are supported by the Microsoft Schannel Provider, but are not enabled by default:
 
 | Elliptic curve string | Available in FIPS mode |
 |-------------|--------------|

--- a/desktop-src/SecAuthN/toc.yml
+++ b/desktop-src/SecAuthN/toc.yml
@@ -280,8 +280,10 @@
               href: tls-cipher-suites-in-windows-7.md
             - name: "TLS Cipher Suites in Windows Vista"
               href: schannel-cipher-suites-in-windows-vista.md
-          - name: "Elliptic Curves in TLS (Schannel SSP)"
+          - name: "Supported Groups and Elliptic Curves in TLS (Schannel SSP)"
             items:
+            - name: "TLS Supported Groups in Windows 11, versions 24H2 and later"
+              href: tls-supported-groups-in-windows-11-24h2-and-later.md
             - name: "TLS Elliptic Curves in Windows 10, versions 1607 and later"
               href: tls-elliptic-curves-in-windows-10-1607-and-later.md
             - name: "TLS Elliptic Curves in Windows 10, versions 1507 and 1511"


### PR DESCRIPTION
These updates are currently available in Windows 11 and Server 2025 preview builds. We have a blog post going out with Build that will need to reference this, and customers who want to enable PQC with TLS will need this for guidance.