### PR TITLE
Remove WindowProc example code from wm-queryendsession.md

### DIFF
--- a/desktop-src/Shutdown/wm-queryendsession.md
+++ b/desktop-src/Shutdown/wm-queryendsession.md
@@ -16,12 +16,7 @@ A window receives this message through its [**WindowProc**](/windows/win32/api/w
 
 
 ```C++
-LRESULT CALLBACK WindowProc( 
-  HWND hwnd,      // handle to window 
-  UINT uMsg,      // message identifier 
-  WPARAM wParam,  // not used 
-  LPARAM lParam   // logoff option
-);
+#define WM_QUERYENDSESSION              0x0011
 ```
 
 


### PR DESCRIPTION
Replace WindowProc example code with WM_QUERYENDSESSION message definition in wm-queryendsession.md。

Refer to the page: https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-ncactivate.