### PR TITLE
Fix GDI pen deletion order in Direct2D getting started sample

### DIFF
--- a/desktop-src/Direct2D/getting-started-with-direct2d.md
+++ b/desktop-src/Direct2D/getting-started-with-direct2d.md
@@ -69,12 +69,12 @@ switch(message)
                 rc.left + 100, 
                 rc.top + 100, 
                 rc.right - 100, 
-                rc.bottom - 100);   
-
-            DeleteObject(blackPen);
+                rc.bottom - 100);
 
             // Restore the original object
             SelectObject(ps.hdc, original);
+
+            DeleteObject(blackPen);
 
             EndPaint(hwnd, &ps);
         }


### PR DESCRIPTION
## Summary

Reorders the GDI pen cleanup in the `WM_PAINT` sample so the original pen is restored before `blackPen` is deleted.

## What changed

Before:

```cpp
DeleteObject(blackPen);

// Restore the original object
SelectObject(ps.hdc, original);
```

After:

```cpp
// Restore the original object
SelectObject(ps.hdc, original);

DeleteObject(blackPen);
```

## Why

The `DeleteObject` documentation states:

> Do not delete a drawing object (pen or brush) while it is still selected into a DC.

In the current sample, `blackPen` is still selected into `ps.hdc` when `DeleteObject(blackPen)` is called. Restoring `original` first deselects `blackPen`, so it can be deleted safely. This avoids relying on undocumented deferred deletion behavior and potential GDI handle leaks on repeated `WM_PAINT`.

## Validation

- Sample code change only.
- Drawing output is unchanged.
- The reordered code follows the documented GDI rule for deleting pens/brushes.
- No rendering behavior change expected.

## References

- [Getting started with Direct2D](https://learn.microsoft.com/en-us/windows/win32/direct2d/getting-started-with-direct2d)
- [DeleteObject function](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-deleteobject)