### PR TITLE
Edit CS reason

### DIFF
--- a/desktop-src/ProcThread/context-switches.md
+++ b/desktop-src/ProcThread/context-switches.md
@@ -25,7 +25,7 @@ Until threads that are suspended or blocked become ready to run, the scheduler d
 
 The most common reasons for a context switch are:
 
--   The time slice has elapsed.
+-   The quantum of a thread expired, and another thread with at least the same priority is ready
 -   A thread with a higher priority has become ready to run.
 -   A running thread needs to wait.
 


### PR DESCRIPTION
A time slice (quantum) expiring doesn't by itself cause a context switch, in `KiQuantumEnd`, the block including the only `KiSwapContext` call only runs when `NextThread` is set:

```c
NextThread = CurrentPrcb->NextThread;
if ( NextThread )
{
```
```c
result = KiSwapContext(v72, NextThread, v103);
```

Means if no other thread is selected, `NextThread` remains null and `KiQuantumEnd` returns without switching.