### PR TITLE
Document DPI scaling improvements in Windows 11

### DIFF
--- a/desktop-src/hidpi/high-dpi-desktop-application-development-on-windows.md
+++ b/desktop-src/hidpi/high-dpi-desktop-application-development-on-windows.md
@@ -242,6 +242,8 @@ When you update your desktop application to DPI scale properly, it can be diffic
 
 Many legacy Windows APIs do not include a DPI or HWND context as part of their interface. As a result, developers often have to do additional work to handle the scaling of any DPI-sensitive information, such as sizes, points, or icons. As an example, developers using [LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadiconw) must either bitmap stretch loaded icons or use alternate APIs to load correctly-sized icons for the appropriate DPI, such as [LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagew).
 
+Starting with Windows 11 (Build 22000), applications that create cursors from in-memory data can use [SetThreadCursorCreationScaling](windows/win32/api/winuser/nf-winuser-setthreadcursorcreationscaling) to enable automatic per-monitor DPI scaling, similar to cursors loaded from module resources.
+
 **Forced reset of process-wide DPI awareness**
 
 In general, the DPI awareness mode of your process cannot be changed after process initialization. Windows can, however, forcibly change the DPI awareness mode of your process if you attempt to break the requirement that all HWNDs in a window tree have the same DPI awareness mode. On all versions of Windows, as of Windows 10 1703, it is not possible to have different HWNDs in an HWND tree run in different DPI awareness modes. If you attempt to create a child-parent relationship that breaks this rule, the DPI awareness of the entire process can be reset. This can be triggered by:

--- a/desktop-src/hidpi/high-dpi-desktop-application-development-on-windows.md
+++ b/desktop-src/hidpi/high-dpi-desktop-application-development-on-windows.md
@@ -242,7 +242,7 @@ When you update your desktop application to DPI scale properly, it can be diffic
 
 Many legacy Windows APIs do not include a DPI or HWND context as part of their interface. As a result, developers often have to do additional work to handle the scaling of any DPI-sensitive information, such as sizes, points, or icons. As an example, developers using [LoadIcon](/windows/desktop/api/winuser/nf-winuser-loadiconw) must either bitmap stretch loaded icons or use alternate APIs to load correctly-sized icons for the appropriate DPI, such as [LoadImage](/windows/desktop/api/winuser/nf-winuser-loadimagew).
 
-Starting with Windows 11 (Build 22000), applications that create cursors from in-memory data can use [SetThreadCursorCreationScaling](windows/win32/api/winuser/nf-winuser-setthreadcursorcreationscaling) to enable automatic per-monitor DPI scaling, similar to cursors loaded from module resources.
+Starting with Windows 11 (Build 22000), applications that create cursors from in-memory data can use [SetThreadCursorCreationScaling](/windows/win32/api/winuser/nf-winuser-setthreadcursorcreationscaling) to enable automatic per-monitor DPI scaling, similar to cursors loaded from module resources.
 
 **Forced reset of process-wide DPI awareness**
 

--- a/desktop-src/hidpi/toc.yml
+++ b/desktop-src/hidpi/toc.yml
@@ -67,7 +67,7 @@
     - name: "GetWindowDpiHostingBehavior"
       href: /windows/desktop/api/winuser/nf-winuser-getwindowdpihostingbehavior
     - name: "SetThreadCursorCreationScaling"
-      href: /windows/desktop/api/winuser/nf-winuser-setthreadcursorcreationscaling
+      href: /windows/win32/api/winuser/nf-winuser-setthreadcursorcreationscaling
     - name: "DPI_AWARENESS"
       href: /windows/desktop/api/windef/ne-windef-dpi_awareness
     - name: "DPI_AWARENESS_CONTEXT"

--- a/desktop-src/hidpi/toc.yml
+++ b/desktop-src/hidpi/toc.yml
@@ -66,6 +66,8 @@
       href: /windows/desktop/api/winuser/nf-winuser-getthreaddpihostingbehavior
     - name: "GetWindowDpiHostingBehavior"
       href: /windows/desktop/api/winuser/nf-winuser-getwindowdpihostingbehavior
+    - name: "SetThreadCursorCreationScaling"
+      href: /windows/desktop/api/winuser/nf-winuser-setthreadcursorcreationscaling
     - name: "DPI_AWARENESS"
       href: /windows/desktop/api/windef/ne-windef-dpi_awareness
     - name: "DPI_AWARENESS_CONTEXT"


### PR DESCRIPTION
Added information about SetThreadCursorCreationScaling for automatic per-monitor DPI scaling in Windows 11.

See https://github.com/MicrosoftDocs/sdk-api/pull/2231