### PR TITLE
Remove erroneous header reference in IncrementCounter

### DIFF
--- a/desktop-src/direct3dhlsl/sm5-object-rwstructuredbuffer-incrementcounter.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwstructuredbuffer-incrementcounter.md
@@ -1,5 +1,5 @@
 ---
-title: RWStructuredBuffer::IncrementCounter function (Httpserv.h)
+title: RWStructuredBuffer::IncrementCounter function
 description: Increments the object's hidden counter.
 ms.assetid: 66385d4f-6db8-49ae-a73a-49089695f5ee
 keywords:


### PR DESCRIPTION
Remove erroneous reference to httpserv.h in RWStructuredBuffer IncrementCounter. It was likely copied there from another page used as a template. This header has nothing to do with HLSL shaders.