### PR TITLE
Update API set conceptual topics for Named Groups and current loader behavior

### DIFF
--- a/desktop-src/apiindex/api-set-loader-operation.md
+++ b/desktop-src/apiindex/api-set-loader-operation.md
@@ -1,8 +1,8 @@
 ---
-description: Describes how Windows uses API sets in loader operations. 
+description: Describes how the Windows library loader resolves an API set reference to the binary that hosts the implementation.
 title: API set loader operation
 ms.topic: reference
-ms.date: 05/31/2023
+ms.date: 09/03/2026
 ---
 
 # API set loader operation
@@ -10,44 +10,119 @@ ms.date: 05/31/2023
 > [!IMPORTANT]
 > The info in this topic applies to all versions of Windows 10, and later. We'll refer to those versions here as "Windows", calling out any exceptions where necessary.
 
-[API sets](windows-apisets.md) rely on OS support in the library loader to effectively introduce a module namespace redirection into the library binding process. The [API set contract name](windows-apisets.md#api-set-contract-names) is used by library loader to perform a runtime redirection of the reference to a target host binary that houses the appropriate implementation of the API set.
+[API sets](windows-apisets.md) rely on OS support in the library loader to introduce a module namespace redirection into the library binding process. An [API set contract name](windows-apisets.md#api-set-contract-names) doesn't name a file. The loader performs a run-time redirection from that contract name to the host binary that contains the implementation.
 
-When the loader encounters a dependency on an API set at run time, the loader consults configuration data in the image to identify the host binary for an API set. This configuration data is called the **API set schema**. The schema is assembled as a property of the OS, and the mapping between API sets and binaries may differ depending on which binaries are included in a given device. The schema enables an imported function in a single binary to be routed correctly on different devices, even if the module names of the binary host have been renamed or completely refactored on different Windows devices.
+When the loader encounters a dependency on an API set at run time, it consults configuration data in the image to identify the host binary for that API set. This configuration data is called the **API set schema**. The schema is assembled as a property of the OS, and the mapping between API sets and binaries can differ depending on which binaries are included on a given device. The schema is what lets an imported function in a single binary be routed correctly on different devices, even when the module that hosts the implementation has been renamed, split apart, or refactored.
 
-Windows supports two standard techniques to consume and interface with API sets: **direct forwarding** and **reverse forwarding**.
+## How imports reach an implementation
 
-### Direct forwarding
+A binary can reach an API set implementation in two ways, decided by the name in its import table:
 
-In this configuration, the consuming code imports an API set module name directly. This import is resolved in a single operation, and is the most efficient method with the least overhead. Conceptually, this resolution may point to different binaries on different Windows devices, as is shown in the following example:
+- **Direct API set import.** The binary imports an API set contract name. The loader resolves that name through the API set schema to the host binary on the current device.
+- **Legacy module import.** The binary imports a legacy Windows module name, such as *samplefeature.dll*. On an edition that ships that module, the loader binds to it directly. On an edition that has replaced it, a *reverse forwarder* carrying the same name redirects the import to an API set, which the loader then resolves through the schema.
 
-Imported API set: **api-feature1-l1-1-0.dll**
--  Windows PC -> **feature1.dll**
--  HoloLens -> **feature1_holo.dll**
--  IoT -> **feature1_iot.dll**
+Which of those names ends up in your import table is usually determined by the library you link against rather than by the source you write. See [Windows umbrella libraries](windows-umbrella-libraries.md).
 
-Because the mappings are kept in a custom schema data repository, it means that an API set name that ends with **.dll** does not directly refer to a file on disk. The **.dll** part of the API set name is only a convention required by the loader. The API set name is more like an alias or a virtual name for a physical DLL file. This makes the name portable across the entire range of Windows devices.
+Prefer the API set contract name for code that targets current versions of Windows. The loader resolves it straight to the host, with no forwarder in between. Import the legacy module name when you need a single binary that also runs on Windows versions released before the API set existed. Reverse forwarding keeps that binary working on editions where the legacy module has been replaced.
 
-### Reverse forwarding
+## Direct API set import
 
-While API set names provide a stable namespace for modules across devices, it is not always practical to convert every binary to this new system. For example, an application may have been in common use for many years, and recompiling the application's binaries may not be feasible. Additionally, some applications may need to continue to run on systems built before specific API sets were introduced.
+Resolution is a three-step sequence:
 
-To accommodate this level of compatibility, a system of *forwarders* are provided on all Windows devices that cover a subset of the Win32 API surface. These forwarders use the module names that were introduced on Windows PCs, and leverage the API Set system to provide compatibility across all Windows devices.
+1. Your binary imports an API set contract name, or passes one to [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw).
+2. The loader looks the contract up in the API set schema on the current device, and finds the host binary that the schema maps it to.
+3. The loader loads that host binary and binds the imported function to the host's export.
+
+Because the mapping lives in the schema rather than in the file system, the same import can resolve to different binaries on different devices:
+
+| Device | `api-win-core-samplefeature` maps to |
+|---|---|
+| A device that includes the feature | *samplefeature.dll* |
+| A device that ships a refactored implementation | *samplefeaturecore.dll* |
+| A device that doesn't include the feature | Not mapped |
+
+The `samplefeature` names used here are illustrative names for a fictional Windows component.
+
+The consuming binary is unaware of which host it was bound to. That's the point of the mechanism: the contract is stable, while the module that implements it is free to change from one device to the next.
+
+An import of a contract name is resolved in a single operation, with no intermediate forwarder module involved. It's the most efficient form, and the normal path for code written against API sets.
+
+### API set names and the .dll suffix
+
+Because the mappings are kept in the schema rather than on disk, an API set name that ends with **.dll** doesn't refer to a file of that name. The **.dll** part is only a convention required by the loader. The API set name is more like an alias, or a virtual name, for a physical DLL file.
+
+The loader resolves both forms of contract name, a versioned contract name and a contract alias, through the same schema, and both take the **.dll** suffix in a loader operation. For the conventions that govern these names, see [API set contract names](windows-apisets.md#api-set-contract-names).
+
+### Name stability isn't the same as availability
+
+An API set name is stable across Windows devices, in the sense that the same name always identifies the same contract wherever it's recognized. That's a property of the namespace, not a guarantee about any particular device.
+
+A given contract can be absent from a device, or present but not mapped to a host. Nothing about the name tells you which. To find out whether the implementation is actually there, see [Detect API set availability](detect-api-set-availability.md).
+
+## What resolution requires
+
+For a call through an API set to reach an implementation, all of the following have to hold:
+
+- The contract is present in the schema on the current device.
+- The schema maps the contract to a host binary, and that host can be loaded.
+- The host exports the specific function your binary is calling.
+
+When one of those doesn't hold, where the failure surfaces depends on how you imported the API set:
+
+| Import style | Behavior when the contract can't be resolved |
+|---|---|
+| Static import | The process fails to start. The loader resolves static imports before any of your code runs. |
+| Delay-loaded import | The process starts normally. Resolution is deferred to the first call to the API, where your code can handle the failure. |
+
+A missing export is reported separately from a missing contract; a binary that imports a function the host doesn't export fails with a missing entry point error.
+
+## What a successful load doesn't tell you
+
+Resolution binds a *contract* to a host. It doesn't evaluate the state of an individual capability within that contract.
+
+A contract can organize its individually available capabilities into [named groups](windows-apisets.md#api-set-contract-names). A group can be unavailable on a device even though the contract that carries it resolves normally, because the loader binds at contract granularity and doesn't consult group state when it binds. That's deliberate: refusing to bind a host is fatal to a static import, so the loader takes the permissive path and leaves the finer question to the caller.
+
+The consequence for your code is that a successful load, or a successful **LoadLibrary** call, isn't evidence that a particular capability is available. Ask that question explicitly with an availability query. See [Detect API set availability](detect-api-set-availability.md).
+
+## Optional API sets and delay loading
+
+If your application calls an API set that might not be present, an availability check on its own isn't enough: with a static import the process fails to start, so execution never reaches the check.
+
+To keep the optional code path reachable, either configure the module that carries the optional API for [delay loading](/cpp/build/reference/linker-support-for-delay-loaded-dlls), or resolve the target dynamically with **LoadLibrary** and [GetProcAddress](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress) after an availability query succeeds. For the details of both approaches, see [Detect API set availability](detect-api-set-availability.md).
+
+## Reverse forwarding
+
+While API set names provide a stable namespace for modules across devices, it isn't always practical to convert every binary to this system. An application might have been in common use for many years, and recompiling its binaries might not be feasible. Some applications also need to keep running on systems that were built before specific API sets were introduced.
+
+To accommodate that, editions that don't carry the original modules include a set of *reverse forwarders*: compatibility binaries that carry the module names originally introduced on Windows PCs, and that redirect their exports to API sets.
+
+A full desktop edition ships the original modules, so an import of a legacy module name binds to the module as it always has. On an edition that has replaced that module, the reverse forwarder carrying the same name covers the gap.
 
 The loader operation behaves like this:
 
-1.  On a device other than a Windows PC, the loader is presented a legacy Windows PC module name dependency that is not present on the device.
-2.  The loader locates an API set forwarder for this module and loads it into memory.
-3.  The forwarder has a mapping for the API set for the given function being called.
-4.  The loader finds the proper host binary for the given device.
+1. The loader is presented with a dependency on a legacy Windows PC module name that isn't present on the device.
+2. The loader locates a reverse forwarder that carries that module name, and loads it.
+3. The reverse forwarder redirects the imported function to an API set.
+4. The loader resolves that API set through the schema, as described earlier in this topic.
 
-Conceptually, the mapping looks like:
+Conceptually, the mapping looks like this:
 
-Imported DLL: **feature1.dll**
-- Windows PC -> **feature1.dll**
-- HoloLens -> **feature1.dll** forwarder -> **api-feature1-l1-1-0.dll** -> **feature1_holo.dll**
-- IoT -> **feature1.dll** forwarder -> **api-feature1-l1-1-0.dll** -> **feature1_iot.dll**
+Imported DLL: *samplefeature.dll*
 
-The end result is functionally the same as [direct forwarding](#direct-forwarding), but it accomplishes it in a way that maximizes application compatibility.
+- On an edition that has the original module: *samplefeature.dll*
+- On an edition that has replaced it: *samplefeature.dll* reverse forwarder -> `api-win-core-samplefeature` -> *samplefeaturecore.dll*
+
+The limit on this path is export coverage. A reverse forwarder carries only the exports that have API set equivalents, so it doesn't necessarily export every function the original module did. A binary that imports a function the reverse forwarder doesn't carry fails to load with a missing entry point error.
+
+Reverse forwarding is also a reason not to treat a successful resolution as proof that an implementation is present. A **GetProcAddress** call against a legacy module name can return a valid function pointer that resolves to a stub returning an error. Query availability explicitly instead. See [Detect API set availability](detect-api-set-availability.md).
 
 > [!NOTE]
-> Reverse forwarding provides coverage only for a subset of the Win32 API surface. It does not allow applications that target desktop versions of Windows to run on all Windows devices.
+> Reverse forwarding covers only a subset of the Win32 API surface. It doesn't allow applications that target desktop versions of Windows to run on all Windows devices. If your binary targets current versions of Windows, the API set contract name is the more direct choice.
+
+## See also
+
+- [Windows API sets](windows-apisets.md)
+- [Detect API set availability](detect-api-set-availability.md)
+- [Windows umbrella libraries](windows-umbrella-libraries.md)
+- [LoadLibrary function](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw)
+- [GetProcAddress function](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress)

--- a/desktop-src/apiindex/detect-api-set-availability.md
+++ b/desktop-src/apiindex/detect-api-set-availability.md
@@ -2,54 +2,116 @@
 description: Describes how to detect whether a specific API set is available on the current device.
 title: Detect API set availability
 ms.topic: reference
-ms.date: 05/31/2023
+ms.date: 09/03/2026
 ---
 
 # Detect API set availability
 
-In some cases, a given API set contract name may be intentionally mapped to an empty module name on some Windows devices. The reasons for this vary, but a common example is that an expensive feature in terms of system resources may be removed from the Windows OS when configured for a resource-constrained device. This poses a challenge for applications to gracefully handle optional features at the API level.
+In some cases, a given API set contract name might be intentionally mapped to an empty module name on some Windows devices. The reasons for this vary, but a common example is that an expensive feature in terms of system resources might be removed from the Windows OS when configured for a resource-constrained device. This poses a challenge for applications to gracefully handle optional features at the API level.
 
-The traditional approach for testing whether a Win32 API is available is to use [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya) or [GetProcAddress](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress). However, these are not a reliable means for testing API sets because of the [reverse forwarding](api-set-loader-operation.md#reverse-forwarding) support in Windows 10, and later. When reverse forwarding is applied to a given API, **LoadLibrary** or **GetProcAddress** may resolve to a valid function pointer even in cases where the internal implementation has been removed. In this case, the function pointer will be pointing to a stub function that simply returns an error.
+The traditional approach for testing whether a Win32 API is available is to use [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw) or [GetProcAddress](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress). However, these are not a reliable means for testing API sets, because of [reverse forwarding](api-set-loader-operation.md#reverse-forwarding). Where reverse forwarding is applied to a given API, **LoadLibrary** or **GetProcAddress** might resolve to a valid function pointer even in cases where the internal implementation has been removed. In this case, the function pointer will be pointing to a stub function that simply returns an error.
 
-In order to detect this case, you can use the [IsApiSetImplemented](/windows/win32/api/apiquery2/nf-apiquery2-isapisetimplemented) function to query the underlying availability of a given API implementation. This test validates that calling this function will result in executing a functional implementation of the API.
+In order to detect this case, you can use the [IsApiSetImplemented](/windows/win32/api/apiquery2/nf-apiquery2-isapisetimplemented) function to query the underlying availability of a given API implementation. This test reports whether the API set is present in the composed API set schema on the running device, and whether it is mapped to an implementation module.
 
-The following code example demonstrates how to use **IsApiSetImplemented** to determine whether the [WTSEnumerateSessions](/windows/win32/api/wtsapi32/nf-wtsapi32-wtsenumeratesessionsa) function is available on the current device before calling it. 
+> [!IMPORTANT]
+> A successful availability query is not a guarantee that a particular call will succeed. Continue to handle module-loading errors, missing exports, and the API's own documented failure results.
 
-```c++
+The following code example demonstrates how to use **IsApiSetImplemented** to determine whether the API set that contains [WTSEnumerateSessionsW](/windows/win32/api/wtsapi32/nf-wtsapi32-wtsenumeratesessionsw) is available on the current device before calling it.
+
+```cpp
 #include <windows.h>
+#include <apiquery2.h>
 #include <stdio.h>
-#include <Wtsapi32.h>
+#include <wtsapi32.h>
+
+#pragma comment(lib, "OneCore.lib")
+#pragma comment(lib, "Wtsapi32.lib")
 
 int __cdecl wmain(int /* argc */, PCWSTR /* argv */ [])
 {
-    PWTS_SESSION_INFO pInfo = {};
+    PWTS_SESSION_INFOW pInfo = nullptr;
     DWORD count = 0;
 
     if (!IsApiSetImplemented("ext-ms-win-session-wtsapi32-l1-1-0"))
     {
-        wprintf(L"IsApiSetImplemented on ext-ms-win-session-wtsapi32-l1-1-0 returns FALSE\n");
+        wprintf(L"ext-ms-win-session-wtsapi32-l1-1-0 is not available.\n");
+        return 0;
+    }
+
+    if (WTSEnumerateSessionsW(WTS_CURRENT_SERVER_HANDLE, 0, 1, &pInfo, &count))
+    {
+        wprintf(L"SessionCount = %lu\n", count);
+
+        for (DWORD i = 0; i < count; i++)
+        {
+            PWTS_SESSION_INFOW pCurInfo = &pInfo[i];
+            wprintf(L"    %ls: ID = %lu, state = %d\n", pCurInfo->pWinStationName,
+                pCurInfo->SessionId, static_cast<int>(pCurInfo->State));
+        }
+
+        WTSFreeMemory(pInfo);
     }
     else
     {
-        if (WTSEnumerateSessionsW(WTS_CURRENT_SERVER_HANDLE, 0, 1, &pInfo, &count))
-        {
-            wprintf(L"SessionCount = %d\n", count);
-
-            for (ULONG i = 0; i < count; i++)
-            {
-                PWTS_SESSION_INFO pCurInfo = &pInfo[i];
-                wprintf(L"    %s: ID = %d, state = %d\n", pCurInfo->pWinStationName, 
-                    pCurInfo->SessionId, pCurInfo->State);
-            }
-
-            WTSFreeMemory(pInfo);
-        }
-        else
-        {
-            wprintf(L"WTSEnumerateSessions failure : %x\n", GetLastError());
-        }
+        wprintf(L"WTSEnumerateSessionsW failure : %lu\n", GetLastError());
     }
 
     return 0;
 }
 ```
+
+`IsApiSetImplemented` is declared in *apiquery2.h*, and the normal public SDK link path supplies it from *OneCore.lib*. That library is separate from any import library needed to call the optional target API itself.
+
+The example above links *Wtsapi32.lib* for a static import, which keeps the example short. A production application that must run where the API set is absent should also apply the guidance in [Keep the optional code path reachable](#keep-the-optional-code-path-reachable).
+
+## Choose the query name
+
+Pass the name of the API set you are testing, without a `.dll` suffix. Add the suffix only when the name is used with a loader operation such as **LoadLibrary**.
+
+To find the name to pass, see the **Requirements** table on the reference page for the API you want to call. When the API is delivered through an API set, the DLL row names the API set rather than a physical module.
+
+The form of the name depends on how the API is addressed.
+
+| API surface | Query form | Example |
+|---|---|---|
+| Named group | `<contract>~<group>` | `api-win-core-samplefeature~AdvancedOperations` |
+| Default group | Contract alias, without `~Default` | `api-win-core-samplefeature` |
+| Versioned contract | Complete versioned contract name | `ext-ms-win-core-samplefeature-l1-1-0` |
+
+The `samplefeature` names are illustrative names for a fictional Windows component. The name prefix (`api-` or `ext-`) doesn't play a role in availability behavior.
+
+For a named group, a successful query means that the group exists, its contract is mapped to an implementation module, that host is usable in the current execution environment, the group isn't disabled, and any system feature associated with the group is enabled. A query that uses a contract alias applies the contract and host checks.
+
+If the API's public header supplies an `Is<APIName>Present` helper, prefer that helper. It already contains the correct name for the API set or group that carries the API.
+
+The result of a query is contract- or group-granular, not function-granular. Two helpers backed by the same named group always return the same result, even though each helper is named for a different API.
+
+## Keep the optional code path reachable
+
+An availability check can't protect process startup if the optional API is linked as a static import. The loader resolves static imports before your code runs, so a missing module fails the process before execution reaches the check.
+
+Use one of these approaches:
+
+- Configure the module that carries the optional API for [delay loading](/cpp/build/reference/linker-support-for-delay-loaded-dlls). Delay loading is a linker setting: specify `/DELAYLOAD:<module>` and link *delayimp.lib*. Specify the module name that appears in your binary's import table, which might be the classic DLL name rather than the API set contract name. For the preceding example, that name is *WTSAPI32.dll*.
+- Or resolve the target dynamically with **LoadLibrary** and [GetProcAddress](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress) after the availability query succeeds.
+
+Don't use **LoadLibrary** or **GetProcAddress** as a substitute for the availability query. They answer module and export questions, they don't evaluate named group state, and they can resolve to a reverse-forwarding stub as described earlier. Use them after the query, to handle the separate module and export checks.
+
+## Behavior on earlier versions of Windows
+
+The implementation supplied by *OneCore.lib* selects an available query mechanism at run time, so an application that calls **IsApiSetImplemented** can still run on a system that predates the underlying query support.
+
+On a system where no query mechanism is available:
+
+- A group-qualified name that contains `~` returns **FALSE**. A system that can't evaluate named groups can't report that a group is available.
+- A name that isn't group-qualified can return **TRUE**. This preserves compatibility with applications that supplied their own forwarder DLLs on early versions of Windows, where the contract was in fact satisfied by that forwarder.
+
+Don't use an API set availability query as a security or authorization check.
+
+## See also
+
+- [IsApiSetImplemented function](/windows/win32/api/apiquery2/nf-apiquery2-isapisetimplemented)
+- [Windows API sets](windows-apisets.md)
+- [API set loader operation](api-set-loader-operation.md)
+- [LoadLibrary function](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw)
+- [GetProcAddress function](/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress)

--- a/desktop-src/apiindex/windows-apisets.md
+++ b/desktop-src/apiindex/windows-apisets.md
@@ -1,8 +1,8 @@
 ---
 title: Windows API sets
-description: API sets are functional groups of Win32 APIs in the core OS. They provide an architectural separation from the host DLL in which a given Win32 API is defined and the functional group to which the API belongs.
+description: API sets are functional groups of Win32 APIs in the core OS. They provide an architectural separation between the host DLL in which a given Win32 API is implemented and the functional contract to which the API belongs.
 ms.topic: concept-article
-ms.date: 05/31/2023
+ms.date: 09/03/2026
 ---
 
 # Windows API sets
@@ -12,61 +12,83 @@ ms.date: 05/31/2023
 
 All versions of Windows share a common base of operating system (OS) components that's called the *core OS* (in some contexts this common base is also called *OneCore*). In core OS components, Win32 APIs are organized into functional groups called *API sets*.
 
-The purpose of an API set is to provide an architectural separation from the host DLL in which a given Win32 API is implemented, and the functional contract to which the API belongs. The decoupling that API sets provide between implementation and contracts offers many engineering advantages for developers. In particular, using API sets in your code can improve compatibility with Windows devices.
+The purpose of an API set is to provide an architectural separation between the host DLL in which a given Win32 API is implemented, and the functional contract to which the API belongs. The decoupling that API sets provide between implementation and contracts offers many engineering advantages for developers. In particular, using API sets in your code can improve compatibility with Windows devices.
 
 API sets specifically address the following scenarios:
 
-- Although the full breadth of the Win32 API is supported on PCs, only a subset of the Win32 API is available on other Windows devices such as HoloLens, Xbox, and other devices. The API set name provides a query mechanism to cleanly detect whether an API is available on any given device.
+- Although the full breadth of the Win32 API is supported on PCs, only a subset of the Win32 API is available on other Windows devices such as HoloLens, Xbox, and other devices. An API set name gives you a stable thing to ask about, so that your app can detect at run time whether a capability is available on the current device. The query itself is performed by the [IsApiSetImplemented](/windows/win32/api/apiquery2/nf-apiquery2-isapisetimplemented) function.
 
-- Some Win32 API implementations exist in DLLs with different names across different Windows devices. Using API set names instead of DLL names when detecting API availability and delay loading APIs provide a correct route to the implementation no matter where the API is actually implemented.
+- Some Win32 API implementations exist in DLLs with different names across different Windows devices. Using API set names instead of DLL names when detecting API availability and delay loading APIs provides a correct route to the implementation no matter where the API is actually implemented.
 
 For more details, see [API set loader operation](api-set-loader-operation.md) and [Detect API set availability](detect-api-set-availability.md).
 
-## Are API sets and dlls the same thing?
+## Are API sets and DLLs the same thing?
 
-No&mdash;an API set name is a *virtual alias* for a physical `.dll` file. It's an implementation-hiding technique, where you as the caller don't have to know exactly which module is hosting the information.
+No&mdash;an API set name identifies a *contract*, not a file. At run time the loader resolves that contract through the API set schema on the current device, and routes the reference to the DLL that hosts the implementation. It's an implementation-hiding technique, where you as the caller don't have to know exactly which module is hosting the information.
 
-The technique allows modules to be refactored (split apart, consolidated, renamed, and so on) on different Windows versions and editions. And your apps still link, and still get routed to the correct code at runtime.
+The technique allows modules to be refactored (split apart, consolidated, renamed, and so on) on different Windows versions and editions. And your apps still link, and still get routed to the correct code at run time.
 
-So why do API sets have `.dll` in their names? The reason is the way the *DLL loader* is implemented. The loader is the part of the OS that loads DLLs and/or resolves references to DLLs. And at the front end, the loader requires any string passed to [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya) to be terminated with ".dll". But after that front end, the loader can strip away that suffix, and query the API set database with the resulting string.
+So why do API sets have `.dll` in their names? The reason is the way the *DLL loader* is implemented. The loader is the part of the OS that loads DLLs and/or resolves references to DLLs. And at the front end, the loader requires any string passed to [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw) to be terminated with ".dll". But after that front end, the loader can strip away that suffix, and query the API set schema with the resulting string.
 
-**LoadLibrary** (and delay load) succeeds with an API set name (with the ".dll" in it); but there isn't necessarily an actual file with that name anywhere on the PC.
+You can pass an API set name (with the ".dll" in it) to **LoadLibrary**, or use it as a delay-load target. The operation succeeds when the schema on the current device maps that contract to a usable host; there isn't necessarily an actual file with that name anywhere on the PC. If the contract isn't mapped on the current device, a direct **LoadLibrary** fails. A delay-loaded reference behaves differently: the process still loads, and the absence surfaces later, when the API is called.
+
+Either way, a successful link or load isn't by itself evidence that an implementation is present. To determine that, see [Detect API set availability](detect-api-set-availability.md).
 
 ## Linking umbrella libraries
 
-To make it easier to restrict your code to Win32 APIs that are supported in the core OS, we provide a series of *umbrella libraries*. For example, an umbrella library named `OneCore.lib` provides the exports for the subset of Win32 APIs that are common to all Windows devices.
+To make it easier to restrict your code to Win32 APIs that are supported in the core OS, we provide a series of *umbrella libraries*. An umbrella library lets you link a single library instead of identifying the individual import library for each API that you call.
 
-For more details, see [Windows umbrella libraries](windows-umbrella-libraries.md).
+For more details, and to choose the umbrella library that matches what you're targeting, see [Windows umbrella libraries](windows-umbrella-libraries.md).
 
 ## API set contract names
 
-API sets are identified by a strong contract name that follows these standard conventions recognized by the library loader. 
+API sets are identified by a contract name that follows conventions recognized by the library loader.
 
-- The name must begin either with the string **api-** or **ext-**. 
-    - Names that begin with **api-** represent APIs that exist on all Windows editions that satisfy the API's version requirements.
-    - Names that begin with **ext-** represent APIs that may not exist on all Windows editions.
-- The name must end with the sequence **l\<n\>-\<n\>-\<n\>**, where **n** consists of decimal digits.
-- The body of the name can be alphanumeric characters, or dashes (**-**).
+All contract names share these conventions:
+
+- The name begins either with the string **api-** or **ext-**.
+- The body of the name can be alphanumeric characters, or dashes (**-**). A tilde (**~**) appears only as the separator before a group name.
 - The name is case insensitive.
 
-Here are some examples of API set contract names:
+Two forms of contract name are in use, and you can encounter either one.
 
-- **api-ms-win-core-ums-l1-1-0**
-- **ext-ms-win-com-ole32-l1-1-5**
-- **ext-ms-win-ntuser-window-l1-1-0**
-- **ext-ms-win-ntuser-window-l1-1-1**
+A *versioned contract name* ends with the sequence **l\<n\>-\<n\>-\<n\>**, where **n** consists of decimal digits&mdash;for example, `ext-ms-win-core-samplefeature-l1-1-0`. The trailing numbers identify one specific version of the contract, and a name in this form should be considered an immutable identifier for that version.
 
-You can use an API set name in the context of a loader operation such as [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibrarya) or [P/Invoke](/dotnet/standard/native-interop/pinvoke) instead of a DLL module name to ensure a correct route to the implementation no matter where the API is actually implemented on the current device. However, when you do this you must append the string **.dll** at the end of the contract name. This is a requirement of the loader to function properly, and is not considered actually a part of the contract name. Although contract names appear similar to DLL names in this context, they are fundamentally different from DLL module names and do not directly refer to a file on disk.
+A *contract alias* carries no version&mdash;for example, `api-win-core-samplefeature`. It identifies the contract itself rather than one version of it. When a contract organizes its individually available capabilities into *named groups*, a group is addressed by appending the group name to the contract alias, separated by a tilde: `api-win-core-samplefeature~AdvancedOperations`.
 
-Except for appending the string **.dll** in loader operations, API set contract names should be considered an immutable identifier that corresponds to a specific contract version.
+The `samplefeature` names used here are illustrative names for a fictional Windows component.
+
+### The api- and ext- prefixes
+
+The prefix is a naming convention. It was originally intended to distinguish contracts that are present on every qualifying edition (**api-**) from contracts that might be absent (**ext-**). That distinction wasn't consistently applied, and a contract's role can change over time without the contract being renamed.
+
+The loader assigns no significance to the prefix; it resolves **api-** and **ext-** names by the same rules. Don't infer availability from the prefix. Query it instead&mdash;see [Detect API set availability](detect-api-set-availability.md).
+
+### Using a contract name
+
+Two different kinds of operation take a contract name, and they take it in different forms.
+
+*Loader operations*&mdash;such as [LoadLibrary](/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryw) or [P/Invoke](/dotnet/standard/native-interop/pinvoke)&mdash;take the name with the string **.dll** appended. Use a contract name in these operations instead of a DLL module name to ensure a correct route to the implementation no matter where the API is actually implemented on the current device. The **.dll** suffix is a requirement of the loader to function properly, and is not considered actually a part of the contract name. Although contract names appear similar to DLL names in this context, they are fundamentally different from DLL module names and do not directly refer to a file on disk.
+
+*Availability queries* take the name without a **.dll** suffix, in the form that matches how the API is addressed:
+
+| API surface | Query form | Example |
+|---|---|---|
+| Named group | `<contract>~<group>` | `api-win-core-samplefeature~AdvancedOperations` |
+| Default group | Contract alias, without `~Default` | `api-win-core-samplefeature` |
+| Versioned contract | Complete versioned contract name | `ext-ms-win-core-samplefeature-l1-1-0` |
+
+A group name can't be combined with a versioned contract name.
 
 ## Identifying API sets for Win32 APIs
 
 To identify whether a particular Win32 API belongs to an API set, review the requirements table in the reference documentation for the API. If the API belongs to an API set, the requirements table in the article lists the API set name and the Windows version in which the API was first introduced to the API set. For examples of APIs that belong to an API set, see these articles:
 
 - [AllowSetForegroundWindow](/windows/win32/api/winuser/nf-winuser-allowsetforegroundwindow)
-- [FindWindowsEx](/windows/win32/api/winuser/nf-winuser-findwindowexa)
+- [FindWindowEx](/windows/win32/api/winuser/nf-winuser-findwindowexa)
 - [GetClassFile](/windows/win32/api/objbase/nf-objbase-getclassfile)
+
+If the API's header supplies an `Is<APIName>Present` helper function, prefer that helper when you test for availability. It already contains the correct name for the API set or group that carries the API. For more info, see [Detect API set availability](detect-api-set-availability.md).
 
 ## In this section
 

--- a/desktop-src/apiindex/windows-umbrella-libraries.md
+++ b/desktop-src/apiindex/windows-umbrella-libraries.md
@@ -1,8 +1,8 @@
 ---
+description: An umbrella library is a single library that covers a selected subset of Win32 APIs, so you can link one library instead of identifying the module that implements each API.
 title: Windows umbrella libraries
-description: An umbrella library is a single static-link library that exports a subset of Win32 APIs. For example, an umbrella lib named OneCore.lib provides the exports for the subset of Win32 APIs that are common to all Windows devices.
 ms.topic: concept-article
-ms.date: 05/31/2023
+ms.date: 09/03/2026
 ms.assetid: A323B5D1-3235-4BBA-96BF-A7DFEBB85C89
 ---
 
@@ -11,13 +11,40 @@ ms.assetid: A323B5D1-3235-4BBA-96BF-A7DFEBB85C89
 > [!IMPORTANT]
 > The info in this topic applies to all versions of Windows 10, and later. We'll refer to those versions here as "Windows", calling out any exceptions where necessary.
 
-An *umbrella library* is a single static-link library that exports a subset of Win32 APIs. For example, an umbrella library named **OneCore.lib** provides the exports for the subset of Win32 APIs that are common to all Windows devices.
+An *umbrella library* is a single library that you link, and that covers a selected subset of Win32 APIs. For example, an umbrella library named **OneCore.lib** covers the subset of Win32 APIs that are common to all Windows devices.
 
-The APIs in an umbrella library might be implemented across a range of modules (where a module is either an [API set](windows-apisets.md) or a DLL). But the umbrella library abstracts that detail away from you, making your app more portable across operating system versions. In your desktop app or driver, simply link the umbrella library that contains the set of APIs that you're interested in, and that's all you need to do.
+The APIs in an umbrella library might be implemented across a range of modules (where a module is either an [API set](windows-apisets.md) or a DLL). But the umbrella library abstracts that detail away from you, making your app more portable across operating system versions. In your desktop app or driver, link the umbrella library that covers the set of APIs that you're interested in, and that's all you need to do.
+
+## What an umbrella library covers
+
+An umbrella library covers a *selected* subset of APIs. It isn't a complete index of every API in every module it draws from, and a given API isn't necessarily present in every umbrella library.
+
+The set of APIs a library covers is also specific to the Windows SDK version you build against. A later SDK can add coverage that an earlier one doesn't have.
+
+For both of those reasons, treat the reference page for an individual API as the authority on which library to link. The **Requirements** table on that page names the library for that API.
+
+## Available libraries
 
 | Library | Description |
 |-|-|
-| OneCore.lib | Provides the exports for the subset of Win32 APIs that are common to all Windows 10 devices, and later. Link `OneCore.lib` (and no other libraries) to access those APIs. If you link `OneCore.lib`, and you call only Win32 APIs in that library, then your desktop app or driver will load successfully on all Windows 10 devices, and later. |
-| OneCore_apiset.lib | Provides the same coverage as `OneCore.lib`, but uses [API set direct forwarding](api-set-loader-operation.md#direct-forwarding). Linking `OneCore_apiset.lib` will be compatible only with the Windows version, or later, relevant to the SDK version you're targeting. |
-| OneCoreUap.lib | Provides the exports for the subset of Win32 APIs that are common to all Windows 10 devices, and later, that support the Windows Runtime (WinRT). Link `OneCoreUap.lib` (and no other libraries) to access those APIs. If you link `OneCore.lib`, and you call only Win32 APIs in that library, then your desktop app or driver will load successfully on all Windows 10 devices, and later, that support the UWP. |
-| OneCoreUAP_apiset.lib | Provides the same coverage as `OneCoreUAP.lib`, but uses [API set direct forwarding](api-set-loader-operation.md#direct-forwarding). Linking `OneCoreUAP_apiset.lib` will be compatible only with the Windows version, or later, relevant to the SDK version you're targeting. |
+| OneCore.lib | Covers the subset of Win32 APIs that are common to all Windows devices. Link `OneCore.lib` (and no other Win32 umbrella library) to reach those APIs. If you link `OneCore.lib`, and you call only Win32 APIs that it covers, then your desktop app or driver loads successfully on all Windows devices. |
+| OneCore_apiset.lib | The API set variant of `OneCore.lib`. Where an API set name is available for an API, it resolves through a [direct API set import](api-set-loader-operation.md#direct-api-set-import), so no intermediate forwarder module is involved at load time. A binary that links it isn't guaranteed to run as-is on versions of Windows released before the API sets it imports. |
+| OneCoreUAP.lib | Covers the subset of Win32 APIs that are common to all Windows devices that support the Windows Runtime (WinRT). Link `OneCoreUAP.lib` (and no other Win32 umbrella library) to reach those APIs. If you link `OneCoreUAP.lib`, and you call only Win32 APIs that it covers, then your desktop app or driver loads successfully on all Windows devices that support WinRT. |
+| OneCoreUAP_apiset.lib | The API set variant of `OneCoreUAP.lib`. Where an API set name is available for an API, it resolves through a [direct API set import](api-set-loader-operation.md#direct-api-set-import), so no intermediate forwarder module is involved at load time. A binary that links it isn't guaranteed to run as-is on versions of Windows released before the API sets it imports. |
+
+Don't combine two of these libraries in one binary. Each one exists to confine your binary to a particular API surface, and linking a second library can bind you to APIs outside that surface.
+
+## Choosing between a library and its API set variant
+
+For an API that both variants cover, the two reach the same implementation at run time. What differs is the name that ends up in your binary's import table, and therefore the range of Windows versions the binary can run on.
+
+- Link the plain library (`OneCore.lib`, `OneCoreUAP.lib`) when you need a single binary that also runs on versions of Windows released before the relevant API sets existed. It imports legacy Windows module names, and [reverse forwarding](api-set-loader-operation.md#reverse-forwarding) redirects those imports on editions that no longer carry the original modules.
+- Link the API set variant (`OneCore_apiset.lib`, `OneCoreUAP_apiset.lib`) when your binary targets current versions of Windows. It prefers an API set name wherever one is available for the API, so that import resolves directly to the binary that hosts the implementation, with no forwarder in between. That's the more efficient form. Where no API set name applies, it uses the module name, the same as the plain library does.
+
+Neither choice changes which APIs you can call. It changes how your imports are named, and how far back your binary can run.
+
+## See also
+
+- [Windows API sets](windows-apisets.md)
+- [API set loader operation](api-set-loader-operation.md)
+- [Detect API set availability](detect-api-set-availability.md)


### PR DESCRIPTION
## Summary

Updates the four API Set conceptual topics under `desktop-src/apiindex`. The
existing pages are broadly sound in structure and intent, so this is an
evolution of them rather than a rewrite — sections were corrected, modernized,
or added, and existing material was preserved where it was still accurate.

The gaps addressed:

- The pages predate **Named Groups**, and describe only versioned contract
  names.
- The account of how the loader resolves an API set reference was incomplete,
  and did not distinguish a successful module load from the availability of a
  particular API.
- There was no guidance on the supported way to detect at run time whether an
  API set is present.
- The umbrella library page did not explain the trade-off between the
  compatibility-oriented libraries and their API set variants.

## Changes by page

| Page | Summary |
|---|---|
| `windows-apisets.md` | Clarifies that a contract name is not a DLL name, describes the `api-` and `ext-` prefixes, and shows how a contract name is used. |
| `api-set-loader-operation.md` | Restructured around how an import reaches an implementation: what resolution requires, what a successful load does not tell you, optional API sets and delay loading, and reverse forwarding. |
| `detect-api-set-availability.md` | Documents choosing the query name, keeping the optional code path reachable, and behavior on earlier versions of Windows. |
| `windows-umbrella-libraries.md` | Describes what an umbrella library covers, lists the available libraries, and explains choosing between a library and its API set variant. |

## Metadata

`ms.date` is updated on all four pages. The `description` front matter is also
updated on three pages (`windows-apisets.md`, `api-set-loader-operation.md`,
`windows-umbrella-libraries.md`) to match the revised content — for example,
the umbrella library description no longer says "static-link library", since
the page now covers the API set variants as well. No other metadata is changed.

## Companion pull request

MicrosoftDocs/sdk-api#2256 — https://github.com/MicrosoftDocs/sdk-api/pull/2256

That pull request adds usage guidance to the three `apiquery2` reference pages.

The two sets are complementary: these conceptual pages describe *when* to query
for availability, and the reference pages define the exact query name forms and
binding requirements. Reviewing them together is recommended.
