### PR TITLE
Remove WindowProc example code from wm-endsession.md

### DIFF
--- a/desktop-src/Shutdown/wm-endsession.md
+++ b/desktop-src/Shutdown/wm-endsession.md
@@ -14,12 +14,7 @@ A window receives this message through its [**WindowProc**](/windows/win32/api/w
 
 
 ```C++
-LRESULT CALLBACK WindowProc( 
-  HWND hwnd,      // handle to window 
-  UINT uMsg,      // message identifier 
-  WPARAM wParam,  // end-session option 
-  LPARAM lParam   // logoff option
-);
+#define WM_ENDSESSION                   0x0016
 ```
 
 


### PR DESCRIPTION
Replace WindowProc example code with WM_ENDSESSION message definition in wm‑endsession.md。

Refer to the page: https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-ncactivate.

> There are no other Microsoft Learn pages covering the WM_ENDSESSION message.