### PR TITLE
Update RootSDDL default configuration for WinRM

### DIFF
--- a/desktop-src/WinRM/installation-and-configuration-for-windows-remote-management.md
+++ b/desktop-src/WinRM/installation-and-configuration-for-windows-remote-management.md
@@ -235,7 +235,7 @@ The service version of WinRM has the following default configuration settings.
 
 ### RootSDDL
 
-Specifies the security descriptor that controls remote access to the listener. The default is `O:NSG:BAD:P(A;;GA;;;BA)(A;;GR;;;ER)S:P(AU;FA;GA;;;WD)(AU;SA;GWGX;;;WD)`.
+Specifies the security descriptor that controls remote access to the listener. The default is `O:NSG:BAD:P(A;;GA;;;BA)(A;;GR;;;IU)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)`.
 
 ### MaxConcurrentOperations
 


### PR DESCRIPTION
The default listener RootSDDL is either super old or just wrong. Since 2012R2 it is this other one:  O:NSG:BAD:P(A;;GA;;;BA)(A;;GR;;;IU)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)