### PR TITLE
Document RvaBased attribute bit in Delay-Load Directory Table

### DIFF
--- a/desktop-src/Debug/pe-format.md
+++ b/desktop-src/Debug/pe-format.md
@@ -1272,7 +1272,11 @@ The tables that are referenced in this data structure are organized and sorted j
 
 #### Attributes
 
-As yet, no attribute flags are defined. The linker sets this field to zero in the image. This field can be used to extend the record by indicating the presence of new fields, or it can be used to indicate behaviors to the delay or unload helper functions.
+The Windows SDK headers define bit 0 of this field. In `winnt.h`, the field is the **Attributes** member of `IMAGE_DELAYLOAD_DESCRIPTOR`, whose low bit is `RvaBased` (commented "Delay load version 2"). In `delayimp.h`, the field is `grAttrs` of `ImgDelayDescr`, and the bit is the `dlattrRva` flag (value `0x1`), commented "RVAs are used instead of pointers ... Having this set indicates a VC7.0 and above delay load descriptor."
+ 
+When `RvaBased` (`dlattrRva`) is set, the address fields of the delay-load directory table (Name, Module Handle, Delay Import Address Table, Delay Import Name Table, and the optional Bound Delay Import and Unload Delay Import tables) are relative virtual addresses (RVAs), as documented in the preceding table. This is the form emitted by Visual C++ 7.0 and later, and is the form produced by current toolchains.
+ 
+When the bit is clear, the descriptor is the earlier form in which those fields are virtual addresses (pointers) rather than RVAs. The remaining 31 bits of the field are reserved. Consumers should examine this bit to determine how to interpret the descriptor's address fields.
 
 #### Name
 


### PR DESCRIPTION
## Summary

The Attributes subsection of "Delay-Load Import Tables (Image Only)" states that "no attribute flags are defined" and the field "must be zero." However, both current Windows SDK headers define bit 0 of this field, and have since Visual C++ 7.0. This PR updates the Attributes subsection to document the bit, using the headers as the source.

## What changed

The Attributes subsection previously read:

> As yet, no attribute flags are defined. The linker sets this field to zero in the image. [...]

It now documents bit 0 (RvaBased / dlattrRva), what its set and clear states mean for the descriptor's address fields, and that it has been defined since VC7.0. The change is descriptive only; it documents the bit's existence and meaning per the headers, without prescribing parser behaviour.

## Source

winnt.h (Windows SDK 10.0.26100.0) defines the field in IMAGE_DELAYLOAD_DESCRIPTOR:

```c
union {
    DWORD AllAttributes;
    struct {
        DWORD RvaBased : 1;             // Delay load version 2
        DWORD ReservedAttributes : 31;
    } DUMMYSTRUCTNAME;
} Attributes;
```

delayimp.h defines the same field in ImgDelayDescr (grAttrs):

```c
enum DLAttr {
    dlattrRva = 0x1,       // RVAs are used instead of pointers
                           // Having this set indicates a VC7.0
                           // and above delay load descriptor.
};
```

## Related - not addressed in this PR

The Delay-Load Directory Table row for the Attributes field still reads "Must be zero." I've left the table row unchanged in this PR to keep the diff minimal; maintainers may wish to update that row to cross-reference the expanded Attributes subsection.

Two further behaviours in this section are undefined by the current text and are resolved differently by independent PE parsers. I am not proposing edits for these, as they concern format semantics that a specification owner should decide, but I raise them here for awareness:

1. **INT/IAT length authority.** The section states the Delay Import Name Table is "ordered in the same fashion as" the Delay Import Address Table, but does not state which is authoritative for enumerating imports if their lengths differ. Tested parsers diverge (some enumerate from the INT, one from the IAT).

2. **Descriptor array termination.** The section does not state whether the descriptor array is terminated by the directory's declared Size, by a null descriptor, or by whichever comes first. Tested parsers diverge when the declared size ends mid-descriptor with no null terminator.

## Evidence

Controlled single-anomaly test fixtures, byte-level specifications, and recorded per-tool output (dumpbin, Ghidra, pefile, and IOCX) for all three points are available at: https://github.com/malx-labs/pe-delayload-divergence

Fixtures rebuild deterministically and all results reproduce on re-run.

*Disclosure: IOCX is my own tool; its behaviour is reported at the same evidence standard as the other three (direct tool output).*