### PR TITLE
about-cursors, about-icons: improve DPI size tables

### DIFF
--- a/desktop-src/menurc/about-cursors.md
+++ b/desktop-src/menurc/about-cursors.md
@@ -102,19 +102,19 @@ To override the class cursor for a specific window or hit-test area, process the
 
 ## Cursor Sizes
 
-The system reports the nominal cursor size via [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXCURSOR** / **SM\_CYCURSOR**. This is the size of the cursor image buffer; the visible cursor shape is typically smaller due to transparent edges. Unlike icon sizes, cursor sizes change in steps - not every DPI value produces a distinct cursor size. The standard sizes at default cursor size setting are:
+The system reports the nominal cursor size via [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXCURSOR** / **SM\_CYCURSOR**. This is the size of the cursor image buffer; the visible cursor shape is typically smaller due to transparent edges. Unlike icon sizes which scale linearly with DPI, cursor sizes change in discrete steps - a wide range of DPI values maps to the same cursor size. The standard sizes at the default cursor size setting are:
 
-| Display scale | DPI range | SM\_CXCURSOR / SM\_CYCURSOR |
+| DPI range | Display scale | SM\_CXCURSOR / SM\_CYCURSOR |
 |---|---|---|
-| < 150% | < 144 DPI | 32x32 |
-| 150-199% | 144-191 DPI | 48x48 |
-| 200-299% | 192-287 DPI | 64x64 |
-| 300-399% | 288-383 DPI | 96x96 |
-| >= 400% | >= 384 DPI | 128x128 |
+| 96-143 DPI | 100%-149% | 32x32 |
+| 144-191 DPI | 150%-199% | 48x48 |
+| 192-287 DPI | 200%-299% | 64x64 |
+| 288-383 DPI | 300%-399% | 96x96 |
+| >= 384 DPI | >= 400% | 128x128 |
 
 The user can also change the cursor size independently of DPI via **Settings > Accessibility > Mouse pointer and touch > Size**. Always call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXCURSOR** to get the actual effective size rather than assuming a fixed value. In per-monitor DPI-aware applications, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the DPI of the target monitor, which you can obtain with [**GetDpiForWindow**](/windows/win32/api/winuser/nf-winuser-getdpiforwindow) or [**GetDpiForMonitor**](/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor). For more information, see [High DPI Desktop Application Development on Windows](/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
 
-To retrieve the dimensions of a cursor from its handle, see [Getting a Cursor size](/windows/win32/menurc/using-cursors#getting-a-cursor-size).
+To retrieve the dimensions of a cursor from its handle, see [Getting Cursor Size from Handle](/windows/win32/menurc/using-cursors#getting-cursor-size-from-handle).
 
 ## Cursor Location and Appearance
 

--- a/desktop-src/menurc/about-icons.md
+++ b/desktop-src/menurc/about-icons.md
@@ -66,28 +66,28 @@ See [Icon scaling](/windows/apps/design/style/iconography/app-icon-construction#
 
 ### System icon sizes
 
-System icon sizes are reported by [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) and scale with the display DPI.
+System icon sizes are reported by [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) and scale linearly with DPI - unlike cursor sizes, which change in discrete steps.
 
-| Size | Metric | 96 DPI | 150% (144 DPI) | 200% (192 DPI) | Description |
-|---|---|---|---|---|---|
-| System small | **SM\_CXSMICON** / **SM\_CYSMICON** | 16x16 | 24x24 | 32x32 | Menus, notification area, Explorer list view |
-| System large | **SM\_CXICON** / **SM\_CYICON** | 32x32 | 48x48 | 64x64 | ICON\_BIG (WM\_SETICON / WM\_GETICON), Alt+Tab (legacy/fallback) |
+| Size | Metric | 96 DPI (100%) | 384 DPI (400%) | Description |
+|---|---|---|---|---|
+| System small | **SM\_CXSMICON** / **SM\_CYSMICON** | 16x16 | 64x64 | Menus, notification area, Explorer list view |
+| System large | **SM\_CXICON** / **SM\_CYICON** | 32x32 | 128x128 | ICON\_BIG (WM\_SETICON / WM\_GETICON), Alt+Tab (legacy/fallback) |
 
 The [**CreateIconFromResource**](/windows/win32/api/winuser/nf-winuser-createiconfromresource), [**DrawIcon**](/windows/win32/api/winuser/nf-winuser-drawicon), [**ExtractAssociatedIcon**](/windows/win32/api/shellapi/nf-shellapi-extractassociatediconw), [**ExtractIcon**](/windows/win32/api/shellapi/nf-shellapi-extracticonw), [**ExtractIconEx**](/windows/win32/api/shellapi/nf-shellapi-extracticonexw), and [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) functions all use the system large icon size. The [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), [**CreateIconFromResourceEx**](/windows/win32/api/winuser/nf-winuser-createiconfromresourceex), [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect), and [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) functions can work with icons at any size.
 
-To retrieve system icon sizes, call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXSMICON** / **SM\_CYSMICON** for the small size, or **SM\_CXICON** / **SM\_CYICON** for the large size. In per-monitor DPI-aware applications, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the DPI of the target monitor instead, so the returned size reflects the correct display. For more information, see [High DPI Desktop Application Development on Windows](/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
+To retrieve system icon sizes, call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics) with **SM\_CXSMICON** / **SM\_CYSMICON** for the small size, or **SM\_CXICON** / **SM\_CYICON** for the large size. In per-monitor DPI-aware applications, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the DPI of the target monitor instead, so the returned size reflects the correct display. The baseline DPI value of 96 is available as **USER\_DEFAULT\_SCREEN\_DPI** in winuser.h, useful when computing scaled sizes with **MulDiv**. For code examples, see [Getting System Icon Sizes](using-icons.md#getting-system-icon-sizes). For more information, see [High DPI Desktop Application Development on Windows](/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
 
 ### Shell icon sizes
 
 The shell uses a separate set of sizes for Explorer views and the system image lists, accessible via [**SHGetImageList**](/windows/win32/api/shellapi/nf-shellapi-shgetimagelistw). Call **SHGetImageList** with the appropriate **SHIL\_\*** constant, then call [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize) on the returned image list.
 
-| SHIL constant | Source | 96 DPI | 150% (144 DPI) | 200% (192 DPI) | Description |
-|---|---|---|---|---|---|
-| **SHIL\_SMALL** (1) | SM\_CXSMICON | 16x16 | 24x24 | 32x32 | Explorer list/details view, common dialogs, window title bar icon |
-| **SHIL\_SYSSMALL** (3) | SM\_CXSMSIZE | 16x16 | 24x24 | 32x32 | Shell toolbars, status bars; tracks caption button size; equals SHIL\_SMALL at default settings |
-| **SHIL\_LARGE** (0) | SM\_CXICON | 32x32 | 48x48 | 64x64 | Explorer medium icons view, dialogs |
-| **SHIL\_EXTRALARGE** (2) | 48 logical px | 48x48 | 72x72 | 96x96 | Explorer large icons view, desktop |
-| **SHIL\_JUMBO** (4) | fixed 256 px | 256x256 | 256x256 | 256x256 | Explorer extra large icons view (Vista+); always 256 physical pixels |
+| SHIL constant | 96 DPI (100%) | 384 DPI (400%) | Description |
+|---|---|---|---|
+| **SHIL\_SMALL** (1) | 16x16 | 64x64 | Explorer list/details view, common dialogs, window title bar icon |
+| **SHIL\_SYSSMALL** (3) | 16x16 | 64x64 | Shell toolbars, status bars; tracks caption button size; may differ from **SHIL\_SMALL** when the user customizes window border and caption size |
+| **SHIL\_LARGE** (0) | 32x32 | 128x128 | Explorer medium icons view, dialogs |
+| **SHIL\_EXTRALARGE** (2) | 48x48 | 192x192 | Explorer large icons view, desktop |
+| **SHIL\_JUMBO** (4) | 256x256 | 256x256 | Explorer extra large icons view (Vista+); always 256 physical pixels |
 
 ## Icon Creation
 
@@ -107,7 +107,7 @@ To set or update a specific window's icon at run time, send [**WM\_SETICON**](/w
 
 ## Icon Display
 
-You can retrieve the image and size of an icon by using the [**GetIconInfo**](/windows/win32/api/winuser/nf-winuser-geticoninfo) function - see [Getting the Icon size](using-icons.md#getting-the-icon-size) for an example. You can draw the icon by using the [**DrawIconEx**](/windows/win32/api/winuser/nf-winuser-drawiconex) function.
+You can retrieve the image and size of an icon by using the [**GetIconInfo**](/windows/win32/api/winuser/nf-winuser-geticoninfo) function - see [Getting Icon Size from Handle](using-icons.md#getting-icon-size-from-handle) for an example. You can draw the icon by using the [**DrawIconEx**](/windows/win32/api/winuser/nf-winuser-drawiconex) function.
 
 To display an icon in a static control, send [**STM\_SETIMAGE**](/windows/win32/controls/stm-setimage) with **IMAGE\_ICON** and the icon handle:
 

--- a/desktop-src/menurc/using-cursors.md
+++ b/desktop-src/menurc/using-cursors.md
@@ -27,7 +27,7 @@ This section discusses the following topics.
 -   [Creating a Cursor](#creating-a-cursor)
 -   [Using Cursor Functions to Create a Mousetrap](#using-cursor-functions-to-create-a-mousetrap)
 -   [Creating an Alpha Blended Cursor](#creating-an-alpha-blended-cursor)
--   [Getting a Cursor size](#getting-a-cursor-size)
+-   [Getting Cursor Size from Handle](#getting-cursor-size-from-handle)
 -   [Displaying a Cursor](#displaying-a-cursor)
 -   [Confining a Cursor](#confining-a-cursor)
 -   [Using the Keyboard to Move the Cursor](#using-the-keyboard-to-move-the-cursor)
@@ -378,7 +378,7 @@ HCURSOR CreateAlphaCursor(void)
 
 Before closing, you must use the [**DestroyCursor**](/windows/win32/api/winuser/nf-winuser-destroycursor) function to destroy any cursors you created with [**CreateCursor**](/windows/win32/api/winuser/nf-winuser-createcursor) or [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect). It is not necessary to destroy cursors created by other functions.
 
-## Getting a Cursor size
+## Getting Cursor Size from Handle
 
 The following example retrieves the dimensions of a cursor or icon from its handle:
 

--- a/desktop-src/menurc/using-icons.md
+++ b/desktop-src/menurc/using-icons.md
@@ -19,7 +19,8 @@ ms.date: 05/31/2018
 The following topics describe how to perform certain tasks related to icons:
 
 -   [Creating an Icon](#creating-an-icon)
--   [Getting the Icon size](#getting-the-icon-size)
+-   [Getting System Icon Sizes](#getting-system-icon-sizes)
+-   [Getting Icon Size from Handle](#getting-icon-size-from-handle)
 -   [Displaying an Icon](#displaying-an-icon)
 -   [Sharing Icon Resources](#sharing-icon-resources)
 
@@ -40,9 +41,54 @@ To create an alpha blended icon at run time, see [Creating an Alpha Blended Curs
 
 Before closing, your application must use [**DestroyIcon**](/windows/win32/api/winuser/nf-winuser-destroyicon) to destroy any icon obtained from [**CreateIcon**](/windows/win32/api/winuser/nf-winuser-createicon), [**CreateIconIndirect**](/windows/win32/api/winuser/nf-winuser-createiconindirect), or [**LoadImage**](/windows/win32/api/winuser/nf-winuser-loadimagew) without the `LR_SHARED` flag. Icons loaded with [**LoadIcon**](/windows/win32/api/winuser/nf-winuser-loadiconw) or `LoadImage` with `LR_SHARED` are shared system resources and must not be destroyed.
 
-## Getting the Icon size
+## Getting System Icon Sizes
 
-See [Getting a Cursor size](/windows/win32/menurc/using-cursors#getting-a-cursor-size). The example works identically for icons — pass an `HICON` in place of `HCURSOR`.
+To retrieve the system icon sizes at the system DPI, call [**GetSystemMetrics**](/windows/win32/api/winuser/nf-winuser-getsystemmetrics):
+
+```c
+int cxSmall = GetSystemMetrics(SM_CXSMICON);
+int cySmall = GetSystemMetrics(SM_CYSMICON);
+
+int cxLarge = GetSystemMetrics(SM_CXICON);
+int cyLarge = GetSystemMetrics(SM_CYICON);
+```
+
+In per-monitor DPI-aware applications these values reflect the system DPI. Use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the target monitor's DPI instead. Obtain the DPI from a window handle with [**GetDpiForWindow**](/windows/win32/api/winuser/nf-winuser-getdpiforwindow), or from a monitor handle with [**GetDpiForMonitor**](/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor):
+
+```c
+// Option A: From a window handle:
+UINT dpi = GetDpiForWindow(hwnd);
+
+// Option B: From a monitor handle:
+UINT dpiX, dpiY;
+GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+UINT dpi = dpiX;
+
+// Compute icon sizes for that DPI:
+int cx   = GetSystemMetricsForDpi(SM_CXICON,   dpi);
+int cy   = GetSystemMetricsForDpi(SM_CYICON,   dpi);
+int cxSm = GetSystemMetricsForDpi(SM_CXSMICON, dpi);
+int cySm = GetSystemMetricsForDpi(SM_CYSMICON, dpi);
+```
+
+To retrieve the size of a shell image list, call [**SHGetImageList**](/windows/win32/api/shellapi/nf-shellapi-shgetimagelistw) and then [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize):
+
+```c
+IImageList *pImgList;
+HRESULT hr = SHGetImageList(SHIL_LARGE, IID_PPV_ARGS(&pImgList));
+if (SUCCEEDED(hr))
+{
+    int cx, cy;
+    ImageList_GetIconSize((HIMAGELIST)pImgList, &cx, &cy);
+    pImgList->Release();
+}
+```
+
+Shell image lists are process-wide singletons sized to the system DPI at shell initialization time; their size does not change when windows move between monitors. For per-monitor icon sizes, use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) directly.
+
+## Getting Icon Size from Handle
+
+See [Getting Cursor Size from Handle](/windows/win32/menurc/using-cursors#getting-cursor-size-from-handle). The example works identically for icons — pass an `HICON` in place of `HCURSOR`.
 
 ## Displaying an Icon
 

--- a/desktop-src/menurc/using-icons.md
+++ b/desktop-src/menurc/using-icons.md
@@ -53,7 +53,7 @@ int cxLarge = GetSystemMetrics(SM_CXICON);
 int cyLarge = GetSystemMetrics(SM_CYICON);
 ```
 
-In per-monitor DPI-aware applications these values reflect the system DPI. Use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the target monitor's DPI instead. Obtain the DPI from a window handle with [**GetDpiForWindow**](/windows/win32/api/winuser/nf-winuser-getdpiforwindow), or from a monitor handle with [**GetDpiForMonitor**](/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor):
+In per-monitor DPI-aware applications, these values reflect the system DPI. Use [**GetSystemMetricsForDpi**](/windows/win32/api/winuser/nf-winuser-getsystemmetricsfordpi) with the target monitor's DPI instead. Obtain the DPI from a window handle with [**GetDpiForWindow**](/windows/win32/api/winuser/nf-winuser-getdpiforwindow), or from a monitor handle with [**GetDpiForMonitor**](/windows/win32/api/shellscalingapi/nf-shellscalingapi-getdpiformonitor):
 
 ```c
 // Option A: From a window handle:
@@ -71,15 +71,15 @@ int cxSm = GetSystemMetricsForDpi(SM_CXSMICON, dpi);
 int cySm = GetSystemMetricsForDpi(SM_CYSMICON, dpi);
 ```
 
-To retrieve the size of a shell image list, call [**SHGetImageList**](/windows/win32/api/shellapi/nf-shellapi-shgetimagelistw) and then [**ImageList\_GetIconSize**](/windows/win32/api/commctrl/nf-commctrl-imagelist_geticonsize):
+To retrieve the size of a shell image list, call [**SHGetImageList**](/windows/win32/api/shellapi/nf-shellapi-shgetimagelistw) and then [**IImageList::GetIconSize**](/windows/win32/api/commoncontrols/nf-commoncontrols-iimagelist-geticonsize):
 
-```c
+```cpp
 IImageList *pImgList;
 HRESULT hr = SHGetImageList(SHIL_LARGE, IID_PPV_ARGS(&pImgList));
 if (SUCCEEDED(hr))
 {
     int cx, cy;
-    ImageList_GetIconSize((HIMAGELIST)pImgList, &cx, &cy);
+    pImgList->GetIconSize(&cx, &cy);
     pImgList->Release();
 }
 ```


### PR DESCRIPTION
- Cursor Sizes: put DPI range first, add lower bound (96 DPI), clarify discrete vs linear scaling
- System icon sizes: show 96/384 DPI endpoints instead of three snapshots
- Shell icon sizes: same endpoints, remove Source column
- Cross-link: note icon sizes scale linearly, cursor sizes in discrete steps
- Mention USER_DEFAULT_SCREEN_DPI