### PR TITLE
Fix using-resources.md example code

### DIFF
--- a/desktop-src/menurc/using-resources.md
+++ b/desktop-src/menurc/using-resources.md
@@ -193,11 +193,11 @@ if (FAILED(hResult))
     return;
 }
 
-WriteFile(g_hFile,       // file to hold resource info
-    szBuffer,            // what to write to the file
-    (DWORD) cbString,    // number of bytes in szBuffer
-    &cbWritten,          // number of bytes written
-    NULL);               // no overlapped I/O
+WriteFile(g_hFile,                       // file to hold resource info
+    szBuffer,                            // what to write to the file
+    (DWORD) (cbString * sizeof(TCHAR)),  // number of bytes in szBuffer
+    &cbWritten,                          // number of bytes written
+    NULL);                               // no overlapped I/O
 
 EnumResourceTypes(hExe,              // module handle
     (ENUMRESTYPEPROC)EnumTypesFunc,  // callback function
@@ -257,7 +257,7 @@ BOOL EnumTypesFunc(
         return FALSE;
     }
 
-    WriteFile(g_hFile, szBuffer, (DWORD) cbString, &cbWritten, NULL);
+    WriteFile(g_hFile, szBuffer, (DWORD) (cbString * sizeof(TCHAR)), &cbWritten, NULL);
     // Find the names of all resources of type lpType.
     EnumResourceNames(hModule,
         lpType,
@@ -311,7 +311,7 @@ BOOL EnumNamesFunc(
         return FALSE;
     }
    
-    WriteFile(g_hFile, szBuffer, (DWORD) cbString, &cbWritten, NULL);
+    WriteFile(g_hFile, szBuffer, (DWORD) (cbString * sizeof(TCHAR)), &cbWritten, NULL);
     // Find the languages of all resources of type
     // lpType and name lpName.
     EnumResourceLanguages(hModule,
@@ -356,7 +356,7 @@ BOOL EnumLangsFunc(
         return FALSE;
     }
 
-    WriteFile(g_hFile, szBuffer, (DWORD) cbString, &cbWritten, NULL); 
+    WriteFile(g_hFile, szBuffer, (DWORD) (cbString * sizeof(TCHAR)), &cbWritten, NULL); 
     // Write the resource handle and size to buffer.
     hResult = StringCchPrintf(szBuffer,
         sizeof(szBuffer)/sizeof(TCHAR),
@@ -376,7 +376,7 @@ BOOL EnumLangsFunc(
         return FALSE;
     }
 
-    WriteFile(g_hFile, szBuffer, (DWORD)cbString, &cbWritten, NULL);
+    WriteFile(g_hFile, szBuffer, (DWORD)(cbString * sizeof(TCHAR)), &cbWritten, NULL);
     return TRUE;
 }
 ```


### PR DESCRIPTION
The example code in the section "Creating a Resource List" does not work for unicode builds, since it sends the string size in characters instead of bytes to the WriteFile function, writing incomplete strings and corrupting the output UTF-16 text file