### PR TITLE
Modernize code examples in using-cursors.md and using-icons.md

### DIFF
--- a/desktop-src/menurc/using-cursors.md
+++ b/desktop-src/menurc/using-cursors.md
@@ -25,627 +25,486 @@ ms.date: 05/31/2018
 This section discusses the following topics.
 
 -   [Creating a Cursor](#creating-a-cursor)
+-   [Using Cursor Functions to Create a Mousetrap](#using-cursor-functions-to-create-a-mousetrap)
 -   [Creating an Alpha Blended Cursor](#creating-an-alpha-blended-cursor)
 -   [Getting a Cursor size](#getting-a-cursor-size)
 -   [Displaying a Cursor](#displaying-a-cursor)
 -   [Confining a Cursor](#confining-a-cursor)
--   [Using Cursor Functions to Create a Mousetrap](#using-cursor-functions-to-create-a-mousetrap)
 -   [Using the Keyboard to Move the Cursor](#using-the-keyboard-to-move-the-cursor)
 
 ## Creating a Cursor
 
 The following example creates two cursor handles: one for the standard hourglass cursor and one for a custom cursor included as a resource in the application's resource-definition file.
 
-
-```cpp
-HINSTANCE hinst;            // handle to current instance 
-HCURSOR hCurs1, hCurs2;     // cursor handles 
- 
-// Create a standard hourglass cursor. 
- 
-hCurs1 = LoadCursor(NULL, IDC_WAIT); 
- 
-// Create a custom cursor based on a resource. 
- 
-hCurs2 = LoadCursor(hinst, MAKEINTRESOURCE(240)); 
+```c
+HCURSOR hCurs1 = LoadCursor(NULL, IDC_WAIT);
+HCURSOR hCurs2 = LoadCursor(hInstance, MAKEINTRESOURCE(IDC_MYICON));
 ```
 
-Applications should implement custom cursors as resources and use [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora), [**LoadCursorFromFile**](/windows/desktop/api/Winuser/nf-winuser-loadcursorfromfilea), or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) rather than create the cursor at run time. Using cursor resources avoids device dependence, simplifies localization, and enables applications to share cursor designs.
+Applications should implement custom cursors as resources and use [**LoadCursor**](/windows/win32/api/winuser/nf-winuser-loadcursorw), [**LoadCursorFromFile**](/windows/win32/api/winuser/nf-winuser-loadcursorfromfilew), or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) rather than create the cursor at run time. Using cursor resources avoids device dependence, simplifies localization, and enables applications to share cursor designs.
 
-The following example uses the [**CreateCursor**](/windows/desktop/api/Winuser/nf-winuser-createcursor) function to create a custom monochrome cursor at run time. The example is included here to illustrate how the system interprets cursor masks.
+The following example uses the [**CreateCursor**](/windows/win32/api/winuser/nf-winuser-createcursor) function to create a custom monochrome cursor at run time. The example is included here to illustrate how the system interprets cursor masks.
 
-```cpp
-HINSTANCE hinst;            // handle to current instance  
-HCURSOR hCurs1, hCurs2;     // cursor handles 
- 
-HCURSOR hCurs3;             // cursor handle 
- 
-// Yin-shaped cursor AND mask (32x32x1bpp)
- BYTE ANDmaskCursor[] =
-{
-    0xFF, 0xFC, 0x3F, 0xFF,   // ##############----##############
-    0xFF, 0xC0, 0x1F, 0xFF,   // ##########---------#############
-    0xFF, 0x00, 0x3F, 0xFF,   // ########----------##############
-    0xFE, 0x00, 0xFF, 0xFF,   // #######---------################
-    0xF8, 0x01, 0xFF, 0xFF,   // #####----------#################
-    0xF0, 0x03, 0xFF, 0xFF,   // ####----------##################
-    0xF0, 0x03, 0xFF, 0xFF,   // ####----------##################
-    0xE0, 0x07, 0xFF, 0xFF,   // ###----------###################
-    0xC0, 0x07, 0xFF, 0xFF,   // ##-----------###################
-    0xC0, 0x0F, 0xFF, 0xFF,   // ##----------####################
-    0x80, 0x0F, 0xFF, 0xFF,   // #-----------####################
-    0x80, 0x0F, 0xFF, 0xFF,   // #-----------####################
-    0x80, 0x07, 0xFF, 0xFF,   // #------------###################
-    0x00, 0x07, 0xFF, 0xFF,   // -------------###################
-    0x00, 0x03, 0xFF, 0xFF,   // --------------##################
-    0x00, 0x00, 0xFF, 0xFF,   // ----------------################
-    0x00, 0x00, 0x7F, 0xFF,   // -----------------###############
-    0x00, 0x00, 0x1F, 0xFF,   // -------------------#############
-    0x00, 0x00, 0x0F, 0xFF,   // --------------------############
-    0x80, 0x00, 0x0F, 0xFF,   // #-------------------############
-    0x80, 0x00, 0x07, 0xFF,   // #--------------------###########
-    0x80, 0x00, 0x07, 0xFF,   // #--------------------###########
-    0xC0, 0x00, 0x07, 0xFF,   // ##-------------------###########
-    0xC0, 0x00, 0x0F, 0xFF,   // ##------------------############
-    0xE0, 0x00, 0x0F, 0xFF,   // ###-----------------############
-    0xF0, 0x00, 0x1F, 0xFF,   // ####---------------#############
-    0xF0, 0x00, 0x1F, 0xFF,   // ####---------------#############
-    0xF8, 0x00, 0x3F, 0xFF,   // #####-------------##############
-    0xFE, 0x00, 0x7F, 0xFF,   // #######----------###############
-    0xFF, 0x00, 0xFF, 0xFF,   // ########--------################
-    0xFF, 0xC3, 0xFF, 0xFF,   // ##########----##################
-    0xFF, 0xFF, 0xFF, 0xFF    // ################################
+Each pixel in the cursor map is represented by a single character:
+
+| Symbol | AND bit | XOR bit | Display         |
+|--------|---------|---------|-----------------|
+| ` `    | 1       | 0       | Transparent     |
+| `X`    | 1       | 1       | Invert screen   |
+| `o`    | 0       | 1       | White           |
+| `+`    | 0       | 0       | Black           |
+
+```c
+#define CURSOR_SIZE 32
+
+// Symbol encoding: ' '=transparent  'o'=white  '+'=black
+static const char *const yin_cursor[CURSOR_SIZE] = {
+    "              ++++              ",
+    "          ++++oooo+             ",
+    "        ++oooooo++              ",
+    "       +ooooooo+                ",
+    "     +oooooooo+                 ",
+    "    +oooooooo+                  ",
+    "    +oooooooo+                  ",
+    "   +oooooooo+                   ",
+    "  +ooooooooo+                   ",
+    "  +oooooooo+                    ",
+    " +ooooooooo+                    ",
+    " +ooooooooo+                    ",
+    " +oooooooooo+                   ",
+    "+ooooooooooo+                   ",
+    "+oooooooooooo+                  ",
+    "+ooooooooooooo++                ",
+    "+ooooooooooooooo+               ",
+    "+oooooooooooooooo++             ",
+    "+oooooooooooooooooo+            ",
+    " +ooooooooooooooooo+            ",
+    " +oooooooo+++ooooooo+           ",
+    " +ooooooo+++++oooooo+           ",
+    "  +oooooo+++++oooooo+           ",
+    "  +oooooo+++++ooooo+            ",
+    "   +oooooo+++oooooo+            ",
+    "    +ooooooooooooo+             ",
+    "    +ooooooooooooo+             ",
+    "     ++oooooooooo+              ",
+    "       +oooooooo+               ",
+    "        ++oooo++                ",
+    "          ++++                  ",
+    "                                ",
 };
- 
-// Yin-shaped cursor XOR mask (32x32x1bpp)
-BYTE XORmaskCursor[] =
+
+// Pack an XPM-style cursor map into separate 1bpp AND and XOR bit planes.
+// Output buffers must be sized: ((w + 15) / 16) * 2 * h bytes.
+static void PackCursorMasks(const char *const rows[], int w, int h,
+                             BYTE *pbAnd, BYTE *pbXor)
 {
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x03, 0xC0, 0x00,   // --------------####--------------
-    0x00, 0x3F, 0x00, 0x00,   // ----------######----------------
-    0x00, 0xFE, 0x00, 0x00,   // --------#######-----------------
-    0x03, 0xFC, 0x00, 0x00,   // ------########------------------
-    0x07, 0xF8, 0x00, 0x00,   // -----########-------------------
-    0x07, 0xF8, 0x00, 0x00,   // -----########-------------------
-    0x0F, 0xF0, 0x00, 0x00,   // ----########--------------------
-    0x1F, 0xF0, 0x00, 0x00,   // ---#########--------------------
-    0x1F, 0xE0, 0x00, 0x00,   // ---########---------------------
-    0x3F, 0xE0, 0x00, 0x00,   // --#########---------------------
-    0x3F, 0xE0, 0x00, 0x00,   // --#########---------------------
-    0x3F, 0xF0, 0x00, 0x00,   // --##########--------------------
-    0x7F, 0xF0, 0x00, 0x00,   // -###########--------------------
-    0x7F, 0xF8, 0x00, 0x00,   // -############-------------------
-    0x7F, 0xFC, 0x00, 0x00,   // -#############------------------
-    0x7F, 0xFF, 0x00, 0x00,   // -###############----------------
-    0x7F, 0xFF, 0x80, 0x00,   // -################---------------
-    0x7F, 0xFF, 0xE0, 0x00,   // -##################-------------
-    0x3F, 0xFF, 0xE0, 0x00,   // --#################-------------
-    0x3F, 0xC7, 0xF0, 0x00,   // --########----######------------
-    0x3F, 0x83, 0xF0, 0x00,   // --#######------#####------------
-    0x1F, 0x83, 0xF0, 0x00,   // ---######------#####------------
-    0x1F, 0x83, 0xE0, 0x00,   // ---######------####-------------
-    0x0F, 0xC7, 0xE0, 0x00,   // ----######----#####-------------
-    0x07, 0xFF, 0xC0, 0x00,   // -----#############--------------
-    0x07, 0xFF, 0xC0, 0x00,   // -----#############--------------
-    0x01, 0xFF, 0x80, 0x00,   // -------##########---------------
-    0x00, 0xFF, 0x00, 0x00,   // --------########----------------
-    0x00, 0x3C, 0x00, 0x00,   // ----------####------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00    // --------------------------------
-};
- 
-// Create a custom cursor at run time. 
- 
-hCurs3 = CreateCursor( hinst,   // app. instance 
-             19,                // horizontal position of hot spot 
-             2,                 // vertical position of hot spot 
-             32,                // cursor width 
-             32,                // cursor height 
-             ANDmaskCursor,     // AND mask 
-             XORmaskCursor );   // XOR mask 
+    int stride = ((w + 15) / 16) * 2;  // WORD-aligned row stride, per CreateCursor contract
+    ZeroMemory(pbAnd, stride * h);
+    ZeroMemory(pbXor, stride * h);
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            BYTE bit = (BYTE)(0x80 >> (x % 8));
+            int  idx = y * stride + x / 8;
+            char sym = rows[y][x];
+            if (sym == ' ' || sym == 'X') pbAnd[idx] |= bit;
+            if (sym == 'o' || sym == 'X') pbXor[idx] |= bit;
+        }
+    }
+}
+
+// Row stride for a 32-pixel-wide 1bpp mask: ((32 + 15) / 16) * 2 = 4 bytes.
+BYTE abAnd[CURSOR_SIZE * 4];
+BYTE abXor[CURSOR_SIZE * 4];
+PackCursorMasks(yin_cursor, CURSOR_SIZE, CURSOR_SIZE, abAnd, abXor);
+
+// hInstance is the application's HINSTANCE from WinMain.
+// Call DestroyCursor when the cursor is no longer needed.
+HCURSOR hCurs3 = CreateCursor(
+    hInstance,  // application instance
+    19,         // hot spot x
+    2,          // hot spot y
+    CURSOR_SIZE,
+    CURSOR_SIZE,
+    abAnd,
+    abXor);
 ```
 
-To create the cursor, [**CreateCursor**](/windows/desktop/api/Winuser/nf-winuser-createcursor) applies the following truth table to the **AND** and **XOR** masks.
+For more information, see [Bitmaps](/windows/win32/gdi/bitmaps).
 
-| AND mask | XOR mask | Display        |
-|----------|----------|----------------|
-| 0        | 0        | Black          |
-| 0        | 1        | White          |
-| 1        | 0        | Screen         |
-| 1        | 1        | Reverse screen |
+## Using Cursor Functions to Create a Mousetrap
 
-For more information, see [Bitmaps](/windows/desktop/gdi/bitmaps).
+The following example uses the [**SetCursorPos**](/windows/win32/api/winuser/nf-winuser-setcursorpos), [**GetCursorPos**](/windows/win32/api/winuser/nf-winuser-getcursorpos), [**CreateCursor**](/windows/win32/api/winuser/nf-winuser-createcursor), [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), [**SetCursor**](/windows/win32/api/winuser/nf-winuser-setcursor), and [**DrawIconEx**](/windows/win32/api/winuser/nf-winuser-drawiconex) functions to create a simple mousetrap. A yang-shaped icon is drawn in the center of the window. If the cursor has not moved for 3 seconds, it snaps to the yang icon and changes to the yin shape. Moving the mouse resets the trap.
+
+```c
+// PackCursorMasks, yin_cursor, and CURSOR_SIZE are defined in the preceding example.
+
+#define ICON_SIZE     32
+#define YIN_HOT_X     19
+#define YIN_HOT_Y      2
+#define IDT_CURSOR     1
+#define TRAP_DELAY  3000    // ms of inactivity before the cursor snaps to the icon
+
+// Symbol encoding: ' '=transparent  'o'=white  '+'=black
+static const char *const yang_icon[ICON_SIZE] = {
+    "                                ",
+    "                  ++++          ",
+    "                ++++++++        ",
+    "               ++++++++++       ",
+    "              +++++++++++++     ",
+    "             +++++++++++++++    ",
+    "             +++++++++++++++    ",
+    "            ++++++ooo++++++++   ",
+    "            +++++ooooo++++++++  ",
+    "           ++++++ooooo++++++++  ",
+    "           ++++++ooooo+++++++++ ",
+    "           +++++++ooo++++++++++ ",
+    "            +++++++++++++++++++ ",
+    "            ++++++++++++++++++++",
+    "             +++++++++++++++++++",
+    "              ++++++++++++++++++",
+    "                ++++++++++++++++",
+    "                 +++++++++++++++",
+    "                   +++++++++++++",
+    "                   ++++++++++++ ",
+    "                    +++++++++++ ",
+    "                    +++++++++++ ",
+    "                    ++++++++++  ",
+    "                   +++++++++++  ",
+    "                   ++++++++++   ",
+    "                  ++++++++++    ",
+    "                  ++++++++++    ",
+    "                 ++++++++++     ",
+    "                +++++++++       ",
+    "              ++++++++++        ",
+    "             +++++++++          ",
+    "              ++++              ",
+};
+
+static HICON   hYang;
+static HCURSOR hYin;
+static POINT   ptLast;
+static BOOL    bTrapped;
+
+LRESULT CALLBACK MainWndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_CREATE:
+        {
+            HINSTANCE hInstance = ((LPCREATESTRUCT)lParam)->hInstance;
+
+            BYTE abAndIcon[ICON_SIZE * 4];
+            BYTE abXorIcon[ICON_SIZE * 4];
+            PackCursorMasks(yang_icon, ICON_SIZE, ICON_SIZE, abAndIcon, abXorIcon);
+            hYang = CreateIcon(hInstance, ICON_SIZE, ICON_SIZE, 1, 1,
+                               abAndIcon, abXorIcon);
+
+            BYTE abAndCursor[CURSOR_SIZE * 4];
+            BYTE abXorCursor[CURSOR_SIZE * 4];
+            PackCursorMasks(yin_cursor, CURSOR_SIZE, CURSOR_SIZE, abAndCursor, abXorCursor);
+            hYin = CreateCursor(hInstance, YIN_HOT_X, YIN_HOT_Y, CURSOR_SIZE, CURSOR_SIZE,
+                                abAndCursor, abXorCursor);
+
+            GetCursorPos(&ptLast);
+            SetTimer(hWnd, IDT_CURSOR, TRAP_DELAY, (TIMERPROC)NULL);
+            return 0;
+        }
+
+        case WM_PAINT:
+        {
+            PAINTSTRUCT ps;
+            HDC hDC = BeginPaint(hWnd, &ps);
+            RECT rc;
+            GetClientRect(hWnd, &rc);
+            DrawIconEx(hDC,
+                       (rc.right  - ICON_SIZE) / 2,
+                       (rc.bottom - ICON_SIZE) / 2,
+                       hYang, ICON_SIZE, ICON_SIZE, 0, NULL, DI_NORMAL);
+            EndPaint(hWnd, &ps);
+            return 0;
+        }
+
+        case WM_MOUSEMOVE:
+            GetCursorPos(&ptLast);
+            bTrapped = FALSE;
+            SetTimer(hWnd, IDT_CURSOR, TRAP_DELAY, (TIMERPROC)NULL);
+            break;
+
+        case WM_TIMER:
+        {
+            POINT ptNow;
+            GetCursorPos(&ptNow);
+            if (ptNow.x == ptLast.x && ptNow.y == ptLast.y)
+            {
+                RECT rc;
+                GetClientRect(hWnd, &rc);
+                POINT ptTarget = {
+                    (rc.right  - ICON_SIZE) / 2 + YIN_HOT_X,
+                    (rc.bottom - ICON_SIZE) / 2 + YIN_HOT_Y
+                };
+                ClientToScreen(hWnd, &ptTarget);
+                SetCursorPos(ptTarget.x, ptTarget.y);
+                SetCursor(hYin);
+                bTrapped = TRUE;
+            }
+            KillTimer(hWnd, IDT_CURSOR);
+            return 0;
+        }
+
+        case WM_SETCURSOR:
+            if (bTrapped)
+            {
+                SetCursor(hYin);
+                return TRUE;
+            }
+            break;
+
+        case WM_DESTROY:
+            KillTimer(hWnd, IDT_CURSOR);
+            DestroyCursor(hYin);
+            DestroyIcon(hYang);
+            PostQuitMessage(0);
+            return 0;
+    }
+
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+}
+```
 
 ## Creating an Alpha Blended Cursor
 
 Follow these steps to create an alpha blended cursor or icon at run time:
-- Complete a [**BITMAPV5HEADER**](/windows/win32/api/wingdi/ns-wingdi-bitmapv5header) structure, as in the code example following these steps, to define a 32 bits per pixel (BPP) alpha blended DIB.
-- Call the [**CreateDIBSection**](/windows/win32/api/wingdi/nf-wingdi-createdibsection) function to create a DIB section based on the [**BITMAPV5HEADER**](/windows/win32/api/wingdi/ns-wingdi-bitmapv5header) structure that you completed.
-- Use the bitmap and alpha information that you want for your alpha blended cursor or icon to complete the DIB section.
-- Complete an [**ICONINFO**](/windows/desktop/api/Winuser/ns-winuser-iconinfo) structure.
-- Place an empty monochrome bitmap in the **hbmMask** field, and then place the alpha blended DIB section in the **hbmColor** field.
-- Call the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function to create the alpha blended cursor or icon.
+- Fill a [**BITMAPINFOHEADER**](/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader) for a top-down DIB (`biBitCount=32`, `biCompression=BI_RGB`, `biHeight` negative) and call [**CreateDIBSection**](/windows/win32/api/wingdi/nf-wingdi-createdibsection) to get the color bitmap. Reuse the same header with `biBitCount=1` to create the 1bpp AND mask.
+- Draw the cursor image into the color DIB section and set the alpha byte of each pixel.
+- Fill the AND mask: set each bit to 0 (opaque) where `alpha > 0`, and to 1 (transparent) where `alpha == 0`.
+- Fill an [**ICONINFO**](/windows/win32/api/winuser/ns-winuser-iconinfo) structure with the DIB section as `hbmColor` and the AND mask as `hbmMask`.
+- Call [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect) to create the cursor or icon.
 
-The following code demonstrates how to create an alpha blended cursor. You can use the same code to create an alpha blended icon by changing the **fIcon** member of the [**ICONINFO**](/windows/desktop/api/Winuser/ns-winuser-iconinfo) structure to **TRUE**:
+The following code demonstrates how to create an alpha blended cursor. `DrawRGBCircles` writes three overlapping R/G/B semi-transparent circles directly into a pixel buffer: it composites the circles analytically using the AC\_SRC\_OVER formula and un-premultiplies the result, so the output is ready-to-use straight alpha. The cursor size is read from [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) to match the system cursor size setting. Change `fIcon` to `TRUE` to create an icon instead.
 
-```cpp
+```c
+#define WIDTHBYTES(bits) ((DWORD)(((bits) + 31) & ~31) / 8)
+
+// Fill pixels (top-down, cx-cy) with three overlapping R/G/B circles, each alpha=128.
+// Composites with AC_SRC_OVER and writes straight alpha into rgbReserved.
+static void DrawRGBCircles(RGBQUAD *pixels, int cx, int cy)
+{
+    // r = cx/3: each center is r px from its nearest edge, so the circle touches exactly.
+    const int r = cx / 3;
+    struct { int x, y; RGBQUAD color; } circles[3] = {
+        //                  B    G    R    A
+        { cx / 2,  r,      {  0,   0, 255, 128 } },  // red,   top-center
+        { r,       cy - r, {  0, 255,   0, 128 } },  // green, bottom-left
+        { cx - r,  cy - r, {255,   0,   0, 128 } },  // blue,  bottom-right
+    };
+
+    for (int y = 0; y < cy; y++) {
+        for (int x = 0; x < cx; x++) {
+            DWORD R = 0, G = 0, B = 0, A = 0;
+            for (int i = 0; i < 3; i++) {
+                int dx = x - circles[i].x, dy = y - circles[i].y;
+                if (dx*dx + dy*dy > r*r) continue;
+                DWORD a = circles[i].color.rgbReserved, inv = 255 - a;
+                // AC_SRC_OVER (premultiplied): dst = src + dst * (1 - src_a/255)
+                R = circles[i].color.rgbRed   * a / 255 + R * inv / 255;
+                G = circles[i].color.rgbGreen * a / 255 + G * inv / 255;
+                B = circles[i].color.rgbBlue  * a / 255 + B * inv / 255;
+                A = a                                    + A * inv / 255;
+            }
+            RGBQUAD *p = &pixels[y * cx + x];
+            p->rgbReserved = (BYTE)A;
+            if (A > 0) {
+                p->rgbRed   = (BYTE)(R * 255 / A);  // un-premultiply to straight alpha
+                p->rgbGreen = (BYTE)(G * 255 / A);
+                p->rgbBlue  = (BYTE)(B * 255 / A);
+            }
+        }
+    }
+}
+
 HCURSOR CreateAlphaCursor(void)
 {
-    HDC hMemDC;
-    DWORD dwWidth, dwHeight;
-    BITMAPV5HEADER bi;
-    HBITMAP hBitmap, hOldBitmap;
-    void *lpBits;
-    DWORD x,y;
-    HCURSOR hAlphaCursor = NULL;
+    int cx = GetSystemMetrics(SM_CXCURSOR);
+    int cy = GetSystemMetrics(SM_CYCURSOR);
 
-    dwWidth  = 32;  // width of cursor
-    dwHeight = 32;  // height of cursor
+    // Extra RGBQUAD at the end for the 1bpp colour table (index 1 = white).
+    BYTE bmiBuffer[sizeof(BITMAPINFO) + sizeof(RGBQUAD)] = {0};
+    BITMAPINFO *pBmi = (BITMAPINFO *)bmiBuffer;
+    pBmi->bmiHeader.biSize        = sizeof(pBmi->bmiHeader);
+    pBmi->bmiHeader.biWidth       = cx;
+    pBmi->bmiHeader.biHeight      = -cy;   // negative = top-down
+    pBmi->bmiHeader.biPlanes      = 1;
+    pBmi->bmiHeader.biCompression = BI_RGB;
 
-    ZeroMemory(&bi,sizeof(BITMAPV5HEADER));
-    bi.bV5Size           = sizeof(BITMAPV5HEADER);
-    bi.bV5Width           = dwWidth;
-    bi.bV5Height          = dwHeight;
-    bi.bV5Planes = 1;
-    bi.bV5BitCount = 32;
-    bi.bV5Compression = BI_BITFIELDS;
-    // The following mask specification specifies a supported 32 BPP
-    // alpha format for Windows XP.
-    bi.bV5RedMask   =  0x00FF0000;
-    bi.bV5GreenMask =  0x0000FF00;
-    bi.bV5BlueMask  =  0x000000FF;
-    bi.bV5AlphaMask =  0xFF000000; 
+    // Create a top-down 32bpp DIB section for the color (XOR) image.
+    pBmi->bmiHeader.biBitCount = 32;
+    RGBQUAD *lpBits;
+    HBITMAP hBitmap = CreateDIBSection(NULL, pBmi, DIB_RGB_COLORS, (void **)&lpBits, NULL, 0);
 
-    HDC hdc;
-    hdc = GetDC(NULL);
+    DrawRGBCircles(lpBits, cx, cy);
 
-    // Create the DIB section with an alpha channel.
-    hBitmap = CreateDIBSection(hdc, (BITMAPINFO *)&bi, DIB_RGB_COLORS, 
-        (void **)&lpBits, NULL, (DWORD)0);
+    // Reuse the same header for the 1bpp AND mask; switch biBitCount and set the colour table.
+    pBmi->bmiHeader.biBitCount = 1;
+    pBmi->bmiColors[0].rgbRed = pBmi->bmiColors[0].rgbGreen = pBmi->bmiColors[0].rgbBlue = 0;
+    pBmi->bmiColors[1].rgbRed = pBmi->bmiColors[1].rgbGreen = pBmi->bmiColors[1].rgbBlue = 255;
+    BYTE *andBits;
+    HBITMAP hMaskBitmap = CreateDIBSection(NULL, pBmi, DIB_RGB_COLORS, (void **)&andBits, NULL, 0);
 
-    hMemDC = CreateCompatibleDC(hdc);
-    ReleaseDC(NULL,hdc);
+    // Set AND mask: bit=1 (transparent) wherever no circle was drawn.
+    int maskStride = WIDTHBYTES(cx * 1);
+    for (int y = 0; y < cy; y++) {
+        for (int x = 0; x < cx; x++) {
+            if (lpBits[y * cx + x].rgbReserved == 0)
+                andBits[y * maskStride + x / 8] |= (BYTE)(0x80 >> (x % 8));
+        }
+    }
 
-    // Draw something on the DIB section.
-    hOldBitmap = (HBITMAP)SelectObject(hMemDC, hBitmap);
-    PatBlt(hMemDC,0,0,dwWidth,dwHeight,WHITENESS);
-    SetTextColor(hMemDC,RGB(0,0,0));
-    SetBkMode(hMemDC,TRANSPARENT);
-    TextOut(hMemDC,0,9,"rgba",4);
-    SelectObject(hMemDC, hOldBitmap);
-    DeleteDC(hMemDC);
+    ICONINFO ii = {0};
+    ii.fIcon     = FALSE;
+    ii.xHotspot  = cx / 2;
+    ii.yHotspot  = cy / 2;
+    ii.hbmMask   = hMaskBitmap;
+    ii.hbmColor  = hBitmap;
 
-    // Create an empty mask bitmap.
-    HBITMAP hMonoBitmap = CreateBitmap(dwWidth,dwHeight,1,1,NULL);
+    HCURSOR hCursor = (HCURSOR)CreateIconIndirect(&ii);
 
-    // Set the alpha values for each pixel in the cursor so that
-    // the complete cursor is semi-transparent.
-    DWORD *lpdwPixel;
-    lpdwPixel = (DWORD *)lpBits;
-    for (x=0;x<dwWidth;x++)
-       for (y=0;y<dwHeight;y++)
-       {
-           // Clear the alpha bits
-           *lpdwPixel &= 0x00FFFFFF;
-           // Set the alpha bits to 0x9F (semi-transparent)
-           *lpdwPixel |= 0x9F000000;
-           lpdwPixel++;
-       }
+    DeleteObject(hBitmap);
+    DeleteObject(hMaskBitmap);
 
-    ICONINFO ii;
-    ii.fIcon = FALSE;  // Change fIcon to TRUE to create an alpha icon
-    ii.xHotspot = 0;
-    ii.yHotspot = 0;
-    ii.hbmMask = hMonoBitmap;
-    ii.hbmColor = hBitmap;
-
-    // Create the alpha cursor with the alpha DIB section.
-    hAlphaCursor = CreateIconIndirect(&ii);
-
-    DeleteObject(hBitmap);          
-    DeleteObject(hMonoBitmap); 
-
-    return hAlphaCursor;
+    return hCursor;
 }
+
 ```
 
-Before closing, you must use the [**DestroyCursor**](/windows/desktop/api/Winuser/nf-winuser-destroycursor) function to destroy any cursors you created with [**CreateCursor**](/windows/desktop/api/Winuser/nf-winuser-createcursor) or [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect). It is not necessary to destroy cursors created by other functions.
+Before closing, you must use the [**DestroyCursor**](/windows/win32/api/winuser/nf-winuser-destroycursor) function to destroy any cursors you created with [**CreateCursor**](/windows/win32/api/winuser/nf-winuser-createcursor) or [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect). It is not necessary to destroy cursors created by other functions.
 
 ## Getting a Cursor size
 
-See [Getting the Icon size](/windows/win32/menurc/using-icons#getting-the-icon-size).
+The following example retrieves the dimensions of a cursor or icon from its handle:
+
+```c
+BOOL GetCursorDimensions(_In_ HCURSOR hcur, _Out_ SIZE *psiz)
+{
+    ICONINFO ii;
+    BOOL fResult = GetIconInfo(hcur, &ii);
+    if (fResult) {
+        BITMAP bm;
+        fResult = GetObject(ii.hbmMask, sizeof(bm), &bm) == sizeof(bm);
+        if (fResult) {
+            psiz->cx = bm.bmWidth;
+            psiz->cy = ii.hbmColor ? bm.bmHeight : bm.bmHeight / 2;
+        }
+        DeleteObject(ii.hbmMask);
+        if (ii.hbmColor) DeleteObject(ii.hbmColor);
+    }
+    return fResult;
+}
+```
 
 ## Displaying a Cursor
 
 The system automatically displays the class cursor (the cursor associated with the window to which the cursor is pointing). You can assign a class cursor while registering a window class. The following example illustrates this by assigning a cursor handle to the **hCursor** member of the [**WNDCLASS**](/windows/win32/api/winuser/ns-winuser-wndclassa) structure identified by the *wc* parameter.
 
-```cpp
-WNDCLASS  wc; 
- 
-// Fill the window class structure with parameters that 
-// describe the main window. 
- 
-wc.style = NULL;                        // class style(s) 
-wc.lpfnWndProc = (WNDPROC) MainWndProc; // window procedure 
-wc.cbClsExtra = 0;           // no per-class extra data 
-wc.cbWndExtra = 0;           // no per-window extra data 
-wc.hInstance = hinst;        // application that owns the class 
-wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);     // class icon 
-wc.hCursor = LoadCursor(hinst, MAKEINTRESOURCE(230)); // class cursor 
-wc.hbrBackground = GetStockObject(WHITE_BRUSH); // class background 
-wc.lpszMenuName =  "GenericMenu";               // class menu 
-wc.lpszClassName = "GenericWClass"              // class name 
- 
-// Register the window class. 
- 
-return RegisterClass(&wc); 
+```c
+WNDCLASS wc = {0};
+wc.lpfnWndProc   = MainWndProc;
+wc.hInstance     = hInstance;
+wc.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
+wc.hCursor       = LoadCursor(hInstance, MAKEINTRESOURCE(IDC_MYICON));
+wc.hbrBackground = GetStockObject(WHITE_BRUSH);
+wc.lpszMenuName  = TEXT("GenericMenu");
+wc.lpszClassName = TEXT("GenericWClass");
+
+return RegisterClass(&wc);
 ```
 
-When the window class is registered, the cursor identified by 230 in the application's resource-definition file is the default cursor for all windows based on the class.
+When the window class is registered, the cursor identified by `IDC_MYICON` in the application's resource-definition file is the default cursor for all windows based on the class.
 
-Your application can change the design of the cursor by using the [**SetCursor**](/windows/desktop/api/Winuser/nf-winuser-setcursor) function and specifying a different cursor handle. However, when the cursor moves, the system redraws the class cursor at the new location. To prevent the class cursor from being redrawn, you must process the [**WM\_SETCURSOR**](wm-setcursor.md) message. Each time the cursor moves and mouse input is not captured, the system sends this message to the window in which the cursor is moving.
+Your application can change the design of the cursor by using the [**SetCursor**](/windows/win32/api/winuser/nf-winuser-setcursor) function and specifying a different cursor handle. However, when the cursor moves, the system redraws the class cursor at the new location. To prevent the class cursor from being redrawn, you must process the [**WM\_SETCURSOR**](wm-setcursor.md) message. Each time the cursor moves and mouse input is not captured, the system sends this message to the window in which the cursor is moving.
 
-You can specify different cursors for different conditions while processing [**WM\_SETCURSOR**](wm-setcursor.md). For example, the following example shows how to display the cursor whenever the cursor moves over the icon of a minimized application.
+You can specify different cursors for different conditions while processing [**WM\_SETCURSOR**](wm-setcursor.md). Check `LOWORD(lParam)` to distinguish the client area from non-client areas such as resize handles; pass non-client hits to [**DefWindowProc**](/windows/win32/api/winuser/nf-winuser-defwindowproc) so the system sets the appropriate system cursor there.
 
-```cpp
-case WM_SETCURSOR: 
- 
-    // If the window is minimized, draw the hCurs3 cursor. 
-    // If the window is not minimized, draw the default 
-    // cursor (class cursor). 
- 
-    if (IsIconic(hwnd)) 
-    { 
-        SetCursor(hCurs3); 
-        break; 
-    } 
+```c
+case WM_SETCURSOR:
+    if (LOWORD(lParam) == HTCLIENT)
+    {
+        SetCursor(hCurs3);
+        return TRUE;
+    }
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
 ```
 
-When the window is not minimized, the system displays the class cursor.
+Returning `TRUE` prevents **DefWindowProc** from resetting the cursor to the class cursor. Passing non-client hits to **DefWindowProc** preserves system resize and move cursors.
 
-You can replace a class cursor by using the [**SetClassLong**](/windows/desktop/api/winuser/nf-winuser-setclasslonga) function. This function changes the default window settings for all windows of a specified class. The following example replaces the existing class cursor with the `hCurs2` cursor.
+You can replace a class cursor by using the [**SetClassLongPtr**](/windows/win32/api/winuser/nf-winuser-setclasslongptrw) function. This function changes the default window settings for all windows of a specified class. The following example replaces the existing class cursor with the `hCurs2` cursor.
 
 
-```cpp
-// Change the cursor for window class represented by hwnd. 
- 
-SetClassLongPtr(hwnd,    // window handle 
-    GCLP_HCURSOR,        // change cursor 
-    (LONG_PTR) hCurs2);  // new cursor 
+```c
+SetClassLongPtr(hWnd, GCLP_HCURSOR, (LONG_PTR)hCurs2);
 ```
 
-For more information, see [Window Classes](/windows/desktop/winmsg/window-classes) and [Mouse Input](/windows/desktop/inputdev/mouse-input).
+For more information, see [Window Classes](/windows/win32/winmsg/window-classes) and [Mouse Input](/windows/win32/inputdev/mouse-input).
 
 ## Confining a Cursor
 
-The following example confines the cursor to the application's window and then restores the cursor to its previous window. The example uses the [**GetClipCursor**](/windows/desktop/api/Winuser/nf-winuser-getclipcursor) function to record the area in which the cursor can move and the [**ClipCursor**](/windows/desktop/api/Winuser/nf-winuser-clipcursor) function to confine and restore the cursor.
+The following example confines the cursor to the application's window and then restores the cursor to its previous window. The example uses the [**GetClipCursor**](/windows/win32/api/winuser/nf-winuser-getclipcursor) function to record the area in which the cursor can move and the [**ClipCursor**](/windows/win32/api/winuser/nf-winuser-clipcursor) function to confine and restore the cursor.
 
-```cpp
-RECT rcClip;           // new area for ClipCursor
-RECT rcOldClip;        // previous area for ClipCursor
- 
-// Record the area in which the cursor can move. 
- 
-GetClipCursor(&rcOldClip); 
- 
-// Get the dimensions of the application's window. 
- 
-GetWindowRect(hwnd, &rcClip); 
- 
-// Confine the cursor to the application's window. 
- 
-ClipCursor(&rcClip); 
- 
-   // 
-   // Process input from the confined cursor. 
-   // 
- 
-// Restore the cursor to its previous area. 
- 
-ClipCursor(&rcOldClip); 
+```c
+RECT rcOldClip;
+GetClipCursor(&rcOldClip);
+
+RECT rcClip;
+GetWindowRect(hWnd, &rcClip);
+ClipCursor(&rcClip);
+
+// ... process input from the confined cursor ...
+
+ClipCursor(&rcOldClip);
 ```
 
 Because there is only one cursor at a time available in the system, an application that confines the cursor must restore the cursor before relinquishing control to another window.
 
-## Using Cursor Functions to Create a Mousetrap
-
-The following example uses the [**SetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-setcursorpos), [**GetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-getcursorpos), [**CreateCursor**](/windows/desktop/api/Winuser/nf-winuser-createcursor), [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora), and [**SetCursor**](/windows/desktop/api/Winuser/nf-winuser-setcursor) functions to create a simple mousetrap. It also uses cursor and timer functions to monitor the cursor's position every 10 seconds. If the cursor position has not changed in the last 10 seconds and the application's main window is minimized, the application changes the cursor and moves it to the mousetrap icon.
-
-An example for a similar mousetrap is included in [Icons](icons.md). It uses the [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora) and [**LoadIcon**](/windows/desktop/api/Winuser/nf-winuser-loadicona) functions instead of the more device-dependent [**CreateCursor**](/windows/desktop/api/Winuser/nf-winuser-createcursor) and [**CreateIcon**](/windows/desktop/api/Winuser/nf-winuser-createicon) functions.
-
-
-```cpp
-HICON hIcon1;               // icon handles 
-POINT ptOld;                // previous cursor location 
-HCURSOR hCurs1;             // cursor handle 
- 
- 
-// The following cursor masks are defined in a code 
-// example that appears earlier in this section. 
- 
-// Yin-shaped cursor AND and XOR masks 
- 
-BYTE ANDmaskCursor[] = ... 
-BYTE XORmaskCursor[] = ... 
- 
-// Yang-shaped icon AND mask (32x32x1bpp)
-BYTE ANDmaskIcon[] =
-{
-    0xFF, 0xFF, 0xFF, 0xFF,   // ################################
-    0xFF, 0xFF, 0xC3, 0xFF,   // ##################----##########
-    0xFF, 0xFF, 0x00, 0xFF,   // ################--------########
-    0xFF, 0xFE, 0x00, 0x7F,   // ###############----------#######
-    0xFF, 0xFC, 0x00, 0x1F,   // ##############-------------#####
-    0xFF, 0xF8, 0x00, 0x0F,   // #############---------------####
-    0xFF, 0xF8, 0x00, 0x0F,   // #############---------------####
-    0xFF, 0xF0, 0x00, 0x07,   // ############-----------------###
-    0xFF, 0xF0, 0x00, 0x03,   // ############------------------##
-    0xFF, 0xE0, 0x00, 0x03,   // ###########-------------------##
-    0xFF, 0xE0, 0x00, 0x01,   // ###########--------------------#
-    0xFF, 0xE0, 0x00, 0x01,   // ###########--------------------#
-    0xFF, 0xF0, 0x00, 0x01,   // ############-------------------#
-    0xFF, 0xF0, 0x00, 0x00,   // ############--------------------
-    0xFF, 0xF8, 0x00, 0x00,   // #############-------------------
-    0xFF, 0xFC, 0x00, 0x00,   // ##############------------------
-    0xFF, 0xFF, 0x00, 0x00,   // ################----------------
-    0xFF, 0xFF, 0x80, 0x00,   // #################---------------
-    0xFF, 0xFF, 0xE0, 0x00,   // ###################-------------
-    0xFF, 0xFF, 0xE0, 0x01,   // ###################------------#
-    0xFF, 0xFF, 0xF0, 0x01,   // ####################-----------#
-    0xFF, 0xFF, 0xF0, 0x01,   // ####################-----------#
-    0xFF, 0xFF, 0xF0, 0x03,   // ####################----------##
-    0xFF, 0xFF, 0xE0, 0x03,   // ###################-----------##
-    0xFF, 0xFF, 0xE0, 0x07,   // ###################----------###
-    0xFF, 0xFF, 0xC0, 0x0F,   // ##################----------####
-    0xFF, 0xFF, 0xC0, 0x0F,   // ##################----------####
-    0xFF, 0xFF, 0x80, 0x1F,   // #################----------#####
-    0xFF, 0xFF, 0x00, 0x7F,   // ################---------#######
-    0xFF, 0xFC, 0x00, 0xFF,   // ##############----------########
-    0xFF, 0xF8, 0x03, 0xFF,   // #############---------##########
-    0xFF, 0xFC, 0x3F, 0xFF    // ##############----##############
-};
- 
-// Yang-shaped icon XOR mask (32x32x1bpp)
-BYTE XORmaskIcon[] =
-{
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x38, 0x00,   // ------------------###-----------
-    0x00, 0x00, 0x7C, 0x00,   // -----------------#####----------
-    0x00, 0x00, 0x7C, 0x00,   // -----------------#####----------
-    0x00, 0x00, 0x7C, 0x00,   // -----------------#####----------
-    0x00, 0x00, 0x38, 0x00,   // ------------------###-----------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00,   // --------------------------------
-    0x00, 0x00, 0x00, 0x00    // --------------------------------
-};
-
-hIcon1 = CreateIcon(hinst, // handle to app. instance 
-             32,           // icon width 
-             32,           // icon height 
-             1,            // number of XOR planes 
-             1,            // number of bits per pixel 
-             ANDmaskIcon,  // AND mask 
-             XORmaskIcon); // XOR mask 
- 
-hCurs1 = CreateCursor(hinst, // handle to app. instance
-             19,             // horizontal position of hot spot 
-             2,              // vertical position of hot spot 
-             32,             // cursor width 
-             32,             // cursor height 
-             ANDmaskCursor,  // AND mask 
-             XORmaskCursor); // XOR mask 
- 
-// Fill in the window class structure. 
- 
-WNDCLASS  wc; 
- 
-wc.hIcon = hIcon1;                        // class icon 
-wc.hCursor = LoadCursor(NULL, IDC_ARROW); // class cursor 
- 
-//
-// Register the window class and perform 
-// other application initialization. 
-//
- 
-// Set a timer for the mousetrap. 
- 
-GetCursorPos(&ptOld); 
- 
-SetTimer(hwnd, IDT_CURSOR, 10000, (TIMERPROC) NULL); 
- 
-LONG APIENTRY MainWndProc( 
-    HWND hwnd,          // window handle 
-    UINT message,       // type of message 
-    UINT wParam,        // additional information 
-    LONG lParam)        // additional information 
-{ 
- 
-    HDC hdc;            // handle to device context 
-    POINT pt;           // current cursor location 
-    RECT rc;            // minimized window location 
- 
-    switch (message) 
-    { 
-        //
-        // Process other messages. 
-        // 
-        case WM_TIMER: 
-        // If the window is minimized, compare the 
-        // current cursor position with the one 10 
-        // seconds before. If the cursor position has 
-        // not changed, move the cursor to the icon. 
- 
-            if (IsIconic(hwnd)) 
-            { 
-                GetCursorPos(&pt); 
- 
-                if ((pt.x == ptOld.x) && (pt.y == ptOld.y)) 
-                { 
-                    GetWindowRect(hwnd, &rc); 
-                    SetCursorPos(rc.left + 20, rc.top + 4); 
- 
-                    // Note that the additional constants 
-                    // (20 and 4) are application-specific 
-                    // values to align the yin-shaped cursor 
-                    // and the yang-shaped icon. 
- 
-                } 
-                else 
-                { 
-                    ptOld.x = pt.x; 
-                    ptOld.y = pt.y; 
-                } 
-            } 
- 
-            return 0; 
- 
-        case WM_SETCURSOR: 
-        // If the window is minimized, draw hCurs1. 
-        // If the window is not minimized, draw the 
-        // default cursor (class cursor). 
- 
-            if (IsIconic(hwnd)) 
-            { 
-                SetCursor(hCurs1); 
-                break; 
-            } 
- 
-        case WM_DESTROY: 
-        // Destroy timer. 
- 
-            KillTimer(hwnd, IDT_CURSOR); 
- 
-            PostQuitMessage(0); 
-            break; 
-    } 
-} 
-```
-
 ## Using the Keyboard to Move the Cursor
 
-Because the system does not require a mouse, an application should be able to simulate mouse actions with the keyboard. The following example shows how to achieve this by using the [**GetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-getcursorpos) and [**SetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-setcursorpos) functions and by processing input from the arrow keys.
+Because the system does not require a mouse, an application should be able to simulate mouse actions with the keyboard. The following example shows how to achieve this by using the [**GetCursorPos**](/windows/win32/api/winuser/nf-winuser-getcursorpos) and [**SetCursorPos**](/windows/win32/api/winuser/nf-winuser-setcursorpos) functions and by processing input from the arrow keys.
 
+```c
+static int nRepeat = 1;
 
-```cpp
-HCURSOR hCurs1, hCurs2;    // cursor handles 
- 
-POINT pt;                  // cursor location  
-RECT rc;                   // client area coordinates 
-static int repeat = 1;     // repeat key counter 
- 
-// 
-// Other declarations and initialization. 
-// 
- 
-switch (message) 
-{ 
-// 
-// Process other messages. 
-// 
- 
-    case WM_KEYDOWN: 
- 
-        if (wParam != VK_LEFT && wParam != VK_RIGHT && 
-        wParam != VK_UP && wParam != VK_DOWN) 
-        { 
-            break; 
-        } 
- 
-        GetCursorPos(&pt); 
- 
-        // Convert screen coordinates to client coordinates. 
- 
-        ScreenToClient(hwnd, &pt); 
- 
-        switch (wParam) 
-        { 
-        // Move the cursor to reflect which 
-        // arrow keys are pressed. 
- 
-            case VK_LEFT:               // left arrow 
-                pt.x -= repeat; 
-                break; 
- 
-            case VK_RIGHT:              // right arrow 
-                pt.x += repeat; 
-                break; 
- 
-            case VK_UP:                 // up arrow 
-                pt.y -= repeat; 
-                break; 
- 
-            case VK_DOWN:               // down arrow 
-                pt.y += repeat; 
-                break; 
- 
-            default: 
-                return 0; 
-        } 
- 
-        repeat++;           // Increment repeat count. 
- 
-        // Keep the cursor in the client area. 
- 
-        GetClientRect(hwnd, &rc); 
- 
-        if (pt.x >= rc.right) 
-        { 
-            pt.x = rc.right - 1; 
-        } 
-        else 
-        { 
-            if (pt.x < rc.left) 
-            { 
-                pt.x = rc.left; 
-            } 
-        } 
- 
-        if (pt.y >= rc.bottom) 
-            pt.y = rc.bottom - 1; 
-        else 
-            if (pt.y < rc.top) 
-                pt.y = rc.top; 
- 
-        // Convert client coordinates to screen coordinates. 
- 
-        ClientToScreen(hwnd, &pt); 
-        SetCursorPos(pt.x, pt.y); 
-        return 0; 
+switch (uMsg)
+{
+    case WM_KEYDOWN:
+    {
+        int dx = 0, dy = 0;
+        switch (wParam)
+        {
+            case VK_LEFT:  dx = -nRepeat; break;
+            case VK_RIGHT: dx = +nRepeat; break;
+            case VK_UP:    dy = -nRepeat; break;
+            case VK_DOWN:  dy = +nRepeat; break;
+            default: return DefWindowProc(hWnd, uMsg, wParam, lParam);
+        }
 
- 
-    case WM_KEYUP: 
- 
-        repeat = 1;            // Clear repeat count. 
-        return 0; 
- 
-} 
+        POINT pt;
+        GetCursorPos(&pt);
+        ScreenToClient(hWnd, &pt);
+        pt.x += dx;
+        pt.y += dy;
+
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+        if (pt.x < rc.left)         pt.x = rc.left;
+        else if (pt.x >= rc.right)  pt.x = rc.right - 1;
+        if (pt.y < rc.top)          pt.y = rc.top;
+        else if (pt.y >= rc.bottom) pt.y = rc.bottom - 1;
+
+        ClientToScreen(hWnd, &pt);
+        SetCursorPos(pt.x, pt.y);
+        if (nRepeat < 32) nRepeat++;
+        return 0;
+    }
+    case WM_KEYUP:
+        nRepeat = 1;
+        return 0;
+}
 ```
-
-
-
- 
-
- 

--- a/desktop-src/menurc/using-icons.md
+++ b/desktop-src/menurc/using-icons.md
@@ -19,257 +19,80 @@ ms.date: 05/31/2018
 The following topics describe how to perform certain tasks related to icons:
 
 -   [Creating an Icon](#creating-an-icon)
--   [Geting the Icon size](#getting-the-icon-size)
+-   [Getting the Icon size](#getting-the-icon-size)
 -   [Displaying an Icon](#displaying-an-icon)
 -   [Sharing Icon Resources](#sharing-icon-resources)
 
 ## Creating an Icon
 
-To use an icon, your application must get a handle to the icon. The following example shows how to create two different icon handles: one for the standard question icon and one for a custom icon included as a resource in the application's resource-definition file.
+The following example creates two icon handles: one for the standard question icon and one for a custom icon included as a resource in the application's resource-definition file.
 
-```cpp
-HICON hIcon1;   // icon handle 
-HICON hIcon2;   // icon handle 
- 
-// Create a standard question icon. 
- 
-hIcon1 = LoadIcon(NULL, IDI_QUESTION); 
- 
-// Create a custom icon based on a resource. 
- 
-hIcon2 = LoadIcon(hinst, MAKEINTRESOURCE(460)); 
- 
-// Create a custom icon at run time.
- 
+```c
+HICON hIcon1 = LoadIcon(NULL, IDI_QUESTION);
+HICON hIcon2 = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_MYICON));
 ```
 
-An application should implement custom icons as resources and should use the [**LoadIcon**](/windows/desktop/api/Winuser/nf-winuser-loadicona) or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) function, rather than create the icons at run-time. This approach avoids device dependence, simplifies localization, and enables applications to share icon bitmaps. However, the following example uses [**CreateIcon**](/windows/desktop/api/Winuser/nf-winuser-createicon) to create a custom monochrome icon at run-time, based on bitmap bitmasks; it is included to illustrate how the system interprets icon bitmap bitmasks.
+Applications should implement custom icons as resources and use [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) rather than create the icon at run time. Using icon resources avoids device dependence, simplifies localization, and enables applications to share icon designs.
 
-```cpp
-HICON hIcon3;      // icon handle 
- 
-// Yang icon AND bitmask 
- 
-BYTE ANDmaskIcon[] = {0xFF, 0xFF, 0xFF, 0xFF,   // line 1 
-                      0xFF, 0xFF, 0xC3, 0xFF,   // line 2 
-                      0xFF, 0xFF, 0x00, 0xFF,   // line 3 
-                      0xFF, 0xFE, 0x00, 0x7F,   // line 4 
- 
-                      0xFF, 0xFC, 0x00, 0x1F,   // line 5 
-                      0xFF, 0xF8, 0x00, 0x0F,   // line 6 
-                      0xFF, 0xF8, 0x00, 0x0F,   // line 7 
-                      0xFF, 0xF0, 0x00, 0x07,   // line 8 
- 
-                      0xFF, 0xF0, 0x00, 0x03,   // line 9 
-                      0xFF, 0xE0, 0x00, 0x03,   // line 10 
-                      0xFF, 0xE0, 0x00, 0x01,   // line 11 
-                      0xFF, 0xE0, 0x00, 0x01,   // line 12 
- 
-                      0xFF, 0xF0, 0x00, 0x01,   // line 13 
-                      0xFF, 0xF0, 0x00, 0x00,   // line 14 
-                      0xFF, 0xF8, 0x00, 0x00,   // line 15 
-                      0xFF, 0xFC, 0x00, 0x00,   // line 16 
- 
-                      0xFF, 0xFF, 0x00, 0x00,   // line 17 
-                      0xFF, 0xFF, 0x80, 0x00,   // line 18 
-                      0xFF, 0xFF, 0xE0, 0x00,   // line 19 
-                      0xFF, 0xFF, 0xE0, 0x01,   // line 20 
- 
-                      0xFF, 0xFF, 0xF0, 0x01,   // line 21 
-                      0xFF, 0xFF, 0xF0, 0x01,   // line 22 
-                      0xFF, 0xFF, 0xF0, 0x03,   // line 23 
-                      0xFF, 0xFF, 0xE0, 0x03,   // line 24 
- 
-                      0xFF, 0xFF, 0xE0, 0x07,   // line 25 
-                      0xFF, 0xFF, 0xC0, 0x0F,   // line 26 
-                      0xFF, 0xFF, 0xC0, 0x0F,   // line 27 
-                      0xFF, 0xFF, 0x80, 0x1F,   // line 28 
- 
-                      0xFF, 0xFF, 0x00, 0x7F,   // line 29 
-                      0xFF, 0xFC, 0x00, 0xFF,   // line 30 
-                      0xFF, 0xF8, 0x03, 0xFF,   // line 31 
-                      0xFF, 0xFC, 0x3F, 0xFF};  // line 32 
- 
-// Yang icon XOR bitmask 
- 
-BYTE XORmaskIcon[] = {0x00, 0x00, 0x00, 0x00,   // line 1 
-                      0x00, 0x00, 0x00, 0x00,   // line 2 
-                      0x00, 0x00, 0x00, 0x00,   // line 3 
-                      0x00, 0x00, 0x00, 0x00,   // line 4 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 5 
-                      0x00, 0x00, 0x00, 0x00,   // line 6 
-                      0x00, 0x00, 0x00, 0x00,   // line 7 
-                      0x00, 0x00, 0x38, 0x00,   // line 8 
- 
-                      0x00, 0x00, 0x7C, 0x00,   // line 9 
-                      0x00, 0x00, 0x7C, 0x00,   // line 10 
-                      0x00, 0x00, 0x7C, 0x00,   // line 11 
-                      0x00, 0x00, 0x38, 0x00,   // line 12 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 13 
-                      0x00, 0x00, 0x00, 0x00,   // line 14 
-                      0x00, 0x00, 0x00, 0x00,   // line 15 
-                      0x00, 0x00, 0x00, 0x00,   // line 16 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 17 
-                      0x00, 0x00, 0x00, 0x00,   // line 18 
-                      0x00, 0x00, 0x00, 0x00,   // line 19 
-                      0x00, 0x00, 0x00, 0x00,   // line 20 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 21 
-                      0x00, 0x00, 0x00, 0x00,   // line 22 
-                      0x00, 0x00, 0x00, 0x00,   // line 23 
-                      0x00, 0x00, 0x00, 0x00,   // line 24 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 25 
-                      0x00, 0x00, 0x00, 0x00,   // line 26 
-                      0x00, 0x00, 0x00, 0x00,   // line 27 
-                      0x00, 0x00, 0x00, 0x00,   // line 28 
- 
-                      0x00, 0x00, 0x00, 0x00,   // line 29 
-                      0x00, 0x00, 0x00, 0x00,   // line 30 
-                      0x00, 0x00, 0x00, 0x00,   // line 31 
-                      0x00, 0x00, 0x00, 0x00};  // line 32 
- 
-hIcon3 = CreateIcon(hinst,    // application instance  
-             32,              // icon width 
-             32,              // icon height 
-             1,               // number of XOR planes 
-             1,               // number of bits per pixel 
-             ANDmaskIcon,     // AND bitmask  
-             XORmaskIcon);    // XOR bitmask 
-              
-```
+[**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon) can be used to create a custom monochrome icon at run time. The technique is identical to the [Creating a Cursor](/windows/win32/menurc/using-cursors#creating-a-cursor) example — use the same `PackCursorMasks` helper and symbol map, replace [**CreateCursor**](/windows/win32/api/winuser/nf-winuser-createcursor) with [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), and omit the hotspot parameters.
 
-To create the icon, [**CreateIcon**](/windows/desktop/api/Winuser/nf-winuser-createicon) applies the following truth table to the AND and XOR bitmasks.
+To create an alpha blended icon at run time, see [Creating an Alpha Blended Cursor](/windows/win32/menurc/using-cursors#creating-an-alpha-blended-cursor) — pass `TRUE` for `fIcon` in [**ICONINFO**](/windows/win32/api/winuser/ns-winuser-iconinfo) to create an icon instead of a cursor.
 
-| AND bitmask | XOR bitmask | Display        |
-|-------------|-------------|----------------|
-| 0           | 0           | Black          |
-| 0           | 1           | White          |
-| 1           | 0           | Screen         |
-| 1           | 1           | Reverse screen |
-
-To create a colored icon at run time you must use the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function, which creates a icon based on the content of an [**ICONINFO**](/windows/desktop/api/Winuser/ns-winuser-iconinfo) structure.
-
-Before closing, your application must use [**DestroyIcon**](/windows/desktop/api/Winuser/nf-winuser-destroyicon) to destroy any icon it created by using [**CreateIcon**](/windows/desktop/api/Winuser/nf-winuser-createicon) or [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect). It is not necessary to destroy icons created by other functions.
+Before closing, your application must use [**DestroyIcon**](/windows/win32/api/winuser/nf-winuser-destroyicon) to destroy any icon obtained from [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect), or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) without the `LR_SHARED` flag. Icons loaded with [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) or `LoadImage` with `LR_SHARED` are shared system resources and must not be destroyed.
 
 ## Getting the Icon size
 
-Here is example code how to get the icon size from the **HICON** handle:
-
-```cpp
-// Also works for cursors
-BOOL GetIconDimensions(__in HICON hico, __out SIZE *psiz)
-{
-  ICONINFO ii;
-  BOOL fResult = GetIconInfo(hico, &ii);
-  if (fResult) {
-    BITMAP bm;
-    fResult = GetObject(ii.hbmMask, sizeof(bm), &bm) == sizeof(bm);
-    if (fResult) {
-      psiz->cx = bm.bmWidth;
-      psiz->cy = ii.hbmColor ? bm.bmHeight : bm.bmHeight / 2;
-    }
-    if (ii.hbmMask)  DeleteObject(ii.hbmMask);
-    if (ii.hbmColor) DeleteObject(ii.hbmColor);
-  }
-  return fResult;
-}
-```
+See [Getting a Cursor size](/windows/win32/menurc/using-cursors#getting-a-cursor-size). The example works identically for icons — pass an `HICON` in place of `HCURSOR`.
 
 ## Displaying an Icon
 
 Your application can load and create icons to display in the application's client area or child windows. The following example demonstrates how to draw an icon in the client area of the window whose device context (DC) is identified by the *hdc* parameter.
 
-```cpp
-HICON hIcon1;   // icon handle  
-HDC hdc;        // handle to display context 
- 
-DrawIcon(hdc, 10, 20, hIcon1); 
+```c
+DrawIcon(hdc, 10, 20, hIcon1);
 ```
 
-The system automatically displays the class icon(s) for a window. Your application can assign class icons while registering a window class. Your application can replace a class icon by using the [**SetClassLong**](/windows/desktop/api/winuser/nf-winuser-setclasslonga) function. This function changes the default window settings for all windows of a given class. The following example replaces a class icon with the icon whose resource identifier is 480.
+The system automatically displays the class icon(s) for a window. Your application can assign class icons while registering a window class. Your application can replace a class icon by using the [**SetClassLongPtr**](/windows/win32/api/winuser/nf-winuser-setclasslongptrw) function. This function changes the default window settings for all windows of a given class. The following example replaces a class icon with the icon whose resource identifier is 480.
 
-```cpp
-HINSTANCE hinst;            // handle to current instance 
-HWND hwnd;                  // main window handle  
- 
-// Change the icon for hwnd's window class. 
- 
-SetClassLongPtr(hwnd,          // window handle 
-    GCLP_HICON,              // changes icon 
-    (LONG_PTR) LoadIcon(hinst, MAKEINTRESOURCE(480))
-   ); 
+```c
+SetClassLongPtr(hWnd, GCLP_HICON,
+    (LONG_PTR)LoadIcon(hInstance, MAKEINTRESOURCE(IDI_MYICON)));
 ```
 
-For more information about window classes, see [Window Classes](/windows/desktop/winmsg/window-classes).
+For more information about window classes, see [Window Classes](/windows/win32/winmsg/window-classes).
 
 ## Sharing Icon Resources
 
-The following code uses the functions [**CreateIconFromResourceEx**](/windows/desktop/api/Winuser/nf-winuser-createiconfromresourceex), [**DrawIcon**](/windows/desktop/api/Winuser/nf-winuser-drawicon), and [**LookupIconIdFromDirectoryEx**](/windows/desktop/api/Winuser/nf-winuser-lookupiconidfromdirectoryex), and several of the resource functions, to create an icon handle based on icon data from another executable file. Then, it displays the icon in a window.
+The following code uses the functions [**CreateIconFromResourceEx**](/windows/win32/api/winuser/nf-winuser-createiconfromresourceex), [**DrawIcon**](/windows/win32/api/winuser/nf-winuser-drawicon), and [**LookupIconIdFromDirectoryEx**](/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectoryex), and several of the resource functions, to create an icon handle based on icon data from another executable file. Then, it displays the icon in a window.
 
-**Security Warning:** Using [**LoadLibrary**](/windows/desktop/api/libloaderapi/nf-libloaderapi-loadlibrarya) incorrectly can compromise the security of your application by loading the wrong DLL. Refer to the **LoadLibrary** documentation for information on how to correctly load DLLs with different versions of Windows.
+**Security Warning:** Using [**LoadLibrary**](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw) incorrectly can compromise the security of your application by loading the wrong DLL. Refer to the **LoadLibrary** documentation for information on how to correctly load DLLs with different versions of Windows.
 
-```cpp
-HICON hIcon1;       // icon handle 
-HINSTANCE hExe;     // handle to loaded .EXE file 
-HRSRC hResource;    // handle to FindResource  
-HRSRC hMem;         // handle to LoadResource 
-BYTE *lpResource;   // pointer to resource data  
-int nID;            // ID of resource that best fits current screen 
- 
-HDC hdc;        // handle to display context 
- 
-// Load the file from which to copy the icon. 
-// Note: LoadLibrary should have a fully explicit path.
-//
-hExe = LoadLibrary("myapp.exe");
+```c
+int cx = GetSystemMetrics(SM_CXICON);
+int cy = GetSystemMetrics(SM_CYICON);
+
+// LoadLibraryExW with LOAD_LIBRARY_AS_DATAFILE avoids running the DLL/EXE.
+// Always use a fully qualified path to prevent DLL planting.
+HINSTANCE hExe = LoadLibraryEx(TEXT("C:\\path\\to\\myapp.exe"), NULL,
+                               LOAD_LIBRARY_AS_DATAFILE);
 if (hExe == NULL)
-{
-    //Error loading module -- fail as securely as possible
     return;
-}
- 
- 
-// Find the icon directory whose identifier is 440. 
- 
-hResource = FindResource(hExe, 
-    MAKEINTRESOURCE(440), 
-    RT_GROUP_ICON); 
- 
-// Load and lock the icon directory. 
- 
-hMem = LoadResource(hExe, hResource); 
- 
-lpResource = LockResource(hMem); 
- 
-// Get the identifier of the icon that is most appropriate 
-// for the video display. 
- 
-nID = LookupIconIdFromDirectoryEx((PBYTE) lpResource, TRUE, 
-    CXICON, CYICON, LR_DEFAULTCOLOR); 
- 
-// Find the bits for the nID icon. 
- 
-hResource = FindResource(hExe, 
-    MAKEINTRESOURCE(nID), 
-    MAKEINTRESOURCE(RT_ICON)); 
- 
-// Load and lock the icon. 
- 
-hMem = LoadResource(hExe, hResource); 
- 
-lpResource = LockResource(hMem); 
- 
-// Create a handle to the icon. 
- 
-hIcon1 = CreateIconFromResourceEx((PBYTE) lpResource, 
-    SizeofResource(hExe, hResource), TRUE, 0x00030000, 
-    CXICON, CYICON, LR_DEFAULTCOLOR); 
- 
-// Draw the icon in the client area. 
- 
-DrawIcon(hdc, 10, 20, hIcon1); 
+
+HRSRC hResource = FindResource(hExe, MAKEINTRESOURCE(440), RT_GROUP_ICON);
+HGLOBAL hMem    = LoadResource(hExe, hResource);
+BYTE *lpResource = LockResource(hMem);
+
+int nID = LookupIconIdFromDirectoryEx(lpResource, TRUE, cx, cy, LR_DEFAULTCOLOR);
+
+hResource  = FindResource(hExe, MAKEINTRESOURCE(nID), RT_ICON);
+hMem       = LoadResource(hExe, hResource);
+lpResource = LockResource(hMem);
+
+HICON hIcon1 = CreateIconFromResourceEx(lpResource,
+    SizeofResource(hExe, hResource), TRUE, 0x00030000,
+    cx, cy, LR_DEFAULTCOLOR);
+
+DrawIcon(hdc, 10, 20, hIcon1);
+
+FreeLibrary(hExe);
 ```


### PR DESCRIPTION
The original examples were written in an older C++ style with filler comments, unused variables, and raw hex byte arrays for cursor/icon masks that were hard to read and error-prone to maintain.

- Cursor and icon mask examples: replaced unreadable hex byte arrays with a symbol map (readable ASCII art) and a PackCursorMasks() helper
- Alpha blended cursor: the original example was incomplete and would not work correctly on modern systems; replaced with a self-contained implementation using analytic AC_SRC_OVER compositing
- Mousetrap: rewrote as a complete, runnable window procedure
- Keyboard cursor movement: fixed incorrect ordering of key check vs GetCursorPos, added acceleration with an upper bound
- Sharing Icon Resources: LoadLibrary with a bare filename is a security issue; replaced with LoadLibraryEx + LOAD_LIBRARY_AS_DATAFILE
- Cleaned up all examples: removed filler comments, unused variable declarations, and outdated C++ style
- Updated all API reference links to /windows/win32/ and wide (W) variants
- Deduplicated GetIconDimensions/GetCursorDimensions between the two files; fixed ownership rules for DestroyIcon