### PR TITLE
Remove erroneous header reference in DecrementCounter

### DIFF
--- a/desktop-src/direct3dhlsl/sm5-object-rwstructuredbuffer-decrementcounter.md
+++ b/desktop-src/direct3dhlsl/sm5-object-rwstructuredbuffer-decrementcounter.md
@@ -1,5 +1,5 @@
 ---
-title: RWStructuredBuffer::DecrementCounter function (Httpserv.h)
+title: RWStructuredBuffer::DecrementCounter function
 description: Decrements the object's hidden counter.
 ms.assetid: 24bc0b63-a482-4fa5-9898-2d43bca20cf4
 keywords:
@@ -8,8 +8,6 @@ topic_type:
 - apiref
 api_name:
 - DecrementCounter
-api_location:
-- httpserv.h
 api_type:
 - HeaderDef
 ms.topic: reference


### PR DESCRIPTION
Remove erroneous reference to httpserv.h in RWStructuredBuffer DecrementCounter. It was likely copied there from another page used as a template. This header has nothing to do with HLSL shaders.