### PR TITLE
Fix formatting of Windows support for SOL_SOCKET options table

### DIFF
--- a/desktop-src/WinSock/sol-socket-socket-options.md
+++ b/desktop-src/WinSock/sol-socket-socket-options.md
@@ -77,53 +77,53 @@ Some socket options require more explanation than these tables can convey; such 
 **Windows Support for SOL_SOCKET Options**
 
 | Option                                          | Windows 10 | Windows 7 | Windows Server 2008 | Windows Vista | Windows Server 2003 | Windows XP | Windows 2000 | Windows NT4 | Windows 9x/ME |
-|-------------------------------------------------|------------|-----------|---------------------|---------------|---------------------|------------|--------------|-------------|---------------|
+|-------------------------------------------------|:----------:|:---------:|:-------------------:|:-------------:|:-------------------:|:----------:|:------------:|:-----------:|:-------------:|
 | PVD\_CONFIG                                     |            |           |                     |               |                     |            |              |             |               |
-| SO\_ACCEPTCONN                                   yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_BROADCAST                                    yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| [**SO\_BSP\_STATE**](so-bsp-state.md)           yes            yes           yes                     yes              |                     |            |              |             |               |
-| SO\_CONDITIONAL\_ACCEPT                          yes            yes           yes                     yes               yes                     yes            yes             |             |               |
-| SO\_CONNDATA                                     yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_CONNDATALEN                                  yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_CONNECT\_TIME                                yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_CONNOPT                                      yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_CONNOPTLEN                                   yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_DISCDATA                                     yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_DISCDATALEN                                  yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_DISCOPT                                      yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_DISCOPTLEN                                   yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_DEBUG                                        yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_DONTLINGER                                   yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_DONTROUTE                                    yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_ERROR                                        yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| [SO\_EXCLUSIVEADDRUSE](so-exclusiveaddruse.md)  yes            yes           yes                     yes               yes                     yes            yes              yes  SP4+      |               |
-| SO\_GROUP\_ID                                    yes            yes           yes                     yes              |                     |            |              |             |               |
-| SO\_GROUP\_PRIORITY                              yes            yes           yes                     yes              |                     |            |              |             |               |
-| SO\_KEEPALIVE                                    yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_LINGER                                       yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_MAX\_MSG\_SIZE                               yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_MAXDG                                        yes            yes           yes                     yes               yes                     yes            yes             |             |               |
-| SO\_MAXPATHDG                                    yes            yes           yes                     yes               yes                     yes            yes             |             |               |
-| SO\_OOBINLINE                                    yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_OPENTYPE                                     yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_PORT\_SCALABILITY                            yes            yes           yes                    |               |                     |            |              |             |               |
-| SO\_PROTECT                                     |            |           |                     |                yes                    |            |              |             |               |
-| SO\_PROTOCOL\_INFO                               yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_PROTOCOL\_INFOA                              yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_PROTOCOL\_INFOW                              yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_RCVBUF                                       yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
+| SO\_ACCEPTCONN                                  |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_BROADCAST                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| [**SO\_BSP\_STATE**](so-bsp-state.md)           |yes         |yes        |yes                  |yes            |                     |            |              |             |               |
+| SO\_CONDITIONAL\_ACCEPT                         |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |             |               |
+| SO\_CONNDATA                                    |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_CONNDATALEN                                 |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_CONNECT\_TIME                               |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_CONNOPT                                     |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_CONNOPTLEN                                  |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_DISCDATA                                    |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_DISCDATALEN                                 |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_DISCOPT                                     |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_DISCOPTLEN                                  |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_DEBUG                                       |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_DONTLINGER                                  |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_DONTROUTE                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_ERROR                                       |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| [SO\_EXCLUSIVEADDRUSE](so-exclusiveaddruse.md)  |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes  SP4+    |               |
+| SO\_GROUP\_ID                                   |yes         |yes        |yes                  |yes            |                     |            |              |             |               |
+| SO\_GROUP\_PRIORITY                             |yes         |yes        |yes                  |yes            |                     |            |              |             |               |
+| SO\_KEEPALIVE                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_LINGER                                      |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_MAX\_MSG\_SIZE                              |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_MAXDG                                       |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |             |               |
+| SO\_MAXPATHDG                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |             |               |
+| SO\_OOBINLINE                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_OPENTYPE                                    |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_PORT\_SCALABILITY                           |yes         |yes        |yes                  |               |                     |            |              |             |               |
+| SO\_PROTECT                                     |            |           |                     |               |yes                  |            |              |             |               |
+| SO\_PROTOCOL\_INFO                              |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_PROTOCOL\_INFOA                             |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_PROTOCOL\_INFOW                             |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_RCVBUF                                      |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
 | SO\_RCVLOWAT                                    |            |           |                     |               |                     |            |              |             |               |
-| SO\_RCVTIMEO                                     yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_RANDOMIZE\_PORT                              yes            yes           yes                     yes              |                     |            |              |             |               |
-| SO\_REUSEADDR                                    yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_REUSE\_UNICASTPORT                           yes           |           |                     |               |                     |            |              |             |               |
-| SO\_REUSE\_MULTICASTPORT                         yes           |           |                     |               |                     |            |              |             |               |
-| SO\_SNDBUF                                       yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
+| SO\_RCVTIMEO                                    |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_RANDOMIZE\_PORT                             |yes         |yes        |yes                  |yes            |                     |            |              |             |               |
+| SO\_REUSEADDR                                   |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_REUSE\_UNICASTPORT                          |yes         |           |                     |               |                     |            |              |             |               |
+| SO\_REUSE\_MULTICASTPORT                        |yes         |           |                     |               |                     |            |              |             |               |
+| SO\_SNDBUF                                      |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
 | SO\_SNDLOWAT                                    |            |           |                     |               |                     |            |              |             |               |
-| SO\_SNDTIMEO                                     yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_TYPE                                         yes            yes           yes                     yes               yes                     yes            yes              yes             yes              |
-| SO\_UPDATE\_ACCEPT\_CONTEXT                      yes            yes           yes                     yes               yes                     yes            yes              yes            |               |
-| SO\_UPDATE\_CONNECT\_CONTEXT                     yes            yes           yes                     yes               yes                     yes           |              |             |               |
+| SO\_SNDTIMEO                                    |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_TYPE                                        |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |yes            |
+| SO\_UPDATE\_ACCEPT\_CONTEXT                     |yes         |yes        |yes                  |yes            |yes                  |yes         |yes           |yes          |               |
+| SO\_UPDATE\_CONNECT\_CONTEXT                    |yes         |yes        |yes                  |yes            |yes                  |yes         |              |             |               |
 | SO\_USELOOPBACK                                 |            |           |                     |               |                     |            |              |             |               |
 
 


### PR DESCRIPTION
Hi,

The faulty formatting of the table made it almost useless, so I fixed it for you! If you don't want to use the column alignment formatting just revert line 80.

Cheers,
  Hans