### PR TITLE
Modernize about-cursors.md and about-icons.md

### DIFF
--- a/desktop-src/menurc/about-cursors.md
+++ b/desktop-src/menurc/about-cursors.md
@@ -48,28 +48,27 @@ A number of additional cursors are also available that do not have identifiers d
 
 See [Guidelines](/windows/win32/uxguide/inter-mouse) for information on using standard cursors.
 
-Each standard cursor has a corresponding default image associated with it. The user or an application can replace the default image associated with any standard cursor at any time. An application replaces a default image by using the [**SetSystemCursor**](/windows/desktop/api/Winuser/nf-winuser-setsystemcursor) function.
-
-An application can use the [**GetIconInfo**](/windows/desktop/api/Winuser/nf-winuser-geticoninfo) function to retrieve the current image for a cursor and can draw the cursor by using the [**DrawIconEx**](/windows/desktop/api/Winuser/nf-winuser-drawiconex) function.
+Each standard cursor has a corresponding default image. The user can replace the default image of any standard cursor system-wide through mouse settings.
 
 Custom cursors are designed for use in a specific application and can be any design the developer defines. The following illustration shows several custom cursors.
 
 ![custom cursors, including hand, banana, drum, wristwatch on hand, metronome](images/cursorscustom.png)
 
-Cursors can be either monochrome or color, and either static or animated. The type of cursor used on a particular computer system depends on the system's display. Old displays such as VGA do not support color or animated cursors. New displays, whose display drivers use the device-independent bitmap (DIB) engine, do support them.
+Cursors can be either monochrome or color (including 32bpp ARGB for per-pixel alpha transparency), and either static or animated.
 
-Cursors and icons are similar and can be used interchangeably in many situations. The only difference between them is that an image specified as a cursor must be in the format that the display can support. For example, a cursor must be monochrome for a VGA display.
+**HCURSOR** and **HICON** are interchangeable - most API functions accept either type. The distinction between cursor and icon is recorded inside the object and affects behavior in a few cases - for example, [**GetIconInfo**](/windows/win32/api/winuser/nf-winuser-geticoninfo) returns **fIcon=FALSE** for a cursor handle.
 
 This overview provides information on the following topics:
 
 -   [The Hot Spot](#the-hot-spot)
 -   [The Mouse and the Cursor](#the-mouse-and-the-cursor)
 -   [Cursor Creation](#cursor-creation)
+-   [The Window Class Cursor](#the-window-class-cursor)
+-   [Cursor Sizes](#cursor-sizes)
 -   [Cursor Location and Appearance](#cursor-location-and-appearance)
 -   [Cursor Confinement](#cursor-confinement)
 -   [Cursor Destruction](#cursor-destruction)
 -   [Cursor Duplication](#cursor-duplication)
--   [The Window Class Cursor](#the-window-class-cursor)
 
 ## The Hot Spot
 
@@ -77,7 +76,7 @@ In the cursor, a pixel called the *hot spot* marks the exact screen location tha
 
 ![hot spots on two cursors](images/cursorhotspot.png)
 
-When a mouse input event occurs, the mouse driver translates the event into an appropriate mouse message that includes the coordinates of the hot spot. The system sends the mouse message to the window that contains the hot spot or to the window that is capturing mouse input. For more information, see [Mouse Input](/windows/desktop/inputdev/mouse-input).
+When a mouse input event occurs, the mouse driver translates the event into an appropriate mouse message that includes the coordinates of the hot spot. The system sends the mouse message to the window that contains the hot spot or to the window that is capturing mouse input. For more information, see [Mouse Input](/windows/win32/inputdev/mouse-input).
 
 ## The Mouse and the Cursor
 
@@ -89,57 +88,56 @@ If the system does not have a mouse, the system displays and moves the cursor on
 
 ## Cursor Creation
 
-Because standard cursors are predefined, it is not necessary to create them. To use a standard cursor, an application retrieves a cursor handle by using the [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora) or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) function. A *cursor handle* is a unique value of the **HCURSOR** type that identifies a standard or custom cursor.
+Standard cursors are predefined and do not need to be created. Use [**LoadCursor**](/windows/win32/api/winuser/nf-winuser-loadcursorw) or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) to obtain an **HCURSOR** handle.
 
-To create a custom cursor for an application, you typically use a graphics application and include the cursor as a resource in the application's resource-definition file. At run time, call [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora) to retrieve the cursor handle. Cursor resources contain data for several different display devices. The **LoadCursor** function automatically selects the most appropriate data for the current display device. To load a cursor directly from a .CUR or .ANI file, use the [**LoadCursorFromFile**](/windows/desktop/api/Winuser/nf-winuser-loadcursorfromfilea) function.
+To create a custom cursor for an application, you typically use a graphics application and include the cursor as a resource in the application's resource-definition file. Like icon resources, cursor resources (.cur files or **RT\_CURSOR** / **RT\_GROUP\_CURSOR** in a PE file) store multiple images at different sizes - see [Icon Creation](about-icons.md#icon-creation) for details on the multi-image format. At run time, call [**LoadCursor**](/windows/win32/api/winuser/nf-winuser-loadcursorw) to retrieve the cursor handle; the system automatically selects the best-matching image. To load a cursor directly from a .cur or .ani file, use [**LoadCursorFromFile**](/windows/win32/api/winuser/nf-winuser-loadcursorfromfilew) or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) with **LR\_LOADFROMFILE**.
 
-You can also create a custom cursor at run time by using the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function, which creates a cursor based on the content of an [**ICONINFO**](/windows/desktop/api/Winuser/ns-winuser-iconinfo) structure. The [**GetIconInfo**](/windows/desktop/api/Winuser/nf-winuser-geticoninfo) function fills this structure with hot spot coordinates and information concerning the associated mask and color.
-
-Applications should implement custom cursors as resources and use [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora), [**LoadCursorFromFile**](/windows/desktop/api/Winuser/nf-winuser-loadcursorfromfilea), or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) rather than create the cursor at run time. Using cursor resources avoids device dependence, simplifies localization, and enables applications to share cursor designs.
-
-The [**CreateIconFromResourceEx**](/windows/desktop/api/Winuser/nf-winuser-createiconfromresourceex) function enables an application to create icons and cursors based on resource data. **CreateIconFromResourceEx** creates a cursor based on binary resource data from other executable (.exe) files or DLLs. It must be preceded by calls to the [**LookupIconIdFromDirectoryEx**](/windows/desktop/api/Winuser/nf-winuser-lookupiconidfromdirectoryex) function, as well as several resource functions. **LookupIconIdFromDirectoryEx** identifies the most appropriate cursor data for the current display device. For more information about resource functions, see [Resources](resources.md).
-
-## Cursor Location and Appearance
-
-The system automatically displays a cursor for the mouse and updates its position on the screen. You can obtain current screen coordinates of the cursor and move the cursor to any location on the screen by using the [**GetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-getcursorpos) and [**SetCursorPos**](/windows/desktop/api/Winuser/nf-winuser-setcursorpos) functions, respectively.
-
-You can also retrieve the handle to the current cursor by using the [**GetCursor**](/windows/desktop/api/Winuser/nf-winuser-getcursor) function, and you can set the cursor by using the [**SetCursor**](/windows/desktop/api/Winuser/nf-winuser-setcursor) function. After you call **SetCursor**, the appearance of the cursor does not change until either the mouse moves, the cursor is explicitly set to a different cursor, or a system command is executed.
-
-When the user moves the mouse, the system redraws the cursor at the new location. The system automatically redraws the cursor design associated with the window to which the cursor is pointing.
-
-You can hide and redisplay the cursor, without changing the cursor design, by using the [**ShowCursor**](/windows/desktop/api/Winuser/nf-winuser-showcursor) function. This function uses an internal counter to determine when to hide or display the cursor. An attempt to show the cursor increments the counter; an attempt to hide the cursor decrements the counter. The cursor is visible only if this counter is greater than or equal to zero.
-
-The [**GetCursorInfo**](/windows/desktop/api/Winuser/nf-winuser-getcursorinfo) function gets the following information for the global cursor: whether the cursor is hidden or shown, the handle to the cursor, and the coordinates of the cursor.
-
-## Cursor Confinement
-
-You can confine the cursor to a rectangular area on the screen by using the [**ClipCursor**](/windows/desktop/api/Winuser/nf-winuser-clipcursor) function. This is useful for when the user must respond to a certain event within the confined area of the rectangle. For example, you might use **ClipCursor** to confine the cursor to a modal dialog box, preventing the user from interacting with other windows until the dialog box is closed.
-
-The [**GetClipCursor**](/windows/desktop/api/Winuser/nf-winuser-getclipcursor) function retrieves the screen coordinates of the rectangular area to which the cursor is temporarily confined. When it is necessary to confine the cursor, you can also use this function to save the coordinates of the original area in which the cursor can move. Then, you can restore the cursor to the original area when the new confinement is no longer necessary.
-
-## Cursor Destruction
-
-You can destroy the cursor handle and free the memory the cursor used by calling the [**DestroyCursor**](/windows/desktop/api/Winuser/nf-winuser-destroycursor) function. However, this function has no effect on a shared cursor. A shared cursor is valid as long as the module from which it was loaded remains in memory. The following functions obtain a shared cursor:
-
--   [**LoadCursor**](/windows/desktop/api/Winuser/nf-winuser-loadcursora)
--   [**LoadCursorFromFile**](/windows/desktop/api/Winuser/nf-winuser-loadcursorfromfilea)
--   [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) (if you use the **LR\_SHARED** flag)
--   [**CopyImage**](/windows/desktop/api/Winuser/nf-winuser-copyimage) (if you use the **LR\_COPYRETURNORG** flag and the *hImage* is a shared cursor)
-
-When you no longer need a cursor you created by using the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function, you should destroy the cursor. The [**DestroyIcon**](/windows/desktop/api/Winuser/nf-winuser-destroyicon) function destroys the cursor handle and frees any memory the cursor used. Use this function only on cursors that were created with **CreateIconIndirect**.
-
-## Cursor Duplication
-
-The [**CopyCursor**](/windows/desktop/api/Winuser/nf-winuser-copycursor) function copies a cursor handle. This enables application or DLL code to retrieve the handle to a cursor owned by another module. Then, if the other module is freed, the module that copied the cursor can still use the cursor design.
-
-For information on how to add, remove, or replace cursor resources in executable files, see [Resources](resources.md).
+You can also create a custom cursor at run time - see [Icon Creation](about-icons.md#icon-creation) for details on programmatic creation.
 
 ## The Window Class Cursor
 
-When you register a window class, using the [**RegisterClass**](/windows/desktop/api/winuser/nf-winuser-registerclassa) function, you can assign it a default cursor, known as the *class cursor*. After the application registers the window class, each window of that class has the specified class cursor.
+When you register a window class using the [**RegisterClassEx**](/windows/win32/api/winuser/nf-winuser-registerclassexw) function, set the **hCursor** field of [**WNDCLASSEX**](/windows/win32/api/winuser/ns-winuser-wndclassexa) to the desired cursor handle. Every window of that class uses this cursor by default. For more information, see [Class Cursor](/windows/win32/winmsg/about-window-classes).
 
-To override the class cursor, process the [**WM\_SETCURSOR**](wm-setcursor.md) message. You can also replace a class cursor by using the [**SetClassLong**](/windows/desktop/api/winuser/nf-winuser-setclasslonga) function. This function changes the default window settings for all windows of a specified class. For more information, see [Class Cursor](/windows/desktop/winmsg/about-window-classes).
+To override the class cursor for a specific window or hit-test area, process the [**WM\_SETCURSOR**](wm-setcursor.md) message and call [**SetCursor**](/windows/win32/api/winuser/nf-winuser-setcursor). To replace the class cursor for all windows of a class, use [**SetClassLongPtr**](/windows/win32/api/winuser/nf-winuser-setclasslongptrw) with **GCLP\_HCURSOR**.
 
- 
+## Cursor Sizes
 
- 
+The system reports the nominal cursor size via [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXCURSOR** / **SM\_CYCURSOR**. This is the size of the cursor image buffer; the visible cursor shape is typically smaller due to transparent edges. Unlike icon sizes, cursor sizes change in steps - not every DPI value produces a distinct cursor size. The standard sizes at default cursor size setting are:
+
+| Display scale | DPI range | SM\_CXCURSOR / SM\_CYCURSOR |
+|---|---|---|
+| < 150% | < 144 DPI | 32x32 |
+| 150-199% | 144-191 DPI | 48x48 |
+| 200-299% | 192-287 DPI | 64x64 |
+| 300-399% | 288-383 DPI | 96x96 |
+| >= 400% | >= 384 DPI | 128x128 |
+
+The user can also change the cursor size independently of DPI via **Settings > Accessibility > Mouse pointer and touch > Size**. Always call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXCURSOR** to get the actual effective size rather than assuming a fixed value. In per-monitor DPI-aware applications, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the DPI of the target monitor, which you can obtain with [**GetDpiForWindow**](/windows/win32/api/winuser/nf-winuser-getdpiforwindow) or [**GetDpiForMonitor**](/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor). For more information, see [High DPI Desktop Application Development on Windows](/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
+
+To retrieve the dimensions of a cursor from its handle, see [Getting a Cursor size](/windows/win32/menurc/using-cursors#getting-a-cursor-size).
+
+## Cursor Location and Appearance
+
+The system automatically displays a cursor for the mouse, updates its position on the screen, and redraws the cursor design associated with the window to which the cursor is pointing. You can obtain current screen coordinates of the cursor and move the cursor to any location on the screen by using the [**GetCursorPos**](/windows/win32/api/winuser/nf-winuser-getcursorpos) and [**SetCursorPos**](/windows/win32/api/winuser/nf-winuser-setcursorpos) functions, respectively. These functions return and accept coordinates in the logical coordinate space of the calling thread's DPI awareness context. To work in physical screen pixels regardless of DPI awareness, use [**GetPhysicalCursorPos**](/windows/win32/api/winuser/nf-winuser-getphysicalcursorpos) and [**SetPhysicalCursorPos**](/windows/win32/api/winuser/nf-winuser-setphysicalcursorpos) instead.
+
+You can retrieve the handle to the current cursor by using the [**GetCursor**](/windows/win32/api/winuser/nf-winuser-getcursor) function, and set the cursor by using the [**SetCursor**](/windows/win32/api/winuser/nf-winuser-setcursor) function. **SetCursor** takes effect only while the calling thread owns mouse input - the reliable place to call it is in a [**WM\_SETCURSOR**](wm-setcursor.md) handler. When handling **WM\_SETCURSOR**, return **TRUE** after calling **SetCursor**; otherwise **DefWindowProc** will override the cursor with the class cursor. See [Displaying a Cursor](/windows/win32/menurc/using-cursors#displaying-a-cursor) for an example.
+
+You can hide and redisplay the cursor by using the [**ShowCursor**](/windows/win32/api/winuser/nf-winuser-showcursor) function. This function maintains a per-thread visibility counter; the cursor is visible only when the counter is greater than or equal to zero. Each call to `ShowCursor(FALSE)` must be paired with a call to `ShowCursor(TRUE)` - an unmatched decrement permanently hides the cursor for that thread.
+
+The [**GetCursorInfo**](/windows/win32/api/winuser/nf-winuser-getcursorinfo) function retrieves whether the cursor is hidden or shown, its handle, and its screen coordinates.
+
+## Cursor Confinement
+
+You can confine the cursor to a rectangular area on the screen by using the [**ClipCursor**](/windows/win32/api/winuser/nf-winuser-clipcursor) function. This is useful for when the user must respond to a certain event within the confined area of the rectangle. For example, you might use **ClipCursor** to confine the cursor to a modal dialog box, preventing the user from interacting with other windows until the dialog box is closed.
+
+The [**GetClipCursor**](/windows/win32/api/winuser/nf-winuser-getclipcursor) function retrieves the screen coordinates of the rectangular area to which the cursor is temporarily confined. When it is necessary to confine the cursor, you can also use this function to save the coordinates of the original area in which the cursor can move. Then, you can restore the cursor to the original area when the new confinement is no longer necessary.
+
+## Cursor Destruction
+
+The same ownership rules that apply to icons also apply to cursors - destroy owned cursor handles by calling [**DestroyCursor**](/windows/win32/api/winuser/nf-winuser-destroycursor). See [Icon Destruction](about-icons.md#icon-destruction) for the shared handle exceptions that apply to both icons and cursors. The cursor-specific shared function is [**LoadCursor**](/windows/win32/api/winuser/nf-winuser-loadcursorw) - it always uses **LR\_SHARED** internally regardless of the instance parameter; use **LoadImage** without **LR\_SHARED** if you need an owned handle.
+
+## Cursor Duplication
+
+The [**CopyCursor**](/windows/win32/api/winuser/nf-winuser-copycursor) function creates a new independent cursor object with the same image and hotspot as the original - analogous to [**CopyIcon**](about-icons.md#icon-duplication) for icons. The copy is owned by the caller.
+
+For information on how to add, remove, or replace cursor resources in executable files, see [Resources](resources.md).

--- a/desktop-src/menurc/about-icons.md
+++ b/desktop-src/menurc/about-icons.md
@@ -4,7 +4,6 @@ description: This topic discusses icons.
 ms.assetid: 67867460-07f6-460f-9263-05bbf3474744
 keywords:
 - resources,icons
-- icons,hot spots
 - icons,standard
 - standard icons
 - icons,custom
@@ -25,31 +24,23 @@ ms.date: 05/31/2018
 
 # About Icons
 
-The system uses icons throughout the user interface to represent objects such as files, folders, shortcuts, applications, and documents. The icon functions enable applications to create, load, display, arrange, animate, and destroy icons. For information on specifying icons for file types, see [**ExtractIcon**](/windows/desktop/api/Shellapi/nf-shellapi-extracticona).
+The system uses icons throughout the user interface to represent objects such as files, folders, shortcuts, applications, and documents. The icon functions enable applications to create, load, display, copy, and destroy icons. For information on specifying icons for file types, see [**ExtractIcon**](/windows/win32/api/shellapi/nf-shellapi-extracticonw).
 
 This overview provides information on the following topics:
 
--   [Icon Hot Spot](#icon-hot-spot)
 -   [Icon Types](#icon-types)
 -   [Icon Sizes](#icon-sizes)
-    -   [To change the size of the system small icon](#to-change-the-size-of-the-system-small-icon)
-    -   [To retrieve the size of the system small icon](#to-retrieve-the-size-of-the-system-small-icon)
-    -   [To retrieve the size of the system large icon](#to-retrieve-the-size-of-the-system-large-icon)
-    -   [To retrieve the size of the shell small icon](#to-retrieve-the-size-of-the-shell-small-icon)
-    -   [To change the size of the large icon](#to-change-the-size-of-the-large-icon)
-    -   [To retrieve the size of the shell large icon](#to-retrieve-the-size-of-the-shell-large-icon)
+    -   [System icon sizes](#system-icon-sizes)
+    -   [Shell icon sizes](#shell-icon-sizes)
 -   [Icon Creation](#icon-creation)
+-   [The Window Class Icon](#the-window-class-icon)
 -   [Icon Display](#icon-display)
 -   [Icon Destruction](#icon-destruction)
 -   [Icon Duplication](#icon-duplication)
 
-## Icon Hot Spot
-
-One of the pixels in an icon is designated as the [hot spot](#icon-hot-spot), which is the point the system tracks and recognizes as the position of the icon. An icon's hot spot is typically the pixel located at the center of the icon. If you use the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function to create an icon, you can specify any pixel to be the hot spot.
-
 ## Icon Types
 
-The operating system provides a set of standard icons that are available for any application to use at any time. The software development kit (SDK) header files contain identifiers for the **system icons** — the identifiers begin with the **IDI\_** prefix.
+The operating system provides a set of standard icons that are available for any application to use at any time. The software development kit (SDK) header files contain identifiers for the **system icons** - the identifiers begin with the **IDI\_** prefix.
 
 | Value | Meaning |
 |---|---|
@@ -71,110 +62,72 @@ Also, starting with Windows Vista, an additional set of **standard system shell 
 
 ## Icon Sizes
 
-The system uses four icon sizes:
-
--   System small
--   System large
--   Shell small
--   Shell large
--   Jumbo (starting Windows Vista)
-
-The *system small icon* is displayed in the window caption.
-
 See [Icon scaling](/windows/apps/design/style/iconography/app-icon-construction#icon-scaling) for recommendations on preferred icon sizes for your application.
 
-### To change the size of the system small icon
+### System icon sizes
 
-1.  From Control Panel, click **Display**, then click the **Appearance** tab.
-2.  Select **Caption Buttons** from the **Item** list, then set the **Size** field.
+System icon sizes are reported by [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) and scale with the display DPI.
 
-### To retrieve the size of the system small icon
+| Size | Metric | 96 DPI | 150% (144 DPI) | 200% (192 DPI) | Description |
+|---|---|---|---|---|---|
+| System small | **SM\_CXSMICON** / **SM\_CYSMICON** | 16x16 | 24x24 | 32x32 | Menus, notification area, Explorer list view |
+| System large | **SM\_CXICON** / **SM\_CYICON** | 32x32 | 48x48 | 64x64 | ICON\_BIG (WM\_SETICON / WM\_GETICON), Alt+Tab (legacy/fallback) |
 
--   Call the [**GetSystemMetrics**](/windows/desktop/api/winuser/nf-winuser-getsystemmetrics) function with **SM\_CXSMICON** and **SM\_CYSMICON**.
+The [**CreateIconFromResource**](/windows/win32/api/winuser/nf-winuser-createiconfromresource), [**DrawIcon**](/windows/win32/api/winuser/nf-winuser-drawicon), [**ExtractAssociatedIcon**](/windows/win32/api/shellapi/nf-shellapi-extractassociatediconw), [**ExtractIcon**](/windows/win32/api/shellapi/nf-shellapi-extracticonw), [**ExtractIconEx**](/windows/win32/api/shellapi/nf-shellapi-extracticonexw), and [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) functions all use the system large icon size. The [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), [**CreateIconFromResourceEx**](/windows/win32/api/winuser/nf-winuser-createiconfromresourceex), [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect), and [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) functions can work with icons at any size.
 
-The *system large icon* is mainly used by applications, but it is also displayed in the Alt+Tab dialog. The [**CreateIconFromResource**](/windows/desktop/api/Winuser/nf-winuser-createiconfromresource), [**DrawIcon**](/windows/desktop/api/Winuser/nf-winuser-drawicon), [**ExtractAssociatedIcon**](/windows/desktop/api/Shellapi/nf-shellapi-extractassociatedicona), [**ExtractIcon**](/windows/desktop/api/Shellapi/nf-shellapi-extracticona), [**ExtractIconEx**](/windows/desktop/api/Shellapi/nf-shellapi-extracticonexa), and [**LoadIcon**](/windows/desktop/api/Winuser/nf-winuser-loadicona) functions all use system large icons. The size of the system large icon is defined by the video driver, therefore it cannot be changed.
+To retrieve system icon sizes, call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXSMICON** / **SM\_CYSMICON** for the small size, or **SM\_CXICON** / **SM\_CYICON** for the large size. In per-monitor DPI-aware applications, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the DPI of the target monitor instead, so the returned size reflects the correct display. For more information, see [High DPI Desktop Application Development on Windows](/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
 
-### To retrieve the size of the system large icon
+### Shell icon sizes
 
--   Call [**GetSystemMetrics**](/windows/desktop/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXICON** and **SM\_CYICON**.
+The shell uses a separate set of sizes for Explorer views and the system image lists, accessible via [**SHGetImageList**](/windows/win32/api/shellapi/nf-shellapi-shgetimagelistw). Call **SHGetImageList** with the appropriate **SHIL\_\*** constant, then call [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize) on the returned image list.
 
-The [**CreateIcon**](/windows/desktop/api/Winuser/nf-winuser-createicon), [**CreateIconFromResourceEx**](/windows/desktop/api/Winuser/nf-winuser-createiconfromresourceex), [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect), and [**SHGetFileInfo**](/windows/win32/api/shellapi/nf-shellapi-shgetfileinfoa) functions can be used to work with icons in sizes other than system large.
-
-The *shell small icon* is used in the Windows Explorer and the common dialogs. Currently, this defaults to the system small size.
-
-### To retrieve the size of the shell small icon
-
-1.  Use the [SHGetFileInfo](/windows/win32/api/shellapi/nf-shellapi-shgetfileinfoa) function with `SHGFI_SHELLICONSIZE | SHGFI_SMALLICON` to retrieve a handle to the system image list.
-2.  Then call the [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize) function to get the icon size.
-
-The shell large icon is used on the desktop.
-
-### To change the size of the large icon
-
-1.  From Control Panel , click **Display**, then click the **Appearance** tab,
-2.  Select **Icon** from the **Item** list, then set the **Size** field (this size is stored in the registry, under **HKEY\_CURRENT\_USER\\Control Panel, Desktop\\WindowMetrics\\Shell Icon Size**).
-3.  Click the **Plus!** tab and then select the **Use Large Icons** check box.
-
-### To retrieve the size of the shell large icon
-
-1.  Use the [**SHGetFileInfo**](/windows/win32/api/shellapi/nf-shellapi-shgetfileinfoa) function with **SHGFI\_SHELLICONSIZE** to retrieve a handle to the system image list.
-2.  Then call the [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize) function to get the icon size.
-
-When filling in the [**WNDCLASSEX**](/windows/win32/api/winuser/ns-winuser-wndclassexa) structure to be used in registering your window class, set the **hIcon** member to the system large icon (usually 32x32) and the **hIconSm** member to the system small icon (usually 16x16). For more information about class icons, see [Class Icons](/windows/desktop/winmsg/about-window-classes).
+| SHIL constant | Source | 96 DPI | 150% (144 DPI) | 200% (192 DPI) | Description |
+|---|---|---|---|---|---|
+| **SHIL\_SMALL** (1) | SM\_CXSMICON | 16x16 | 24x24 | 32x32 | Explorer list/details view, common dialogs, window title bar icon |
+| **SHIL\_SYSSMALL** (3) | SM\_CXSMSIZE | 16x16 | 24x24 | 32x32 | Shell toolbars, status bars; tracks caption button size; equals SHIL\_SMALL at default settings |
+| **SHIL\_LARGE** (0) | SM\_CXICON | 32x32 | 48x48 | 64x64 | Explorer medium icons view, dialogs |
+| **SHIL\_EXTRALARGE** (2) | 48 logical px | 48x48 | 72x72 | 96x96 | Explorer large icons view, desktop |
+| **SHIL\_JUMBO** (4) | fixed 256 px | 256x256 | 256x256 | 256x256 | Explorer extra large icons view (Vista+); always 256 physical pixels |
 
 ## Icon Creation
 
-Standard icons are predefined, so it is not necessary to create them. To use a standard icon, an application can obtain its handle by using the [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) function. An *icon handle* is a unique value of the **HICON** type that identifies a standard or custom icon.
+An icon resource (.ico file or **RT\_ICON** / **RT\_GROUP\_ICON** in a PE file) stores multiple images - typically at standard sizes 16, 32, 48, and 256 pixels, optionally at different color depths including 32bpp ARGB for per-pixel alpha transparency. Each image is optimized for its size; providing all standard sizes avoids the quality loss that results from scaling a single image up or down.
 
-To create a custom icon for an application, you would typically use a graphics application and include the [ICON Resource](./icon-resource.md) in the application's resource-definition file. At run-time, you can call [**LoadIcon**](/windows/desktop/api/Winuser/nf-winuser-loadicona) or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea) to retrieve a handle to the icon. An icon resource can contain a group of images for several different display devices. **LoadIcon** and **LoadImage** automatically select the most appropriate icon from the group for the current display device.
+To load an icon from a resource, call [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew). The system automatically selects the best-matching image for the requested size and display color depth using the same algorithm as [**LookupIconIdFromDirectoryEx**](/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectoryex). To load directly from an .ico file, pass **LR\_LOADFROMFILE** to **LoadImage**. To load at a non-standard size with high-quality scaling, use [**LoadIconWithScaleDown**](/windows/win32/api/commctrl/nf-commctrl-loadiconwithscaledown) - it selects the nearest larger standard image (16, 32, 48, or 256) and scales it down to the requested size.
 
-An application can also create a custom icon at run-time by using the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function, which creates an icon based on the contents of an [**ICONINFO**](/windows/desktop/api/Winuser/ns-winuser-iconinfo) structure. The [**GetIconInfo**](/windows/desktop/api/Winuser/nf-winuser-geticoninfo) function fills the structure with the hot-spot coordinates and information about the bitmask bitmap and color bitmap for the icon.
+An application can also create a custom icon at run-time by using the [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect) function, which creates an icon based on the contents of an [**ICONINFO**](/windows/win32/api/winuser/ns-winuser-iconinfo) structure. Note that for icons the hotspot fields in **ICONINFO** are ignored by the system - the hotspot is always the center of the image. The [**CreateIconFromResourceEx**](/windows/win32/api/winuser/nf-winuser-createiconfromresourceex) function creates an icon from binary resource data from other executable files or DLLs; use [**LookupIconIdFromDirectoryEx**](/windows/win32/api/winuser/nf-winuser-lookupiconidfromdirectoryex) first to identify the most appropriate image for the current display size and color depth. For examples, see [Creating an Icon](using-icons.md#creating-an-icon).
 
-Applications should implement custom icons as resources and should use [**LoadIcon**](/windows/desktop/api/Winuser/nf-winuser-loadicona) or [**LoadImage**](/windows/desktop/api/Winuser/nf-winuser-loadimagea), rather than create the icon at run-time. Using icon resources avoids device dependence, simplifies localization, and enables applications to share icon shapes.
+Applications should implement custom icons as resources and use **LoadIcon** or **LoadImage** rather than create icons at run-time. Using icon resources avoids device dependence, simplifies localization, and enables applications to share icon shapes.
 
-The [**CreateIconFromResourceEx**](/windows/desktop/api/Winuser/nf-winuser-createiconfromresourceex) function enables an application to browse through the system's resources and create icons and cursors based on resource data. **CreateIconFromResourceEx** creates an icon based on binary resource data from other executable files or DLLs. An application must precede this function with calls to the [**LookupIconIdFromDirectoryEx**](/windows/desktop/api/Winuser/nf-winuser-lookupiconidfromdirectoryex) function and several of the resource functions. **LookupIconIdFromDirectoryEx** returns the identifier of the most appropriate icon data for the current display device.
+## The Window Class Icon
+
+When you register a window class using the [**RegisterClassEx**](/windows/win32/api/winuser/nf-winuser-registerclassexw) function, set the **hIcon** field of [**WNDCLASSEX**](/windows/win32/api/winuser/ns-winuser-wndclassexa) to the large icon (**SM\_CXICON** x **SM\_CYICON**) and **hIconSm** to the small icon (**SM\_CXSMICON** x **SM\_CYSMICON**). Every window of that class uses these icons by default. For more information, see [Class Icons](/windows/win32/winmsg/about-window-classes).
+
+To set or update a specific window's icon at run time, send [**WM\_SETICON**](/windows/win32/winmsg/wm-seticon) with **ICON\_BIG** or **ICON\_SMALL**. To retrieve the current icon handle, send [**WM\_GETICON**](/windows/win32/winmsg/wm-geticon) with the same wParam value. To replace the class icon for all windows of a class, use [**SetClassLongPtr**](/windows/win32/api/winuser/nf-winuser-setclasslongptrw) with **GCLP\_HICON** or **GCLP\_HICONSM**.
 
 ## Icon Display
 
-You can retrieve the image for an icon by using the [**GetIconInfo**](/windows/desktop/api/Winuser/nf-winuser-geticoninfo) function, and can draw it by using the [**DrawIconEx**](/windows/desktop/api/Winuser/nf-winuser-drawiconex) function. To draw the default image for a icon, specify the **DI\_COMPAT** flag in the call to **DrawIconEx**. If you do not specify the **DI\_COMPAT** flag, **DrawIconEx** draws the icon using the image that the user specified.
+You can retrieve the image and size of an icon by using the [**GetIconInfo**](/windows/win32/api/winuser/nf-winuser-geticoninfo) function - see [Getting the Icon size](using-icons.md#getting-the-icon-size) for an example. You can draw the icon by using the [**DrawIconEx**](/windows/win32/api/winuser/nf-winuser-drawiconex) function.
 
-When the system displays an icon, it must extract the appropriate icon image from the .exe or .dll file. The system uses the following steps to select the icon image:
+To display an icon in a static control, send [**STM\_SETIMAGE**](/windows/win32/controls/stm-setimage) with **IMAGE\_ICON** and the icon handle:
 
-1.  Select the **RT\_GROUP\_ICON** resource. If more than one such resource exists, the system uses the first resource listed in the resource scrip.
-2.  Select the appropriate **RT\_ICON** image from the **RT\_GROUP\_ICON** resource. If more than one image exists, the system uses the following criteria to choose an image:
-    -   The image closest in size to the requested size is chosen.
-    -   If two or more images of that size are present, the one that matches the color depth of the display is chosen.
-    -   If no images exactly match the color depth of the display, the image with the greatest color depth that does not exceed the color depth of the display is chosen. If all exceed the color depth, the one with the lowest color depth is chosen.
-
-> [!Note]  
-> The system treats all color depths of 8 or more bpp as equal. Therefore, there is no advantage of including a 16x16 256-color image and a 16x16 16-color image in the same resource—the system will simply choose the first one it encounters. When the display is in 8-bpp mode, the system will choose a 16-color icon over a 256-color icon, and will display all icons using the system default palette.
-
- 
-
-To display an animated icon, use a static control as shown in the following code fragment.
-
-
+```c
+HICON hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_MYICON));
+SendMessage(hStatic, STM_SETIMAGE, IMAGE_ICON, (LPARAM)hIcon);
 ```
-hIcon = LoadImage(NULL, "ico.ani", IMAGE_ICON, 0, 0, LR_LOADFROMFILE);
-SendMessage( hStatic, STM_SETIMAGE, IMAGE_ICON, (LPARAM)(UINT)hIcon);
-```
-
-
 
 ## Icon Destruction
 
-When an application no longer needs an icon it created by using the [**CreateIconIndirect**](/windows/desktop/api/Winuser/nf-winuser-createiconindirect) function, it should destroy the icon. The [**DestroyIcon**](/windows/desktop/api/Winuser/nf-winuser-destroyicon) function destroys the icon handle and frees any memory used by the icon. Applications should use this function only for icons created with **CreateIconIndirect**; it is not necessary to destroy other icons.
+When an application no longer needs an icon, destroy it by calling [**DestroyIcon**](/windows/win32/api/winuser/nf-winuser-destroyicon). The only exceptions are shared handles, which must **not** be destroyed:
+
+- [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) - always uses **LR\_SHARED** internally regardless of the instance parameter; use **LoadImage** without **LR\_SHARED** if you need an owned handle
+- [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) with **LR\_SHARED**
+- [**CopyImage**](/windows/win32/api/winuser/nf-winuser-copyimage) with **LR\_COPYRETURNORG** when the size already matches - returns the original handle, which may be shared
 
 ## Icon Duplication
 
-The [**CopyIcon**](/windows/desktop/api/Winuser/nf-winuser-copyicon) function copies an icon handle. This enables an application or DLL to get its own handle to an icon owned by another module. Then, if the other module is freed, the application that copied the icon will still be able to use the icon.
+The [**CopyIcon**](/windows/win32/api/winuser/nf-winuser-copyicon) function creates a new independent icon object with the same image as the original. This enables an application or DLL to obtain an icon that outlives the module it was loaded from - if the original module is freed, the copy remains valid. The copy is owned by the caller.
 
-The [**CopyImage**](/windows/desktop/api/Winuser/nf-winuser-copyimage) function creates a new icon based on the specified source icon. The new icon can be larger or smaller than the source icon.
+The [**CopyImage**](/windows/win32/api/winuser/nf-winuser-copyimage) function creates a new icon based on an existing icon handle, optionally at a different size - useful when you already hold a handle and need a resized copy without reloading the original resource.
 
 For information about adding, removing, or replacing icon resources in executable (.exe) files, see [Resources](resources.md).
-
-The [**DuplicateIcon**](/windows/desktop/api/Shellapi/nf-shellapi-duplicateicon) function makes an actual copy of the icon.
-
- 
-
- 


### PR DESCRIPTION
The original files contained outdated API links, factually incorrect statements, and sections that either duplicated each other or described VGA-era behavior no longer relevant on modern Windows.

- API links: updated all /windows/desktop/api/Winuser/ paths to /windows/win32/api/winuser/ with W-suffix variants; display names without W suffix
- about-cursors: fixed CopyCursor description (creates independent owned object, not a handle alias); replaced SetClassLong with SetClassLongPtr, RegisterClass with RegisterClassEx; corrected cursor ownership lists in Cursor Destruction (added CreateCursor, LoadCursorFromFile; removed incorrect DestroyIcon reference)
- about-cursors: added Cursor Sizes section with DPI step table (32/48/64/96/128), accessibility size setting note, and GetSystemMetricsForDpi recommendation; noted that PE-resource cursors get DPI copies automatically
- about-cursors: fixed SetCursor description -- effective only when calling thread owns mouse input; added WM_SETCURSOR pattern with return TRUE requirement; documented ShowCursor per-thread counter and mandatory FALSE/TRUE pairing
- about-cursors: removed outdated VGA monochrome text; deduplicated Creation/Destruction/Duplication sections with references to about-icons
- about-icons: removed Icon Hot Spot section (hotspot is always center for icons, not user-controllable)
- about-icons: restructured Icon Sizes into System icon sizes / Shell icon sizes subsections with DPI tables; corrected SHIL_SYSSMALL metric (SM_CXSMSIZE, not SM_CXSMICON); fixed SHIL_LARGE/EXTRALARGE descriptions; added GetSystemMetricsForDpi and High DPI docs link
- about-icons: replaced inaccurate icon selection algorithm description with high-level prose referencing LookupIconIdFromDirectoryEx; added LR_LOADFROMFILE mention; added LoadIconWithScaleDown description; added STM_SETIMAGE code example
- about-icons: expanded Icon Destruction to include ExtractIcon, ExtractIconEx, SHGetFileInfo(SHGFI_ICON); clarified CopyImage LR_COPYRETURNORG behavior; removed DuplicateIcon in favor of CopyIcon