### PR TITLE
[HLSL] Update Shader Model 6.0 Documentation

### DIFF
--- a/desktop-src/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12.md
+++ b/desktop-src/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12.md
@@ -128,14 +128,14 @@ v
 Y 
 
 
-In shader model 6.0, these routines are available only in pixel shaders. They should be used on waves captured by WaveQuadLanes; otherwise, results are undefined. Starting with shader model 6.6, these routines are also available in compute, amplification, and mesh shaders, where they operate in quads defined by the shader's thread-group dimensions.
+In shader model 6.0, these routines are available in pixel and compute shaders. In pixel shaders, they should be used on waves captured by WaveQuadLanes; otherwise, results are undefined. In compute shaders targeting shader model 6.0 through 6.5, the mapping of threads to quads is implementation-dependent. Shader model 6.6 defines the quad layout in terms of the shader's thread-group dimensions and adds support for these routines in amplification and mesh shaders.
 
 | **Intrinsic** | **Description** | **Pixel shader** | **Compute shader** | **Amplification shader** | **Mesh shader** |
 |-|-|-|-|-|-|
-| [**QuadReadLaneAt**](quadreadlaneat.md) | Returns the specified source value read from the lane of the current quad identified by quadLaneID \[0..3\] which must be uniform across the quad. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
-| [**QuadReadAcrossDiagonal**](quadreadacrossdiagonal.md) | Returns the specified local value which is read from the diagonally opposite lane in this quad. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
-| [**QuadReadAcrossX**](quadswapx.md) | Returns the specified source value read from the other lane in this quad in the X direction. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
-| [**QuadReadAcrossY**](quadswapy.md) | Returns the specified source value read from the other lane in this quad in the Y direction. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadLaneAt**](quadreadlaneat.md) | Returns the specified source value read from the lane of the current quad identified by quadLaneID \[0..3\] which must be uniform across the quad. | \* | \* | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossDiagonal**](quadreadacrossdiagonal.md) | Returns the specified local value which is read from the diagonally opposite lane in this quad. | \* | \* | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossX**](quadswapx.md) | Returns the specified source value read from the other lane in this quad in the X direction. | \* | \* | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossY**](quadswapy.md) | Returns the specified source value read from the other lane in this quad in the Y direction. | \* | \* | Requires SM 6.6 | Requires SM 6.6 |
 
 ## Hardware capability
 

--- a/desktop-src/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12.md
+++ b/desktop-src/direct3dhlsl/hlsl-shader-model-6-0-features-for-direct3d-12.md
@@ -76,7 +76,7 @@ This set of intrinsics compare values across threads currently active from the c
 |-|-|-|-|
 | [**WaveActiveAnyTrue**](waveanytrue.md) | Returns true if the expression is true in any active lane in the current wave. | \* | \* |
 | [**WaveActiveAllTrue**](wavealltrue.md) | Returns true if the expression is true in all active lanes in the current wave. | \* | \* |
-| [**WaveActiveBallot**](waveballot.md) | Returns a 64-bit unsigned integer bitmask of the evaluation of the Boolean expression for all active lanes in the specified wave. | \* | \* |
+| [**WaveActiveBallot**](waveballot.md) | Returns a `uint4` containing a bitmask of the evaluation of the Boolean expression for all active lanes in the current wave. | \* | \* |
 
 ### Wave Broadcast
 
@@ -101,7 +101,7 @@ These intrinsics compute the specified operation across all active lanes in the 
 | [**WaveActiveMax**](waveallmax.md) | Computes the maximum value of the expression across all active lanes in the current wave, and replicates the result to all lanes in the wave. | \* | \* |
 | [**WaveActiveMin**](waveallmin.md) | Computes the minimum value of the expression across all active lanes in the current wave, and replicates the result to all lanes in the wave. | \* | \* |
 | [**WaveActiveProduct**](waveallproduct.md) | Multiplies the values of the expression together across all active lanes in the current wave, and replicates the result to all lanes in the wave. | \* | \* |
-| [**WaveActiveSum**](waveallsum.md) | Sums up the value of the expression across all active lanes in the current wave and replicates it to all lanes in the current wave, and replicates the result to all lanes in the wave. | \* | \* |
+| [**WaveActiveSum**](waveallsum.md) | Sums the values of the expression across all active lanes in the current wave and replicates the result to all active lanes. | \* | \* |
 
 ### Wave Scan and Prefix
 
@@ -128,14 +128,14 @@ v
 Y 
 
 
-These routines work in either compute shaders or pixel shaders. In compute shaders they operate in quads defined as evenly divided groups of 4 within an SIMD wave. In pixel shaders they should be used on waves captured by WaveQuadLanes, otherwise results are undefined.
+In shader model 6.0, these routines are available only in pixel shaders. They should be used on waves captured by WaveQuadLanes; otherwise, results are undefined. Starting with shader model 6.6, these routines are also available in compute, amplification, and mesh shaders, where they operate in quads defined by the shader's thread-group dimensions.
 
-| **Intrinsic** | **Description** | **Pixel shader** | **Compute shader** |
-|-|-|-|-|
-| [**QuadReadLaneAt**](quadreadlaneat.md) | Returns the specified source value read from the lane of the current quad identified by quadLaneID \[0..3\] which must be uniform across the quad. | \* | |
-| [**QuadReadAcrossDiagonal**](quadreadacrossdiagonal.md) | Returns the specified local value which is read from the diagonally opposite lane in this quad. | \* | |
-| [**QuadReadAcrossX**](quadswapx.md) | Returns the specified source value read from the other lane in this quad in the X direction. | \* | |
-| [**QuadReadAcrossY**](quadswapy.md) | Returns the specified source value read from the other lane in this quad in the Y direction. | \* | |
+| **Intrinsic** | **Description** | **Pixel shader** | **Compute shader** | **Amplification shader** | **Mesh shader** |
+|-|-|-|-|-|-|
+| [**QuadReadLaneAt**](quadreadlaneat.md) | Returns the specified source value read from the lane of the current quad identified by quadLaneID \[0..3\] which must be uniform across the quad. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossDiagonal**](quadreadacrossdiagonal.md) | Returns the specified local value which is read from the diagonally opposite lane in this quad. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossX**](quadswapx.md) | Returns the specified source value read from the other lane in this quad in the X direction. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
+| [**QuadReadAcrossY**](quadswapy.md) | Returns the specified source value read from the other lane in this quad in the Y direction. | \* | Requires SM 6.6 | Requires SM 6.6 | Requires SM 6.6 |
 
 ## Hardware capability
 

--- a/desktop-src/direct3dhlsl/quadreadacrossdiagonal.md
+++ b/desktop-src/direct3dhlsl/quadreadacrossdiagonal.md
@@ -49,7 +49,7 @@ The specified local value which is read from the diagonally opposite lane in thi
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
+This function is supported in pixel and compute shaders starting with shader model 6.0. In compute shaders targeting shader model 6.0 through 6.5, the mapping of threads to quads is implementation-dependent. Shader model 6.6 defines the quad layout for compute shaders and adds support for this function in amplification and mesh shaders.
 
 
 

--- a/desktop-src/direct3dhlsl/quadreadacrossdiagonal.md
+++ b/desktop-src/direct3dhlsl/quadreadacrossdiagonal.md
@@ -49,7 +49,7 @@ The specified local value which is read from the diagonally opposite lane in thi
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported from shader model 6.0 only in pixel and compute shaders.
+This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
 
 
 

--- a/desktop-src/direct3dhlsl/quadreadlaneat.md
+++ b/desktop-src/direct3dhlsl/quadreadlaneat.md
@@ -45,19 +45,19 @@ The requested type.
 *quadLaneID* 
 </dt> <dd>
 
-The lane ID; this will be a value from 0 to 3.
+The lane ID, in the range 0 through 3. The value must be uniform across the quad.
 
 </dd> </dl>
 
 ## Return value
 
-The specified source value. The result of this function is uniform across the quad. If the source lane is inactive, the results are undefined.
+The value of *sourceValue* from the selected lane. The result is uniform across the quad. If *quadLaneID* is not uniform across the quad, or if the selected source lane is inactive, the result is undefined.
 
 ## Remarks
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported from shader model 6.0 only in pixel and compute shaders.
+This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
 
 
 

--- a/desktop-src/direct3dhlsl/quadreadlaneat.md
+++ b/desktop-src/direct3dhlsl/quadreadlaneat.md
@@ -45,13 +45,13 @@ The requested type.
 *quadLaneID* 
 </dt> <dd>
 
-The lane ID, in the range 0 through 3. The value must be uniform across the quad.
+The lane ID, in the range 0 through 3.
 
 </dd> </dl>
 
 ## Return value
 
-The value of *sourceValue* from the selected lane. The result is uniform across the quad. If *quadLaneID* is not uniform across the quad, or if the selected source lane is inactive, the result is undefined.
+The value of *sourceValue* from the selected lane. If the selected source lane is inactive, the result is undefined.
 
 ## Remarks
 

--- a/desktop-src/direct3dhlsl/quadreadlaneat.md
+++ b/desktop-src/direct3dhlsl/quadreadlaneat.md
@@ -57,7 +57,7 @@ The value of *sourceValue* from the selected lane. The result is uniform across 
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
+This function is supported in pixel and compute shaders starting with shader model 6.0. In compute shaders targeting shader model 6.0 through 6.5, the mapping of threads to quads is implementation-dependent. Shader model 6.6 defines the quad layout for compute shaders and adds support for this function in amplification and mesh shaders.
 
 
 

--- a/desktop-src/direct3dhlsl/quadswapx.md
+++ b/desktop-src/direct3dhlsl/quadswapx.md
@@ -46,7 +46,7 @@ The specified local value. If the source lane is inactive, the results are undef
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
+This function is supported in pixel and compute shaders starting with shader model 6.0. In compute shaders targeting shader model 6.0 through 6.5, the mapping of threads to quads is implementation-dependent. Shader model 6.6 defines the quad layout for compute shaders and adds support for this function in amplification and mesh shaders.
 
 
 

--- a/desktop-src/direct3dhlsl/quadswapx.md
+++ b/desktop-src/direct3dhlsl/quadswapx.md
@@ -46,7 +46,7 @@ The specified local value. If the source lane is inactive, the results are undef
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported from shader model 6.0 only in pixel and compute shaders.
+This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
 
 
 

--- a/desktop-src/direct3dhlsl/quadswapy.md
+++ b/desktop-src/direct3dhlsl/quadswapy.md
@@ -46,7 +46,7 @@ The specified source value. If the source lane is inactive, the results are unde
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
+This function is supported in pixel and compute shaders starting with shader model 6.0. In compute shaders targeting shader model 6.0 through 6.5, the mapping of threads to quads is implementation-dependent. Shader model 6.6 defines the quad layout for compute shaders and adds support for this function in amplification and mesh shaders.
 
 
 

--- a/desktop-src/direct3dhlsl/quadswapy.md
+++ b/desktop-src/direct3dhlsl/quadswapy.md
@@ -46,7 +46,7 @@ The specified source value. If the source lane is inactive, the results are unde
 
 For more information on quads, refer to [Overview of Shader Model 6](hlsl-shader-model-6-0-features-for-direct3d-12.md).
 
-This function is supported from shader model 6.0 only in pixel and compute shaders.
+This function is supported in pixel shaders starting with shader model 6.0. It is supported in compute, amplification, and mesh shaders starting with shader model 6.6.
 
 
 

--- a/desktop-src/direct3dhlsl/shader-model-6-0.md
+++ b/desktop-src/direct3dhlsl/shader-model-6-0.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Shader Model 6
 
-All non-quad related Wave Intrinsics are available in all shader stages. Quad wave intrinsics are available only in pixel and compute shaders.
+All non-quad-related wave intrinsics are available in all shader stages. In shader model 6.0, quad wave intrinsics are available only in pixel shaders. Quad wave intrinsics are also available in compute, amplification, and mesh shaders starting with shader model 6.6.
 
 ## In this section
 
@@ -26,12 +26,12 @@ All non-quad related Wave Intrinsics are available in all shader stages. Quad wa
 | [**WaveActiveBitXor**](waveallbitxor.md)<br/>                  | Returns the bitwise XOR of all the values of the expression across all active lanes in the current wave and replicates it back to all active lanes. <br/>           |
 | [**WaveActiveCountBits**](waveactivecountbits.md)<br/>         | Counts the number of boolean variables which evaluate to true across all active lanes in the current wave, and replicates the result to all lanes in the wave.<br/> |
 | [**WaveActiveMax**](waveallmax.md)<br/>                        | Returns the maximum value of the expression across all active lanes in the current wave and replicates it back to all active lanes. <br/>                           |
-| [**WaveActiveMin**](waveallmin.md)<br/>                        | Returns the minimum value of the expression across all active lanes in the current wave replicates it back to all active lanes. <br/>                               |
+| [**WaveActiveMin**](waveallmin.md)<br/>                        | Returns the minimum value of the expression across all active lanes in the current wave and replicates it back to all active lanes. <br/>                           |
 | [**WaveActiveProduct**](waveallproduct.md)<br/>                | Multiplies the values of the expression together across all active lanes in the current wave and replicates it back to all active lanes.<br/>                       |
 | [**WaveActiveSum**](waveallsum.md)<br/>                        | Sums up the value of the expression across all active lanes in the current wave and replicates it to all lanes in the current wave.<br/>                            |
 | [**WaveActiveAllTrue**](wavealltrue.md)<br/>                   | Returns true if the expression is true in all active lanes in the current wave.<br/>                                                                                |
 | [**WaveActiveAnyTrue**](waveanytrue.md)<br/>                   | Returns true if the expression is true in any of the active lanes in the current wave.<br/>                                                                         |
-| [**WaveActiveBallot**](waveballot.md)<br/>                     | Returns a 4-bit unsigned integer bitmask of the evaluation of the Boolean expression for all active lanes in the specified wave. <br/>                              |
+| [**WaveActiveBallot**](waveballot.md)<br/>                     | Returns a `uint4` containing a bitmask of the evaluation of the Boolean expression for all active lanes in the current wave. <br/>                                  |
 | [**WaveGetLaneCount**](wavegetlanecount.md)<br/>               | Returns the number of lanes in a wave on this architecture. <br/>                                                                                                   |
 | [**WaveGetLaneIndex**](wavegetlaneindex.md)<br/>               | Returns the index of the current lane within the current wave. <br/>                                                                                                |
 | [**WaveIsFirstLane**](waveisfirstlane.md)<br/>                 | Returns true only for the active lane in the current wave with the smallest index. <br/>                                                                            |

--- a/desktop-src/direct3dhlsl/shader-model-6-0.md
+++ b/desktop-src/direct3dhlsl/shader-model-6-0.md
@@ -8,7 +8,7 @@ ms.date: 05/31/2018
 
 # Shader Model 6
 
-All non-quad-related wave intrinsics are available in all shader stages. In shader model 6.0, quad wave intrinsics are available only in pixel shaders. Quad wave intrinsics are also available in compute, amplification, and mesh shaders starting with shader model 6.6.
+All non-quad-related wave intrinsics are available in all shader stages. In shader model 6.0, quad wave intrinsics are available in pixel and compute shaders, but the quad layout in compute shaders isn't defined. Shader model 6.6 defines the quad layout for compute shaders and adds support for quad wave intrinsics in amplification and mesh shaders.
 
 ## In this section
 

--- a/desktop-src/direct3dhlsl/waveactivecountbits.md
+++ b/desktop-src/direct3dhlsl/waveactivecountbits.md
@@ -55,10 +55,10 @@ This function is supported from shader model 6.0 in all shader stages.
 
 ## Examples
 
-This can be implemented more efficiently than a full WaveActiveSum, as described in the following example:
+The following example counts the active lanes for which `bBit` is true:
 
-``` syntax
-result = WaveActiveCountBits( WaveActiveBallot( bBit ) );
+```hlsl
+uint result = WaveActiveCountBits(bBit);
 ```
 
 ## See also

--- a/desktop-src/direct3dhlsl/waveallmin.md
+++ b/desktop-src/direct3dhlsl/waveallmin.md
@@ -1,6 +1,6 @@
 ---
 title: WaveActiveMin function
-description: Returns the minimum value of the expression across all active lanes in the current wave replicates it back to all active lanes.
+description: Returns the minimum value of the expression across all active lanes in the current wave and replicates it back to all active lanes.
 ms.assetid: BA762C02-894C-4AF9-A226-C1E3AAC286FF
 keywords:
 - WaveActiveMin function HLSL
@@ -17,7 +17,7 @@ api_location:
 
 # WaveActiveMin function
 
-Returns the minimum value of the expression across all active lanes in the current wave replicates it back to all active lanes.
+Returns the minimum value of the expression across all active lanes in the current wave and replicates it back to all active lanes.
 
 ## Syntax
 

--- a/desktop-src/direct3dhlsl/wavegetlanecount.md
+++ b/desktop-src/direct3dhlsl/wavegetlanecount.md
@@ -31,7 +31,7 @@ This function has no parameters.
 
 ## Return value
 
-The result will be between 4 and 128, and includes all waves: active, inactive, and/or helper lanes. The result returned from this function may vary significantly depending on the driver implementation.
+The number of lanes in the current wave. The result is between 4 and 128 and includes active, inactive, and helper lanes. The returned value can vary depending on the driver implementation.
 
 ## Remarks
 

--- a/desktop-src/direct3dhlsl/wavegetlaneindex.md
+++ b/desktop-src/direct3dhlsl/wavegetlaneindex.md
@@ -31,7 +31,7 @@ This function has no parameters.
 
 ## Return value
 
-The current lane index. The result will be between 0 and the result returned from [**WaveGetLaneCount**](wavegetlanecount.md).
+The index of the current lane. The result is greater than or equal to zero and less than the value returned by [**WaveGetLaneCount**](wavegetlanecount.md).
 
 ## Remarks
 

--- a/desktop-src/direct3dhlsl/waveprefixcountbytes.md
+++ b/desktop-src/direct3dhlsl/waveprefixcountbytes.md
@@ -70,9 +70,11 @@ if ( WaveIsFirstLane () )
     // and keeps the output data for each lane in this wave together in the output buffer
     InterlockedAdd(bufferSize, appendCount, appendOffset);
 }
-appendOffset = WaveReadLaneFirst( appendOffset ); // broadcast value
-appendOffset += laneAppendOffset; // and add in the offset for this lane
-buffer[appendOffset] = myData; // write to the offset location for this lane
+appendOffset = WaveReadLaneFirst(appendOffset); // broadcast value
+if (bDoesThisLaneHaveAnAppendItem)
+{
+  buffer[appendOffset + laneAppendOffset] = myData;
+}
 ```
 
 ## See also


### PR DESCRIPTION
This update corrects a number of inconsistencies and errors across the SM 6.0 documentation including updating the language around Quad operations to capture the changes introduced in SM 6.6 where quad operations become available in compute, mesh, and amplification shaders.

Assisted-by: GitHub Copilot