### PR TITLE
Fix 'ms.product' to 'ms.prod' in DLL documentation

### DIFF
--- a/desktop-src/Dlls/unknown/nf-unknown-dllgetdocumentation.md
+++ b/desktop-src/Dlls/unknown/nf-unknown-dllgetdocumentation.md
@@ -23,7 +23,7 @@ api_location:
 api_name:
  - DLLGetDocumentation
 targetos: Windows
-ms.product: Windows
+ms.prod: Windows
 req.product: Windows
 ---
 


### PR DESCRIPTION
Corrected the formatting of the 'ms.prod' field in the documentation.