### PR TITLE
Fix links from AcquireCredentialsHandle to EnumerateSecurityPackages

### DIFF
--- a/desktop-src/SecAuthN/acquirecredentialshandle--digest.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--digest.md
@@ -55,7 +55,7 @@ When using the Digest SSP, this parameter is optional.
 *pszPackage* \[in\]
 </dt> <dd>
 
-A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [**QueryContextAttributes (Digest)**](querycontextattributes--digest.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [**QueryContextAttributes (Digest)**](querycontextattributes--digest.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
 
 When using the Digest SSP, set this parameter to WDIGEST\_SP\_NAME.
 

--- a/desktop-src/SecAuthN/acquirecredentialshandle--general.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--general.md
@@ -74,7 +74,7 @@ When using the Schannel SSP, this parameter is not used and should be set to **N
 *pszPackage* \[in\]
 </dt> <dd>
 
-A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [**QueryContextAttributes (General)**](querycontextattributes--general.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [**QueryContextAttributes (General)**](querycontextattributes--general.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
 
 When using the Digest SSP, set this parameter to WDIGEST\_SP\_NAME.
 

--- a/desktop-src/SecAuthN/acquirecredentialshandle--kerberos.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--kerberos.md
@@ -53,7 +53,7 @@ A pointer to a null-terminated string that specifies the name of the principal w
 *pszPackage* \[in\]
 </dt> <dd>
 
-A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [**QueryContextAttributes (Kerberos)**](querycontextattributes--kerberos.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [**QueryContextAttributes (Kerberos)**](querycontextattributes--kerberos.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
 
 </dd> <dt>
 

--- a/desktop-src/SecAuthN/acquirecredentialshandle--negotiate.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--negotiate.md
@@ -53,7 +53,7 @@ A pointer to a null-terminated string that specifies the name of the principal w
 *pszPackage* \[in\]
 </dt> <dd>
 
-A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [**QueryContextAttributes (Negotiate)**](querycontextattributes--negotiate.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [**QueryContextAttributes (Negotiate)**](querycontextattributes--negotiate.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
 
 To successfully call this function using the Negotiate SSP, set this parameter to "Negotiate".
 

--- a/desktop-src/SecAuthN/acquirecredentialshandle--ntlm.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--ntlm.md
@@ -53,7 +53,7 @@ A pointer to a null-terminated string that specifies the name of the principal w
 *pszPackage* \[in\]
 </dt> <dd>
 
-A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [**QueryContextAttributes (NTLM)**](querycontextattributes--ntlm.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [*security package*](../secgloss/s-gly.md) with which these credentials will be used. This is a [*security package*](../secgloss/s-gly.md) name returned in the **Name** member of a [**SecPkgInfo**](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [**EnumerateSecurityPackages**](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [**QueryContextAttributes (NTLM)**](querycontextattributes--ntlm.md) can be called with *ulAttribute* set to SECPKG\_ATTR\_PACKAGE\_INFO to return information on the [*security package*](../secgloss/s-gly.md) in use.
 
 </dd> <dt>
 

--- a/desktop-src/SecAuthN/acquirecredentialshandle--schannel.md
+++ b/desktop-src/SecAuthN/acquirecredentialshandle--schannel.md
@@ -42,7 +42,7 @@ When using the Schannel SSP, this parameter is not used and should be set to `NU
 
 *pszPackage* `[in]`
 
-A pointer to a null-terminated string that specifies the name of the [security package](../secgloss/s-gly.md) with which these credentials will be used. This is a [security package](../secgloss/s-gly.md) name returned in the **Name** member of a [SecPkgInfo](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [EnumerateSecurityPackages](/windows/win32/api/sspi/ns-sspi-secpkginfoa) function. After a context is established, [QueryContextAttributes (Schannel)](querycontextattributes--schannel.md) can be called with *ulAttribute* set to **SECPKG\_ATTR\_PACKAGE\_INFO** to return information on the [security package](../secgloss/s-gly.md) in use.
+A pointer to a null-terminated string that specifies the name of the [security package](../secgloss/s-gly.md) with which these credentials will be used. This is a [security package](../secgloss/s-gly.md) name returned in the **Name** member of a [SecPkgInfo](/windows/win32/api/sspi/ns-sspi-secpkginfoa) structure returned by the [EnumerateSecurityPackages](/windows/win32/api/sspi/nf-sspi-enumeratesecuritypackagesa) function. After a context is established, [QueryContextAttributes (Schannel)](querycontextattributes--schannel.md) can be called with *ulAttribute* set to **SECPKG\_ATTR\_PACKAGE\_INFO** to return information on the [security package](../secgloss/s-gly.md) in use.
 
 When using the Schannel SSP, set this parameter to `UNISP_NAME`.
 


### PR DESCRIPTION
Fixes incorrectly pointing links from various AcquireCredentialsHandle docs to EnumerateSecurityPackages.

They were pointing to SecPkgInfo.